### PR TITLE
Fix/editor camera capture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,12 @@ endif()
 
 # GLM: Use Vulkan-compatible [0,1] depth range instead of OpenGL [-1,1]
 # GLM: Use left-handed coordinate system (Unity convention: X+=right, Y+=up, Z+=forward)
-target_compile_definitions(_Infernux PRIVATE GLM_FORCE_DEPTH_ZERO_TO_ONE GLM_FORCE_LEFT_HANDED)
+target_compile_definitions(_Infernux PRIVATE 
+   GLSLANG_IS_STATIC
+    GLSLANG_EXPORTING=0
+    SH_EXPORTING=0
+    GLM_FORCE_DEPTH_ZERO_TO_ONE
+    GLM_FORCE_LEFT_HANDED)
 
 # Enable frame profiling instrumentation only in RelWithDebInfo builds.
 # Terminal output (stderr) is OFF by default — enable with -DINFERNUX_FRAME_PROFILE_TERMINAL=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,12 +119,7 @@ endif()
 
 # GLM: Use Vulkan-compatible [0,1] depth range instead of OpenGL [-1,1]
 # GLM: Use left-handed coordinate system (Unity convention: X+=right, Y+=up, Z+=forward)
-target_compile_definitions(_Infernux PRIVATE 
-   GLSLANG_IS_STATIC
-    GLSLANG_EXPORTING=0
-    SH_EXPORTING=0
-    GLM_FORCE_DEPTH_ZERO_TO_ONE
-    GLM_FORCE_LEFT_HANDED)
+target_compile_definitions(_Infernux PRIVATE GLM_FORCE_DEPTH_ZERO_TO_ONE GLM_FORCE_LEFT_HANDED)
 
 # Enable frame profiling instrumentation only in RelWithDebInfo builds.
 # Terminal output (stderr) is OFF by default — enable with -DINFERNUX_FRAME_PROFILE_TERMINAL=1

--- a/cpp/infernux/function/renderer/InxRenderStruct.h
+++ b/cpp/infernux/function/renderer/InxRenderStruct.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <function/renderer/Frustum.h>
 #include <glm/glm.hpp>

--- a/cpp/infernux/platform/input/InputManager.cpp
+++ b/cpp/infernux/platform/input/InputManager.cpp
@@ -163,10 +163,9 @@ void InputManager::BeginFrame()
     m_touchCount = 0;
     m_droppedFiles.clear();
 
-    // Scene-view drag capture must not survive focus loss. Gameplay cursor
-    // lock state is preserved so it can be restored automatically after the
-    // window regains focus.
-    m_editorMouseCaptured = false;
+    // Re-apply relative mouse mode for the current window/focus state without
+    // disturbing persistent capture flags. Editor capture is released on
+    // explicit end or focus loss, not once per frame.
     ApplyRelativeMouseMode();
 }
 
@@ -263,9 +262,11 @@ void InputManager::ProcessSDLEvent(const SDL_Event &event)
         break;
     }
 
-    // ---- Window focus lost → clear all held keys ----
+    // ---- Window focus lost → release editor drag capture and clear inputs ----
     case SDL_EVENT_WINDOW_FOCUS_LOST:
+        m_editorMouseCaptured = false;
         ResetAll();
+        ApplyRelativeMouseMode();
         break;
 
     default:

--- a/cpp/infernux/platform/window/InxView.cpp
+++ b/cpp/infernux/platform/window/InxView.cpp
@@ -46,7 +46,20 @@ void InxView::ProcessEvent()
 
     SDL_Event event{};
     while (SDL_PollEvent(&event)) {
-        ImGui_ImplSDL3_ProcessEvent(&event);
+        bool forwardToImGui = true;
+        if (InputManager::Instance().IsEditorMouseCaptureActive()) {
+            switch (event.type) {
+            case SDL_EVENT_MOUSE_MOTION:
+                forwardToImGui = false;
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (forwardToImGui) {
+            ImGui_ImplSDL3_ProcessEvent(&event);
+        }
 
         // Feed every event into the input manager
         InputManager::Instance().ProcessSDLEvent(event);


### PR DESCRIPTION
## Summary

When I was using the newly released v0.1.1 version, I found that the newly fixed camera, in the capture mode, not only did not hide the mouse cursor, but also when the mouse pointer moved to the edge of the display, it could no longer move (the camera could not to rotate)

This PR addresses two critical issues regarding editor camera input handling:
- The m_editorMouseCaptured state was incorrectly reset every frame in BeginFrame(), preventing the Relative Mouse Mode from staying active during continuous camera movement.
- Mouse motion and specific button events were "leaking" to ImGui windows while the Editor Camera was actively capturing input (right-click dragging).

## What changed
- Introduced forwardToImGui logic in the main event loop.When IsEditorMouseCaptureActive() is true, Mouse Motion, Right Click, and Middle Click events are blocked from reaching ImGui to prevent accidental UI interactions
- Removed the logic in BeginFrame() that reset m_editorMouseCaptured = false every frame. The editor capture is now a persistent state。
-  Added a safety reset in SDL_EVENT_WINDOW_FOCUS_LOST to ensure that if the window loses focus (Alt-Tab), the capture state is cleared and the mouse mode is updated.
- By maintaining the RelativeMouseMode, providing a seamless "infinite" rotation experience.
## Verification

- [x] Built the affected targets
- [x] Ran the relevant tests or static validation
- [x] Updated docs if behavior or public APIs changed

## Notes for reviewers

List any risky areas, migration notes, or tradeoffs that need reviewer attention.
