### PR TITLE
Nuitka + Numba compatibility & clean JIT public API

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -20,6 +20,10 @@ set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 set(ASSIMP_BUILD_ASSIMP_TOOLS OFF CACHE BOOL "" FORCE)
 set(ASSIMP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(ASSIMP_NO_EXPORT ON CACHE BOOL "" FORCE)
+# IFC importer triggers a spurious MSVC /MP parallel compilation error
+# (C2065 "_Ty1" in <map> from IFCUtil.h) — disable it; IFC (building
+# CAD) is not needed for game asset pipelines.
+set(ASSIMP_BUILD_IFC_IMPORTER OFF CACHE BOOL "" FORCE)
 if(APPLE OR UNIX)
     # Use system zlib on macOS/Linux — assimp's bundled old zlib has
     # compilation issues with modern Apple Clang system headers.

--- a/python/Infernux/__init__.py
+++ b/python/Infernux/__init__.py
@@ -55,7 +55,10 @@ def __getattr__(name: str):
     """
     if name == "jit":
         return importlib.import_module("Infernux.jit")
-    if name in {"njit", "precompile", "precompile_jit", "ensure_jit_runtime", "JIT_AVAILABLE"}:
+    if name in {
+        "njit", "warmup", "precompile_jit", "ensure_jit_runtime",
+        "JIT_AVAILABLE",
+    }:
         jit_module = importlib.import_module("Infernux.jit")
         return getattr(jit_module, name)
     raise AttributeError(f"module 'Infernux' has no attribute {name!r}")

--- a/python/Infernux/__init__.pyi
+++ b/python/Infernux/__init__.pyi
@@ -40,7 +40,7 @@ from Infernux.mathf import Mathf as Mathf
 from Infernux.jit import JIT_AVAILABLE as JIT_AVAILABLE
 from Infernux.jit import ensure_jit_runtime as ensure_jit_runtime
 from Infernux.jit import njit as njit
-from Infernux.jit import precompile as precompile
+from Infernux.jit import warmup as warmup
 from Infernux.jit import precompile_jit as precompile_jit
 from Infernux.coroutine import (
     Coroutine as Coroutine,

--- a/python/Infernux/_jit_kernels.py
+++ b/python/Infernux/_jit_kernels.py
@@ -1,146 +1,104 @@
 """
-JIT-accelerated math kernels for Infernux hot paths.
+Internal JIT bootstrap — DO NOT import directly.
 
-Uses Numba ``@njit(cache=True)`` when available, with pure-Python fallbacks.
-The ``precompile()`` function triggers ahead-of-time compilation so the
-engine startup pays the cost once (subsequent imports read the on-disk cache).
+Use the public API instead::
 
-Usage::
-
-    from Infernux._jit_kernels import (
-        jit_smooth_damp,
-        jit_contains_point_rotated,
-        jit_wire_sphere_verts,
-        precompile,
-    )
+    from Infernux.jit import njit, warmup, JIT_AVAILABLE
 """
 
 from __future__ import annotations
 
-import math
-
 _HAS_NUMBA = False
+_real_njit = None
 try:
-    from numba import njit  # type: ignore[import-untyped]
+    from numba import njit as _numba_njit  # type: ignore[import-untyped]
+    _real_njit = _numba_njit
     _HAS_NUMBA = True
-except ImportError:
-    # Provide a no-op decorator fallback
-    def njit(*args, **kwargs):  # noqa: D103
-        def _wrap(fn):
-            return fn
-        if args and callable(args[0]):
-            return args[0]
-        return _wrap
+except Exception as _exc:
+    import sys as _sys
+    if hasattr(_sys, '_INFERNUX_DEBUG'):
+        print(f"[_jit_kernels] numba unavailable: {type(_exc).__name__}: {_exc}",
+              flush=True)
+    del _sys
 
 
 JIT_AVAILABLE = _HAS_NUMBA
 
-
-# ====================================================================
-# Kernel: smooth_damp (critically-damped spring)
-# ====================================================================
-
-@njit(cache=True)
-def jit_smooth_damp(current: float, target: float,
-                    current_velocity: float, smooth_time: float,
-                    max_speed: float, delta_time: float):
-    """Critically-damped spring — returns (new_value, new_velocity)."""
-    if smooth_time < 0.0001:
-        smooth_time = 0.0001
-    omega = 2.0 / smooth_time
-    x = omega * delta_time
-    exp_factor = 1.0 / (1.0 + x + 0.48 * x * x + 0.235 * x * x * x)
-    change = current - target
-    original_to = target
-
-    max_change = max_speed * smooth_time
-    if change < -max_change:
-        change = -max_change
-    elif change > max_change:
-        change = max_change
-    target = current - change
-
-    temp = (current_velocity + omega * change) * delta_time
-    new_velocity = (current_velocity - omega * temp) * exp_factor
-    output = target + (change + temp) * exp_factor
-
-    # Prevent overshoot
-    if (original_to - current > 0.0) == (output > original_to):
-        output = original_to
-        if delta_time > 0.0:
-            new_velocity = (output - original_to) / delta_time
-        else:
-            new_velocity = 0.0
-
-    return output, new_velocity
+# In Nuitka standalone builds user scripts are compiled to .pyc and the
+# originals removed.  Numba's cache locator requires the source .py to
+# exist, so ``cache=True`` would raise RuntimeError.
+_NUITKA_COMPILED = "__compiled__" in globals()
 
 
-# ====================================================================
-# Kernel: rotated point containment test
-# ====================================================================
+# ── njit wrapper ──────────────────────────────────────────────────────
 
-@njit(cache=True)
-def jit_contains_point_rotated(px: float, py: float,
-                                rx: float, ry: float,
-                                rw: float, rh: float,
-                                sin_a: float, cos_a: float) -> bool:
-    """Test if (px, py) lies inside a rotated rect.
+def njit(*args, **kwargs):
+    """``numba.njit`` wrapper — safe for both editor and standalone builds.
 
-    ``sin_a``, ``cos_a`` are from the element's rotation angle.
-    Inverse-rotates the point into local space for AABB check.
-    """
-    dx = px - (rx + rw * 0.5)
-    dy = py - (ry + rh * 0.5)
-    # Inverse rotation (negate sin)
-    lx = dx * cos_a + dy * sin_a + rw * 0.5
-    ly = -dx * sin_a + dy * cos_a + rh * 0.5
-    return (0.0 <= lx <= rw) and (0.0 <= ly <= rh)
+    The returned callable always has a ``.py`` attribute pointing to the
+    original pure-Python function, so callers can force the fallback::
 
+        @njit(cache=True, fastmath=True)
+        def burn(n: int) -> float: ...
 
-# ====================================================================
-# Kernel: wire sphere trig table
-# ====================================================================
-
-@njit(cache=True)
-def jit_wire_sphere_trig(segments: int):
-    """Return (cos_table, sin_table) arrays for a unit circle.
-
-    Each has *segments* entries: cos/sin of ``2π * i / segments``.
-    """
-    two_pi = 2.0 * math.pi
-    cos_tab = [0.0] * segments
-    sin_tab = [0.0] * segments
-    for i in range(segments):
-        angle = two_pi * i / segments
-        cos_tab[i] = math.cos(angle)
-        sin_tab[i] = math.sin(angle)
-    return cos_tab, sin_tab
-
-
-# ====================================================================
-# Pre-compilation trigger
-# ====================================================================
-
-def precompile():
-    """Force Numba to compile all kernels (and cache to disk).
-
-    Call once at engine startup to hide JIT latency.
-    Does nothing if Numba is not installed.
+        burn(100)       # JIT-accelerated (or fallback if no Numba)
+        burn.py(100)    # always pure Python
     """
     if not _HAS_NUMBA:
-        return
+        # No-op fallback — attach .py for uniform API
+        def _wrap(fn):
+            fn.py = fn
+            return fn
+        if args and callable(args[0]):
+            args[0].py = args[0]
+            return args[0]
+        return _wrap
 
-    # Trigger compilation with representative argument types
-    jit_smooth_damp(0.0, 1.0, 0.0, 0.3, float('inf'), 0.016)
-    jit_contains_point_rotated(50.0, 50.0, 0.0, 0.0, 100.0, 100.0, 0.0, 1.0)
-    jit_wire_sphere_trig(24)
+    if _NUITKA_COMPILED:
+        kwargs.pop("cache", None)
+
+    # @njit  (bare decorator, no parentheses)
+    if args and callable(args[0]):
+        fn = args[0]
+        compiled = _real_njit(fn)
+        compiled.py = fn
+        return compiled
+
+    # @njit(cache=True, ...)  (decorator factory)
+    inner = _real_njit(**kwargs)
+
+    def _decorator(fn):
+        compiled = inner(fn)
+        compiled.py = fn
+        return compiled
+    return _decorator
+
+
+# ── warmup helper ─────────────────────────────────────────────────────
+
+def warmup(fn, *args, **kwargs):
+    """Pre-compile a ``@njit`` function by calling it once.
+
+    No-op when Numba is unavailable or inside a Nuitka standalone build.
+    Exceptions during warmup are silently swallowed.
+
+    Usage::
+
+        @njit(cache=True, fastmath=True)
+        def burn(n: int) -> float: ...
+
+        warmup(burn, 1)
+    """
+    if not _HAS_NUMBA or _NUITKA_COMPILED:
+        return
+    try:
+        fn(*args, **kwargs)
+    except Exception:
+        pass
 
 
 __all__ = [
     "njit",
+    "warmup",
     "JIT_AVAILABLE",
-    "jit_smooth_damp",
-    "jit_contains_point_rotated",
-    "jit_wire_sphere_trig",
-    "precompile",
 ]

--- a/python/Infernux/engine/game_builder.py
+++ b/python/Infernux/engine/game_builder.py
@@ -120,6 +120,8 @@ class GameBuilder:
         window_height: int = 720,
         window_resizable: bool = True,
         splash_items: Optional[List[Dict]] = None,
+        debug_mode: bool = False,
+        lto: bool = True,
     ):
         self.project_path = os.path.abspath(project_path)
         self.project_name = game_name.strip() if game_name.strip() else os.path.basename(self.project_path)
@@ -130,6 +132,8 @@ class GameBuilder:
         self.window_height = window_height
         self.window_resizable = window_resizable
         self.splash_items = list(splash_items) if splash_items else []
+        self.debug_mode = debug_mode
+        self.lto = lto
 
     # ------------------------------------------------------------------
     # Public API
@@ -239,6 +243,9 @@ class GameBuilder:
         _p("清理临时文件 Cleaning temp files...", 0.99)
         self._cleanup_temp(boot_script)
 
+        # Log per-directory size breakdown so the user sees where size goes
+        self._report_build_size(final_dir, _blog)
+
         _p("构建完成 Build complete!", 1.0)
         elapsed_seconds = time.perf_counter() - build_start
         done_msg = t("build.completed_log").format(
@@ -340,7 +347,14 @@ class GameBuilder:
         for name in os.listdir(self.output_dir):
             path = os.path.join(self.output_dir, name)
             if os.path.isdir(path) and not os.path.islink(path):
-                shutil.rmtree(path, ignore_errors=True)
+                if sys.platform == "win32":
+                    subprocess.run(
+                        ["cmd", "/c", "rd", "/s", "/q", path],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                else:
+                    shutil.rmtree(path, ignore_errors=True)
             else:
                 try:
                     os.remove(path)
@@ -372,6 +386,9 @@ class GameBuilder:
 
         Returns the path to the temporary boot script.
         """
+        _debug_mode = self.debug_mode
+        _log_level_str = "LogLevel.Debug" if _debug_mode else "LogLevel.Info"
+
         boot_src = f'''\
 """Infernux Game — compiled entry point."""
 import os
@@ -382,16 +399,52 @@ import traceback
 # package skips heavy editor-only UI panels and watchdog file watcher.
 os.environ["_INFERNUX_PLAYER_MODE"] = "1"
 
+_DEBUG_MODE = {_debug_mode!r}
+
 # Determine the directory containing the executable
 _DIR = os.path.dirname(os.path.abspath(sys.argv[0]))
 if not os.path.isdir(os.path.join(_DIR, "Data")):
     _DIR = os.path.dirname(os.path.abspath(sys.executable))
+
+# Ensure raw-copied JIT packages (numba, numpy, llvmlite) are importable.
+# Nuitka standalone may not include the exe directory in sys.path by default.
+if _DIR not in sys.path:
+    sys.path.insert(0, _DIR)
+
+# On Windows, add the exe directory as a DLL search path so that
+# native extensions inside raw-copied packages can find their .dll deps.
+if sys.platform == 'win32':
+    try:
+        os.add_dll_directory(_DIR)
+    except OSError:
+        pass
+    # Pre-load bundled MSVC CRT DLLs so the dynamic linker can resolve
+    # them even on machines without Visual C++ Redistributable installed.
+    import ctypes as _ctypes
+    for _crt in ('vcruntime140.dll', 'vcruntime140_1.dll',
+                 'msvcp140.dll', 'msvcp140_1.dll', 'msvcp140_2.dll',
+                 'msvcp140_atomic_wait.dll', 'msvcp140_codecvt_ids.dll',
+                 'concrt140.dll'):
+        _crt_path = os.path.join(_DIR, _crt)
+        if os.path.isfile(_crt_path):
+            try:
+                _ctypes.WinDLL(_crt_path)
+            except OSError:
+                pass
+    del _ctypes
 
 # Logs go into Data/Logs/ to keep the root directory clean
 _LOGS_DIR = os.path.join(_DIR, "Data", "Logs")
 os.makedirs(_LOGS_DIR, exist_ok=True)
 _LOG = os.path.join(_LOGS_DIR, "player.log")
 os.environ["_INFERNUX_PLAYER_LOG"] = _LOG
+
+# Debug mode: write a detailed log next to the executable
+if _DEBUG_MODE:
+    _DEBUG_LOG = os.path.join(_DIR, "{self.project_name}_debug.log")
+    _debug_fh = open(_DEBUG_LOG, "w", encoding="utf-8")
+    sys.stdout = _debug_fh
+    sys.stderr = _debug_fh
 
 # Clear previous log
 try:
@@ -405,6 +458,8 @@ def _log(msg):
             _f.write(str(msg) + "\\n")
     except OSError:
         pass
+    if _DEBUG_MODE:
+        print(msg, flush=True)
 
 def _crash_report(exc):
     """Write crash details to a log file and show a Windows message box."""
@@ -432,12 +487,18 @@ try:
     _log("boot: calling run_player")
     run_player(
         project_path=os.path.join(_DIR, "Data"),
-        engine_log_level=LogLevel.Info,
+        engine_log_level={_log_level_str},
     )
     _log("boot: run_player returned")
 except Exception as _exc:
     _crash_report(_exc)
     sys.exit(1)
+finally:
+    if _DEBUG_MODE:
+        try:
+            _debug_fh.close()
+        except Exception:
+            pass
 '''
         # Write boot script to a temp location (NuitkaBuilder will copy
         # it into its ASCII-safe staging directory).
@@ -464,14 +525,25 @@ except Exception as _exc:
 
         selected_icon = self.icon_path if self.icon_path else icon_path
 
+        # Separate JIT-related packages that must be raw-copied (not
+        # compiled by Nuitka) from ordinary packages that Nuitka should
+        # compile normally.
+        jit_set = NuitkaBuilder._JIT_NOFOLLOW_PACKAGES
+        all_pkgs = user_packages or []
+        compiled_pkgs = [p for p in all_pkgs if p not in jit_set]
+        jit_pkgs = [p for p in all_pkgs if p in jit_set]
+
         nk = NuitkaBuilder(
             entry_script=boot_script,
             output_dir=self.output_dir,
             output_filename=f"{self.project_name}.exe",
             product_name=self.project_name,
             icon_path=selected_icon if selected_icon and os.path.isfile(selected_icon) else None,
-            extra_include_packages=user_packages or [],
+            extra_include_packages=compiled_pkgs,
             extra_requirements_files=self._project_requirement_files(),
+            raw_copy_packages=jit_pkgs,
+            console_mode="force" if self.debug_mode else "disable",
+            lto=self.lto,
         )
 
         def _nk_progress(msg: str, pct: float):
@@ -504,25 +576,55 @@ except Exception as _exc:
         os.makedirs(final_dir, exist_ok=True)
 
         _move_t0 = time.perf_counter()
-        _item_count = 0
-        for item in os.listdir(dist_dir):
-            _item_count += 1
-            src = os.path.join(dist_dir, item)
-            dst = os.path.join(final_dir, item)
-            if os.path.exists(dst):
-                if os.path.isdir(dst):
-                    shutil.rmtree(dst)
-                else:
-                    os.remove(dst)
-            shutil.move(src, dst)
+
+        if sys.platform == "win32":
+            # robocopy /MOVE /E is dramatically faster than per-item
+            # shutil.move for large directory trees (native NTFS ops).
+            rc = subprocess.call(
+                ["robocopy", dist_dir, final_dir, "/E", "/MOVE",
+                 "/NFL", "/NDL", "/NJH", "/NJS", "/NP"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=0x08000000,
+            )
+            if rc >= 8:
+                Debug.log_warning(
+                    f"robocopy /MOVE failed (exit {rc}), falling back to Python move"
+                )
+                for item in os.listdir(dist_dir):
+                    src = os.path.join(dist_dir, item)
+                    dst = os.path.join(final_dir, item)
+                    if os.path.exists(dst):
+                        if os.path.isdir(dst):
+                            shutil.rmtree(dst)
+                        else:
+                            os.remove(dst)
+                    shutil.move(src, dst)
+        else:
+            for item in os.listdir(dist_dir):
+                src = os.path.join(dist_dir, item)
+                dst = os.path.join(final_dir, item)
+                if os.path.exists(dst):
+                    if os.path.isdir(dst):
+                        shutil.rmtree(dst)
+                    else:
+                        os.remove(dst)
+                shutil.move(src, dst)
+
         Debug.log_internal(
-            f"  moved {_item_count} items from staging in "
-            f"{time.perf_counter() - _move_t0:.2f}s"
+            f"  moved dist to output in {time.perf_counter() - _move_t0:.2f}s"
         )
 
-        # Remove the now-empty dist directory and its staging parent
+        # Remove the now-empty staging parent
         staging_parent = os.path.dirname(dist_dir)
-        shutil.rmtree(staging_parent, ignore_errors=True)
+        if sys.platform == "win32":
+            subprocess.run(
+                ["cmd", "/c", "rd", "/s", "/q", staging_parent],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            shutil.rmtree(staging_parent, ignore_errors=True)
 
         return final_dir
 
@@ -539,7 +641,26 @@ except Exception as _exc:
             dst = os.path.join(data_dir, dirname)
             if os.path.isdir(src):
                 _t0 = time.perf_counter()
-                shutil.copytree(src, dst, ignore=ignore)
+                if sys.platform == "win32":
+                    os.makedirs(dst, exist_ok=True)
+                    rc = subprocess.call(
+                        ["robocopy", src, dst, "/E",
+                         "/NFL", "/NDL", "/NJH", "/NJS", "/NP",
+                         "/XD", "__pycache__", ".git"],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        creationflags=0x08000000,
+                    )
+                    if rc >= 8:
+                        Debug.log_warning(
+                            f"robocopy failed for {dirname}/ (exit {rc}), "
+                            f"falling back to shutil.copytree"
+                        )
+                        if os.path.isdir(dst):
+                            shutil.rmtree(dst)
+                        shutil.copytree(src, dst, ignore=ignore)
+                else:
+                    shutil.copytree(src, dst, ignore=ignore)
                 Debug.log_internal(
                     f"  copied {dirname}/ in {time.perf_counter() - _t0:.2f}s"
                 )
@@ -649,7 +770,10 @@ except Exception as _exc:
                                     uses_infernux_jit = True
                                 elif node.module == "Infernux":
                                     imported_names = {alias.name for alias in node.names}
-                                    if imported_names & {"jit", "njit", "precompile", "precompile_jit", "JIT_AVAILABLE"}:
+                                    if imported_names & {
+                                        "jit", "njit", "warmup", "precompile_jit",
+                                        "JIT_AVAILABLE",
+                                    }:
                                         uses_infernux_jit = True
         Debug.log_internal(
             f"  AST scanned {_ast_file_count} .py files in "
@@ -660,13 +784,15 @@ except Exception as _exc:
         found -= self._BUILTIN_MODULES
         found -= self._collect_internal_asset_module_names()
 
-        # Public JIT API ultimately depends on numba + llvmlite.  Make that
-        # explicit so standalone player builds include the runtime pieces even
-        # when user scripts import the supported ``Infernux.jit`` surface
-        # instead of importing ``numba`` directly.
+        # Public JIT API ultimately depends on numba + llvmlite + numpy.
+        # Make that explicit so standalone player builds include the runtime
+        # pieces even when user scripts import the supported ``Infernux.jit``
+        # surface instead of importing ``numba`` directly.  numpy must also
+        # be raw-copied because numba introspects numpy bytecode at JIT time.
         if uses_infernux_jit or "numba" in found:
             found.add("numba")
             found.add("llvmlite")
+            found.add("numpy")
 
         # Only keep packages that are actually importable in the current
         # environment so Nuitka doesn't error on stale or optional imports.
@@ -903,6 +1029,34 @@ except Exception as _exc:
         """Remove editor-only and redundant files from the build output."""
         removed_bytes = 0
 
+        def _rm_dir(d: str):
+            nonlocal removed_bytes
+            if not os.path.isdir(d):
+                return
+            for r, _, fs in os.walk(d):
+                for f in fs:
+                    try:
+                        removed_bytes += os.path.getsize(os.path.join(r, f))
+                    except OSError:
+                        pass
+            if sys.platform == "win32":
+                subprocess.run(
+                    ["cmd", "/c", "rd", "/s", "/q", d],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            else:
+                shutil.rmtree(d, ignore_errors=True)
+
+        def _rm_file(f: str):
+            nonlocal removed_bytes
+            if os.path.isfile(f):
+                try:
+                    removed_bytes += os.path.getsize(f)
+                except OSError:
+                    pass
+                os.remove(f)
+
         # Directories that are entirely unnecessary at runtime
         remove_dirs = [
             os.path.join(final_dir, "Infernux", "lib", "_player_runtime"),
@@ -910,11 +1064,7 @@ except Exception as _exc:
             os.path.join(final_dir, "Infernux", "resources", "supports"),
         ]
         for d in remove_dirs:
-            if os.path.isdir(d):
-                for r, _, fs in os.walk(d):
-                    for f in fs:
-                        removed_bytes += os.path.getsize(os.path.join(r, f))
-                shutil.rmtree(d, ignore_errors=True)
+            _rm_dir(d)
 
         # Individual files not needed at runtime
         remove_files = [
@@ -924,9 +1074,7 @@ except Exception as _exc:
             os.path.join(final_dir, "Data", "ProjectSettings", "GameView.ini"),
         ]
         for f in remove_files:
-            if os.path.isfile(f):
-                removed_bytes += os.path.getsize(f)
-                os.remove(f)
+            _rm_file(f)
 
         # Remove duplicate engine DLLs from Infernux/lib/ — they already
         # exist in the dist root (placed by Nuitka / _inject_native_libs)
@@ -936,10 +1084,7 @@ except Exception as _exc:
         if os.path.isdir(lib_dir):
             for fname in os.listdir(lib_dir):
                 if fname.lower().endswith(".dll"):
-                    fp = os.path.join(lib_dir, fname)
-                    if os.path.isfile(fp):
-                        removed_bytes += os.path.getsize(fp)
-                        os.remove(fp)
+                    _rm_file(os.path.join(lib_dir, fname))
 
         # Remove .meta files from engine shaders (editor hot-reload metadata)
         shaders_dir = os.path.join(final_dir, "Infernux", "resources", "shaders")
@@ -947,9 +1092,23 @@ except Exception as _exc:
             for root, _, files in os.walk(shaders_dir):
                 for fname in files:
                     if fname.endswith(".meta"):
-                        fp = os.path.join(root, fname)
-                        removed_bytes += os.path.getsize(fp)
-                        os.remove(fp)
+                        _rm_file(os.path.join(root, fname))
+
+        # ── Global cleanup: __pycache__ and .dist-info everywhere ─────
+        for root, dirs, files in os.walk(final_dir, topdown=False):
+            for dname in dirs:
+                dpath = os.path.join(root, dname)
+                if dname == "__pycache__" or dname.endswith(".dist-info"):
+                    _rm_dir(dpath)
+
+        # ── Remove stale .pyc files from raw-copied JIT packages ──────
+        for pkg_name in ("numba", "llvmlite", "numpy"):
+            pkg_dir = os.path.join(final_dir, pkg_name)
+            if os.path.isdir(pkg_dir):
+                for root, _, files in os.walk(pkg_dir):
+                    for fname in files:
+                        if fname.endswith(".pyc"):
+                            _rm_file(os.path.join(root, fname))
 
         # Ensure Data/Logs exists for runtime log output
         logs_dir = os.path.join(final_dir, "Data", "Logs")
@@ -964,3 +1123,41 @@ except Exception as _exc:
         boot_dir = os.path.dirname(boot_script)
         if os.path.isdir(boot_dir):
             shutil.rmtree(boot_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Build size report
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _report_build_size(final_dir: str, _blog: Callable[[str], None]) -> None:
+        """Log a per-directory size breakdown of the final build output."""
+        total = 0
+        entries: list[tuple[str, int]] = []
+
+        for item in os.scandir(final_dir):
+            if item.is_dir(follow_symlinks=False):
+                sz = 0
+                for root, _, files in os.walk(item.path):
+                    for f in files:
+                        try:
+                            sz += os.path.getsize(os.path.join(root, f))
+                        except OSError:
+                            pass
+                entries.append((item.name + "/", sz))
+            elif item.is_file(follow_symlinks=False):
+                sz = item.stat().st_size
+                entries.append((item.name, sz))
+            else:
+                continue
+            total += sz
+
+        entries.sort(key=lambda x: x[1], reverse=True)
+        lines = [f"Build size report — total {total / (1024*1024):.1f} MB"]
+        for name, sz in entries:
+            mb = sz / (1024 * 1024)
+            pct = (sz / total * 100) if total else 0
+            if mb >= 0.1:
+                lines.append(f"  {mb:7.1f} MB  {pct:4.1f}%  {name}")
+        report = "\n".join(lines)
+        Debug.log_internal(report)
+        _blog(report)

--- a/python/Infernux/engine/i18n.py
+++ b/python/Infernux/engine/i18n.py
@@ -210,6 +210,8 @@ _STRINGS: dict[str, dict[str, str]] = {
     # ── Build settings body ───────────────────────────────────────────
     "build.game_name":                  {"en": "Game Name",                 "zh": "游戏名称"},
     "build.game_name_hint":             {"en": "(default: {name})",         "zh": "(默认: {name})"},
+    "build.debug_mode":                 {"en": "Debug Mode",               "zh": "调试模式"},
+    "build.lto":                        {"en": "LTO (slower build, better perf)", "zh": "LTO（编译更慢，性能更好）"},
     "build.output_directory":           {"en": "Output Directory",          "zh": "输出目录"},
     "build.output_directory_hint":      {"en": "Use an empty folder, or reuse one containing {marker} from a previous Infernux build.", "zh": "请使用空文件夹，或复用包含旧 Infernux 构建标记文件 {marker} 的目录。"},
     "build.output_directory_error_title": {"en": "Invalid Build Output Directory", "zh": "无效的构建输出目录"},

--- a/python/Infernux/engine/nuitka_builder.py
+++ b/python/Infernux/engine/nuitka_builder.py
@@ -203,6 +203,30 @@ def _install_requirements_files(python_exe: str, requirement_files: List[str]) -
 class NuitkaBuilder:
     """Wraps Nuitka compilation for Infernux standalone builds."""
 
+    # Packages that must be excluded from Nuitka compilation and
+    # injected as raw site-packages into the dist.  Numba requires
+    # Python bytecode at runtime for its LLVM JIT compiler — Nuitka's
+    # C compilation removes the bytecode, making @njit silently fail.
+    _JIT_NOFOLLOW_PACKAGES = frozenset({"numba", "llvmlite", "numpy"})
+
+    # Directories stripped from raw-copied JIT packages to slim down
+    # the build output.  These are never needed at runtime.
+    _JIT_STRIP_DIRS: dict[str, list[str]] = {
+        "numba": [
+            "tests", "cuda", "testing", "pycc", "scripts",
+            # CUDA is ~4 MB and only needed for GPU compute
+            # tests/testing are ~10 MB of test fixtures
+        ],
+        "numpy": [
+            "tests", "f2py", "testing", "doc",
+            "_pyinstaller", "distutils",
+            # f2py is 1.6 MB Fortran build tooling
+        ],
+        "llvmlite": [
+            "tests",
+        ],
+    }
+
     def __init__(
         self,
         entry_script: str,
@@ -215,7 +239,9 @@ class NuitkaBuilder:
         extra_include_packages: Optional[List[str]] = None,
         extra_include_data: Optional[List[str]] = None,
         extra_requirements_files: Optional[List[str]] = None,
+        raw_copy_packages: Optional[List[str]] = None,
         console_mode: str = "disable",
+        lto: bool = True,
     ):
         self.entry_script = os.path.abspath(entry_script)
         self.output_dir = os.path.abspath(output_dir)
@@ -224,6 +250,7 @@ class NuitkaBuilder:
         self.file_version = file_version
         self.icon_path = icon_path
         self.console_mode = console_mode
+        self.lto = lto
         self.extra_include_packages = list(extra_include_packages or [])
         self.extra_include_data = list(extra_include_data or [])
         self.extra_requirements_files = [
@@ -231,6 +258,7 @@ class NuitkaBuilder:
             for path in list(extra_requirements_files or [])
             if path
         ]
+        self.raw_copy_packages = list(raw_copy_packages or [])
 
         # Staging directory — unique per build to allow parallel builds
         tag = hashlib.md5(self.output_dir.encode()).hexdigest()[:8]
@@ -280,6 +308,10 @@ class NuitkaBuilder:
 
         _p("注入原生引擎库 Injecting native engine libraries...", 0.85)
         self._inject_native_libs(dist_dir)
+
+        if self.raw_copy_packages:
+            _p("注入 JIT 运行时包 Injecting JIT runtime packages...", 0.87)
+            self._inject_jit_packages(dist_dir)
 
         if sys.platform == "win32":
             _p("嵌入 UTF-8 清单 Embedding UTF-8 manifest...", 0.90)
@@ -340,7 +372,14 @@ class NuitkaBuilder:
         edge cases and keeps compiler output paths stable on Windows.
         """
         if os.path.isdir(self._staging_dir):
-            shutil.rmtree(self._staging_dir, ignore_errors=True)
+            if sys.platform == "win32":
+                subprocess.run(
+                    ["cmd", "/c", "rd", "/s", "/q", self._staging_dir],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            else:
+                shutil.rmtree(self._staging_dir, ignore_errors=True)
         os.makedirs(self._staging_dir, exist_ok=True)
 
         # Copy entry script into staging (path itself may be non-ASCII)
@@ -383,7 +422,18 @@ class NuitkaBuilder:
             cmd.append("--msvc=latest")
 
         # Link-time optimization for smaller and faster binaries
-        cmd.append("--lto=yes")
+        if self.lto:
+            cmd.append("--lto=yes")
+
+        # Strip docstrings and assert statements for smaller output
+        cmd.append("--python-flag=-OO")
+
+        # Tell Nuitka to exclude large dev-only frameworks at the module
+        # level — catches transitive imports that --nofollow-import-to
+        # might miss.
+        cmd.append("--noinclude-pytest-mode=nofollow")
+        cmd.append("--noinclude-unittest-mode=nofollow")
+        cmd.append("--noinclude-setuptools-mode=nofollow")
 
         # Parallel C compilation
         cmd.append("--jobs=%d" % max(1, os.cpu_count() - 1))
@@ -419,8 +469,24 @@ class NuitkaBuilder:
         ):
             cmd.append(f"--nofollow-import-to={_editor_mod}")
 
+        # Exclude JIT packages from Nuitka compilation — they will be
+        # injected as raw site-packages afterwards so numba retains the
+        # Python bytecode it needs for LLVM JIT at runtime.
+        _nofollow_jit = self._JIT_NOFOLLOW_PACKAGES | set(self.raw_copy_packages)
+        for _jit_pkg in sorted(_nofollow_jit):
+            cmd.append(f"--nofollow-import-to={_jit_pkg}")
+
+        # Auto-discover stdlib modules that the raw-copied JIT packages
+        # import transitively.  Nuitka can't discover them because the
+        # packages are excluded via --nofollow-import-to, so we trace
+        # them in a subprocess and include them explicitly.
+        if self.raw_copy_packages:
+            for _stdlib_mod in self._discover_jit_stdlib_deps():
+                cmd.append(f"--include-module={_stdlib_mod}")
+
         for pkg in self.extra_include_packages:
-            cmd.append(f"--include-package={pkg}")
+            if pkg not in _nofollow_jit:
+                cmd.append(f"--include-package={pkg}")
 
         for pattern in self.extra_include_data:
             cmd.append(f"--include-package-data={pattern}")
@@ -443,6 +509,60 @@ class NuitkaBuilder:
 
         cmd.append(self._staged_entry)
         return cmd
+
+    # ------------------------------------------------------------------
+    # Auto-discover JIT package stdlib dependencies
+    # ------------------------------------------------------------------
+
+    def _discover_jit_stdlib_deps(self) -> List[str]:
+        """Import raw_copy_packages in the builder Python and return the
+        set of stdlib top-level modules they transitively load.
+
+        This replaces the manual list approach — numba/llvmlite/numpy
+        pull in dozens of stdlib modules (email, csv, html, http, …)
+        that Nuitka cannot discover because we exclude these packages
+        via --nofollow-import-to.
+        """
+        import time as _time
+        _t0 = _time.perf_counter()
+
+        pkgs_arg = ",".join(sorted(self.raw_copy_packages))
+        # The subprocess: record modules before vs after importing the
+        # packages, then report only stdlib top-level names.
+        trace_script = (
+            "import sys; "
+            "before = set(sys.modules); "
+            "pkgs = '$PKGS'.split(','); "
+            "[__import__(p) for p in pkgs]; "
+            "after = set(sys.modules); "
+            "new = {m.split('.')[0] for m in after - before}; "
+            "stdlib = sorted(new & sys.stdlib_module_names); "
+            "print(','.join(stdlib))"
+        ).replace("$PKGS", pkgs_arg)
+
+        try:
+            result = _run_python(
+                self._builder_python,
+                ["-c", trace_script],
+                timeout=120,
+            )
+            if result.returncode != 0 or not result.stdout.strip():
+                Debug.log_warning(
+                    f"JIT stdlib trace failed (exit {result.returncode}): "
+                    f"{(result.stderr or '').strip()[:200]}"
+                )
+                return []
+
+            mods = [m for m in result.stdout.strip().split(",") if m]
+            Debug.log_internal(
+                f"  JIT stdlib trace: {len(mods)} modules in "
+                f"{_time.perf_counter() - _t0:.2f}s  "
+                f"({', '.join(mods[:10])}{'…' if len(mods) > 10 else ''})"
+            )
+            return mods
+        except Exception as exc:
+            Debug.log_warning(f"JIT stdlib trace error: {exc}")
+            return []
 
     # ------------------------------------------------------------------
     # Nuitka execution
@@ -602,6 +722,148 @@ class NuitkaBuilder:
             f"  native lib injection total: {_time.perf_counter() - _inject_t0:.2f}s  "
             f"({len(native_files)} files)"
         )
+
+    # ------------------------------------------------------------------
+    # Inject raw JIT packages
+    # ------------------------------------------------------------------
+
+    def _inject_jit_packages(self, dist_dir: str):
+        """Copy raw site-packages into the Nuitka dist for JIT-dependent packages.
+
+        Numba requires Python bytecode at runtime for LLVM JIT compilation.
+        Nuitka's C compilation removes bytecode, so these packages must be
+        copied as-is from the builder environment's site-packages.
+        """
+        if not self.raw_copy_packages:
+            return
+
+        import time as _time
+        _t0 = _time.perf_counter()
+
+        # Discover site-packages directory of the builder Python.
+        # In conda environments getsitepackages() returns [env_root,
+        # env_root/Lib/site-packages] — we need the one that actually
+        # contains installed packages (the "Lib/site-packages" entry).
+        result = _run_python(
+            self._builder_python,
+            ["-c",
+             "import site, os, json; "
+             "print(json.dumps(site.getsitepackages()))"],
+        )
+        import json as _json
+        candidates = _json.loads(result.stdout.strip())
+        site_packages = ""
+        for cand in reversed(candidates):
+            if os.path.isdir(cand) and os.path.isdir(os.path.join(cand, "numba")):
+                site_packages = cand
+                break
+        if not site_packages:
+            # Fallback: pick the last entry (usually Lib/site-packages)
+            for cand in reversed(candidates):
+                if os.path.isdir(cand):
+                    site_packages = cand
+                    break
+        if not site_packages:
+            Debug.log_warning(
+                f"Builder site-packages not found in {candidates}"
+            )
+            return
+
+        Debug.log_internal(
+            f"  site-packages resolved: {site_packages}  "
+            f"({_time.perf_counter() - _t0:.2f}s)"
+        )
+
+        copied: list[str] = []
+        dist_root = Path(dist_dir)
+
+        for pkg in sorted(self.raw_copy_packages):
+            src = os.path.join(site_packages, pkg)
+            if not os.path.isdir(src):
+                Debug.log_warning(
+                    f"JIT package '{pkg}' not found in {site_packages} — skipping"
+                )
+                continue
+
+            _pkg_t0 = _time.perf_counter()
+            dst = dist_root / pkg
+            if dst.exists():
+                if sys.platform == "win32":
+                    subprocess.run(
+                        ["cmd", "/c", "rd", "/s", "/q", str(dst)],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                else:
+                    shutil.rmtree(dst)
+
+            # Use robocopy on Windows for significantly faster bulk copy.
+            # /XD skips directories that are never needed at runtime,
+            # cutting the copy volume substantially (especially numpy).
+            # Package-specific strip dirs come from _JIT_STRIP_DIRS.
+            xd_dirs = ["__pycache__", "tests", "test"]
+            xd_dirs.extend(self._JIT_STRIP_DIRS.get(pkg, []))
+            if sys.platform == "win32":
+                rc = subprocess.call(
+                    ["robocopy", src, str(dst), "/E",
+                     "/XD", *xd_dirs,
+                     "/XF", "*.pyc", "*.pdb", "*.lib", "*.a",
+                     "/NFL", "/NDL", "/NJH", "/NJS", "/NP"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    creationflags=0x08000000,
+                )
+                if rc >= 8:
+                    Debug.log_warning(
+                        f"robocopy failed for '{pkg}' (exit {rc}), "
+                        f"falling back to shutil.copytree"
+                    )
+                    if dst.exists():
+                        shutil.rmtree(dst)
+                    shutil.copytree(src, dst)
+            else:
+                shutil.copytree(src, dst)
+                # Strip on non-Windows too
+                for strip_dir in xd_dirs:
+                    strip_path = dst / strip_dir
+                    if strip_path.is_dir():
+                        shutil.rmtree(strip_path)
+
+            elapsed = _time.perf_counter() - _pkg_t0
+            copied.append(f"{pkg} ({elapsed:.1f}s)")
+
+            # Copy companion .libs directory if it exists (e.g. numpy.libs
+            # contains OpenBLAS DLLs that numpy's C extensions need).
+            libs_name = f"{pkg}.libs"
+            libs_src = os.path.join(site_packages, libs_name)
+            if os.path.isdir(libs_src):
+                libs_dst = dist_root / libs_name
+                if libs_dst.exists():
+                    if sys.platform == "win32":
+                        subprocess.run(
+                            ["cmd", "/c", "rd", "/s", "/q", str(libs_dst)],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                        )
+                    else:
+                        shutil.rmtree(libs_dst)
+                if sys.platform == "win32":
+                    subprocess.call(
+                        ["robocopy", libs_src, str(libs_dst), "/E",
+                         "/NFL", "/NDL", "/NJH", "/NJS", "/NP"],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        creationflags=0x08000000,
+                    )
+                else:
+                    shutil.copytree(libs_src, libs_dst)
+                copied.append(f"{libs_name}")
+
+        if copied:
+            Debug.log_internal(
+                f"  JIT package injection: {', '.join(copied)}  "
+                f"(total {_time.perf_counter() - _t0:.1f}s)"
+            )
 
     # ------------------------------------------------------------------
     # UTF-8 application manifest (Windows)

--- a/python/Infernux/engine/ui/build_settings_panel.py
+++ b/python/Infernux/engine/ui/build_settings_panel.py
@@ -381,6 +381,8 @@ class BuildSettingsPanel:
         self._window_width = data.get("window_width", 1280)
         self._window_height = data.get("window_height", 720)
         self._window_resizable = data.get("window_resizable", True)
+        self._debug_mode = data.get("debug_mode", False)
+        self._lto = data.get("lto", True)
         self._splash_items = list(data.get("splash_items", []))
 
     def _prune_missing_splash(self):
@@ -403,6 +405,8 @@ class BuildSettingsPanel:
             "window_width": self._window_width,
             "window_height": self._window_height,
             "window_resizable": self._window_resizable,
+            "debug_mode": self._debug_mode,
+            "lto": self._lto,
             "splash_items": self._splash_items,
         })
 
@@ -474,10 +478,20 @@ class BuildSettingsPanel:
         ctx.label(t("build.game_name"))
         root = get_project_root()
         placeholder = os.path.basename(root) if root else "MyGame"
-        ctx.set_next_item_width(400)
+        ctx.set_next_item_width(300)
         new_name = ctx.text_input("##game_name", self._game_name, 256)
         if new_name != self._game_name:
             self._game_name = new_name
+            self._save()
+        ctx.same_line(0, 20)
+        new_debug = ctx.checkbox(t("build.debug_mode") + "##debug_mode", self._debug_mode)
+        if new_debug != self._debug_mode:
+            self._debug_mode = new_debug
+            self._save()
+        ctx.same_line(0, 20)
+        new_lto = ctx.checkbox(t("build.lto") + "##lto", self._lto)
+        if new_lto != self._lto:
+            self._lto = new_lto
             self._save()
         if not self._game_name:
             ctx.same_line()
@@ -882,6 +896,8 @@ class BuildSettingsPanel:
             window_height=self._window_height,
             window_resizable=self._window_resizable,
             splash_items=self._splash_items,
+            debug_mode=self._debug_mode,
+            lto=self._lto,
         )
 
     def _cancel_build(self):

--- a/python/Infernux/gizmos/gizmos.py
+++ b/python/Infernux/gizmos/gizmos.py
@@ -196,9 +196,11 @@ class Gizmos:
         verts = []
         indices = []
 
-        # Pre-compute trig table (JIT-accelerated when Numba available)
-        from Infernux._jit_kernels import jit_wire_sphere_trig
-        cos_tab, sin_tab = jit_wire_sphere_trig(segments)
+        # Pre-compute trig table
+        import math as _math
+        _two_pi = 2.0 * _math.pi
+        cos_tab = [_math.cos(_two_pi * i / segments) for i in range(segments)]
+        sin_tab = [_math.sin(_two_pi * i / segments) for i in range(segments)]
 
         for axis in range(3):
             base = len(verts)

--- a/python/Infernux/jit.py
+++ b/python/Infernux/jit.py
@@ -1,11 +1,27 @@
-"""Public JIT helpers for gameplay scripts.
+"""Infernux JIT — public API for JIT-accelerated computation.
 
-This is the supported import surface for Infernux JIT usage:
+Canonical import surface for user scripts::
 
-    from Infernux.jit import njit, precompile_jit
+    from Infernux.jit import njit, warmup, JIT_AVAILABLE
 
-The implementation delegates to ``Infernux._jit_kernels`` so the engine keeps
-one canonical JIT/fallback mechanism.
+Or via the top-level convenience re-export::
+
+    from Infernux import njit
+
+``njit`` wraps ``numba.njit`` with two extra niceties:
+
+* Falls back to a no-op decorator when Numba is not installed.
+* Attaches a ``.py`` attribute to every decorated function,
+  pointing to the original pure-Python source so callers can
+  explicitly bypass JIT::
+
+    @njit(cache=True, fastmath=True)
+    def compute(x): ...
+
+    compute(42)      # JIT (or fallback)
+    compute.py(42)   # always pure Python
+
+``warmup(fn, *args)`` pre-compiles a ``@njit`` function.
 """
 
 from __future__ import annotations
@@ -25,10 +41,10 @@ _JIT_CHECK_ENV = "_INFERNUX_JIT_RUNTIME_CHECKED"
 
 
 def _sync_exports() -> None:
-    global JIT_AVAILABLE, njit, precompile
+    global JIT_AVAILABLE, njit, warmup
     JIT_AVAILABLE = _jit_kernels.JIT_AVAILABLE
     njit = _jit_kernels.njit
-    precompile = _jit_kernels.precompile
+    warmup = _jit_kernels.warmup
 
 
 def _run_python(args: list[str], *, timeout: int) -> subprocess.CompletedProcess:
@@ -126,19 +142,18 @@ def ensure_jit_runtime(*, auto_install: bool = True) -> bool:
 
 
 def precompile_jit() -> None:
-    """Compile and cache built-in JIT kernels ahead of time.
+    """No-op kept for backward compatibility.
 
-    The generic project-requirements phase (``ensure_project_requirements``)
-    already handles numba installation, so we no longer call
-    ``ensure_jit_runtime`` here — just trigger the AOT warm-up.
+    Previously warmed up built-in JIT kernels; those are now pure Python.
+    User code should use ``warmup(fn, *args)`` for their own functions.
     """
-    precompile()
+    pass
 
 
 __all__ = [
     "JIT_AVAILABLE",
     "ensure_jit_runtime",
     "njit",
-    "precompile",
+    "warmup",
     "precompile_jit",
 ]

--- a/python/Infernux/jit.pyi
+++ b/python/Infernux/jit.pyi
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable, TypeVar
+
+_F = TypeVar("_F", bound=Callable[..., Any])
 
 JIT_AVAILABLE: bool
 
@@ -9,15 +11,19 @@ def ensure_jit_runtime(*, auto_install: bool = True) -> bool:
     ...
 
 def njit(*args: Any, **kwargs: Any) -> Any:
-    """Numba ``njit`` decorator, or a no-op fallback when Numba is unavailable."""
+    """Numba ``njit`` decorator, or a no-op fallback when Numba is unavailable.
+
+    The decorated function gains a ``.py`` attribute pointing to the
+    original pure-Python source.
+    """
     ...
 
-def precompile() -> None:
-    """Compile and cache built-in JIT kernels ahead of time."""
+def warmup(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+    """Pre-compile a ``@njit`` function by calling it with representative args."""
     ...
 
 def precompile_jit() -> None:
-    """Compile and cache built-in JIT kernels ahead of time."""
+    """No-op kept for backward compatibility."""
     ...
 
 __all__: list[str]

--- a/python/Infernux/lib/__init__.py
+++ b/python/Infernux/lib/__init__.py
@@ -55,28 +55,60 @@ def _iter_dev_native_search_dirs():
             yield os.path.join(build_root, *prefix, config)
 
 
+_SYSTEM_DLL_CHECKS = (
+    ("MSVCP140.dll", "Install or repair the Microsoft Visual C++ Redistributable."),
+    ("VCRUNTIME140.dll", "Install or repair the Microsoft Visual C++ Redistributable."),
+    ("VCRUNTIME140_1.dll", "Install or repair the Microsoft Visual C++ Redistributable."),
+    ("vulkan-1.dll", "Install a current GPU driver or the Vulkan Runtime."),
+)
+
+_ENGINE_DLLS = (
+    "SDL3.dll",
+    "assimp-vc143-mt.dll",
+    "glslang.dll",
+    "SPIRV.dll",
+    "Jolt.dll",
+)
+
+
 def _collect_windows_native_load_hints():
     if sys.platform != "win32":
         return []
 
     hints = []
-    checks = (
-        ("MSVCP140.dll", "Install or repair the Microsoft Visual C++ Redistributable."),
-        ("VCRUNTIME140.dll", "Install or repair the Microsoft Visual C++ Redistributable."),
-        ("VCRUNTIME140_1.dll", "Install or repair the Microsoft Visual C++ Redistributable."),
-        ("vulkan-1.dll", "Install a current GPU driver or the Vulkan Runtime."),
-    )
 
-    for dll_name, remedy in checks:
+    for dll_name, remedy in _SYSTEM_DLL_CHECKS:
         try:
             ctypes.WinDLL(dll_name)
         except OSError:
-            hints.append(f"Missing {dll_name}. {remedy}")
+            hints.append(f"Missing system DLL: {dll_name}. {remedy}")
 
     if not glob.glob(os.path.join(lib_dir, "_Infernux*.pyd")):
         hints.append(f"Missing _Infernux*.pyd under {lib_dir}. Reinstall the Infernux wheel.")
 
+    for dll_name in _ENGINE_DLLS:
+        full = os.path.join(lib_dir, dll_name)
+        if not os.path.isfile(full):
+            hints.append(f"Missing engine DLL: {dll_name}. Reinstall the Infernux wheel.")
+        else:
+            try:
+                ctypes.WinDLL(full)
+            except OSError as e:
+                hints.append(
+                    f"Engine DLL present but failed to load: {dll_name} ({e}). "
+                    f"A dependency of this DLL may be missing."
+                )
+
     return hints
+
+
+def _list_lib_dir_contents():
+    try:
+        entries = sorted(os.listdir(lib_dir))
+        dlls = [e for e in entries if e.lower().endswith((".dll", ".pyd", ".so", ".dylib"))]
+        return dlls
+    except OSError:
+        return []
 
 
 def _raise_native_import_error(exc):
@@ -88,8 +120,8 @@ def _raise_native_import_error(exc):
 
     hints = _collect_windows_native_load_hints()
     if hints:
-        lines.append("Likely causes:")
-        lines.extend(f"- {hint}" for hint in hints)
+        lines.append("Diagnostic results:")
+        lines.extend(f"  - {hint}" for hint in hints)
     elif sys.platform == "darwin":
         if not glob.glob(os.path.join(lib_dir, "_Infernux*.so")):
             lines.append(f"Missing _Infernux*.so under {lib_dir}. Build the native module first.")
@@ -100,6 +132,13 @@ def _raise_native_import_error(exc):
         lines.append(
             "Likely causes: a missing Vulkan runtime or missing Microsoft Visual C++ runtime DLLs."
         )
+
+    found = _list_lib_dir_contents()
+    if found:
+        lines.append(f"Native files found in lib directory ({len(found)}):")
+        lines.extend(f"  {f}" for f in found)
+    else:
+        lines.append("WARNING: No native files found in lib directory!")
 
     raise ImportError("\n".join(lines)) from exc
 

--- a/python/Infernux/lib/__init__.py
+++ b/python/Infernux/lib/__init__.py
@@ -103,7 +103,46 @@ def _raise_native_import_error(exc):
 
     raise ImportError("\n".join(lines)) from exc
 
+
+def _preload_bundled_crt_dlls() -> None:
+    """Pre-load MSVC CRT DLLs bundled alongside ``_Infernux.pyd``.
+
+    On machines without a system-wide Visual C++ Redistributable install,
+    ``os.add_dll_directory()`` alone is not always sufficient —
+    ``_Infernux.pyd`` (and the engine DLLs it depends on) may still fail
+    to resolve ``vcruntime140.dll`` / ``msvcp140.dll`` at load time.
+
+    Explicitly loading them via ``ctypes.WinDLL`` before the ``from
+    ._Infernux import *`` guarantees they are resident in the process
+    and the dynamic linker can satisfy the dependency.
+    """
+    if sys.platform != "win32":
+        return
+
+    # Order matters: vcruntime first, then msvcp / concrt (they depend
+    # on vcruntime).
+    _CRT_LOAD_ORDER = (
+        "vcruntime140.dll",
+        "vcruntime140_1.dll",
+        "msvcp140.dll",
+        "msvcp140_1.dll",
+        "msvcp140_2.dll",
+        "msvcp140_atomic_wait.dll",
+        "msvcp140_codecvt_ids.dll",
+        "concrt140.dll",
+    )
+
+    for name in _CRT_LOAD_ORDER:
+        full = os.path.join(lib_dir, name)
+        if os.path.isfile(full):
+            try:
+                ctypes.WinDLL(full)
+            except OSError:
+                pass  # Best-effort; the import below will give a clear error.
+
+
 _register_native_search_dir(lib_dir)
+_preload_bundled_crt_dlls()
 
 try:
     from ._Infernux import *

--- a/python/Infernux/mathf.py
+++ b/python/Infernux/mathf.py
@@ -133,9 +133,30 @@ class Mathf:
                     smooth_time=0.3, delta_time=Time.delta_time,
                 )
         """
-        from Infernux._jit_kernels import jit_smooth_damp
-        return jit_smooth_damp(current, target, current_velocity,
-                               smooth_time, max_speed, delta_time)
+        if smooth_time < 0.0001:
+            smooth_time = 0.0001
+        omega = 2.0 / smooth_time
+        x = omega * delta_time
+        exp_factor = 1.0 / (1.0 + x + 0.48 * x * x + 0.235 * x * x * x)
+        change = current - target
+        original_to = target
+
+        max_change = max_speed * smooth_time
+        if change < -max_change:
+            change = -max_change
+        elif change > max_change:
+            change = max_change
+        target = current - change
+
+        temp = (current_velocity + omega * change) * delta_time
+        new_velocity = (current_velocity - omega * temp) * exp_factor
+        output = target + (change + temp) * exp_factor
+
+        if (original_to - current > 0.0) == (output > original_to):
+            output = original_to
+            new_velocity = (output - original_to) / delta_time if delta_time > 0.0 else 0.0
+
+        return output, new_velocity
 
     # ====================================================================
     # Angle helpers (degrees)

--- a/python/Infernux/ui/inx_ui_screen_component.py
+++ b/python/Infernux/ui/inx_ui_screen_component.py
@@ -359,6 +359,9 @@ class InxUIScreenComponent(InxUIComponent):
             return (rx <= px <= rx + rw) and (ry <= py <= ry + rh)
 
         # Rotate point into element's local frame (negate angle)
-        from Infernux._jit_kernels import jit_contains_point_rotated
         sin_a, cos_a = self._rot_sincos()
-        return jit_contains_point_rotated(px, py, rx, ry, rw, rh, sin_a, cos_a)
+        dx = px - (rx + rw * 0.5)
+        dy = py - (ry + rh * 0.5)
+        lx = dx * cos_a + dy * sin_a + rw * 0.5
+        ly = -dx * sin_a + dy * cos_a + rh * 0.5
+        return (0.0 <= lx <= rw) and (0.0 <= ly <= rh)

--- a/python/test/test_jit.py
+++ b/python/test/test_jit.py
@@ -63,20 +63,6 @@ class TestEnsureJitRuntime:
 
 
 class TestPrecompileJit:
-    def test_precompile_jit_uses_non_installing_check(self, monkeypatch):
-        called = {"auto_install": None, "precompile": False}
-
-        def _ensure(*, auto_install: bool = True) -> bool:
-            called["auto_install"] = auto_install
-            return False
-
-        def _precompile() -> None:
-            called["precompile"] = True
-
-        monkeypatch.setattr(jit, "ensure_jit_runtime", _ensure)
-        monkeypatch.setattr(jit, "precompile", _precompile)
-
-        jit.precompile_jit()
-
-        assert called["auto_install"] is False
-        assert called["precompile"] is True
+    def test_precompile_jit_is_noop(self):
+        # precompile_jit() is kept for backward compat; it does nothing.
+        jit.precompile_jit()  # should not raise

--- a/python/test/test_math.py
+++ b/python/test/test_math.py
@@ -1,4 +1,4 @@
-"""Tests for Infernux.mathf (Mathf utility class) and Infernux._jit_kernels."""
+"""Tests for Infernux.mathf (Mathf utility class) and Infernux.jit kernels."""
 
 from __future__ import annotations
 
@@ -7,11 +7,6 @@ import math
 import pytest
 
 from Infernux.mathf import Mathf
-from Infernux._jit_kernels import (
-    jit_smooth_damp,
-    jit_contains_point_rotated,
-    jit_wire_sphere_trig,
-)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -296,34 +291,4 @@ class TestPowerOfTwo:
         assert Mathf.closest_power_of_two(7) == 8
 
 
-# ═══════════════════════════════════════════════════════════════════════════
-# JIT Kernels
-# ═══════════════════════════════════════════════════════════════════════════
 
-class TestJitKernels:
-    def test_smooth_damp_kernel(self):
-        val, vel = jit_smooth_damp(0.0, 10.0, 0.0, 0.3, float("inf"), 0.016)
-        assert val > 0
-        assert vel > 0
-
-    def test_smooth_damp_zero_dt(self):
-        val, vel = jit_smooth_damp(5.0, 10.0, 1.0, 0.3, float("inf"), 0.0)
-        assert isinstance(val, float)
-
-    def test_contains_point_inside(self):
-        assert jit_contains_point_rotated(50, 50, 0, 0, 100, 100, 0.0, 1.0) is True
-
-    def test_contains_point_outside(self):
-        assert jit_contains_point_rotated(150, 150, 0, 0, 100, 100, 0.0, 1.0) is False
-
-    def test_contains_point_rotated(self):
-        sin45 = math.sin(math.pi / 4)
-        cos45 = math.cos(math.pi / 4)
-        assert jit_contains_point_rotated(50, 50, 0, 0, 100, 100, sin45, cos45) is True
-
-    def test_wire_sphere_trig(self):
-        cos_tab, sin_tab = jit_wire_sphere_trig(8)
-        assert len(cos_tab) == 8
-        assert len(sin_tab) == 8
-        assert cos_tab[0] == pytest.approx(1.0)
-        assert sin_tab[0] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

Establish full Nuitka standalone build compatibility with Numba JIT and refactor the JIT module into a minimal, user-facing API surface. The engine's internal kernel functions are removed from the JIT module and inlined as pure Python into their respective callers, leaving @njit as a clean decorator for user scripts with automatic fallback when Numba is unavailable.

## What changed

- Nuitka + Numba hybrid exclusion: `nuitka_builder.py` now strips JIT-related packages via `_JIT_STRIP_DIRS`, adds robocopy exclusions, and disables Numba cache in Nuitka builds. 

## Verification

- [ ] Built the affected targets
- [ ] Ran the relevant tests or static validation
- [ ] Updated docs if behavior or public APIs changed

## Notes for reviewers

nothing. 
