### PR TITLE
015/fix tech debt

### DIFF
--- a/cpp/infernux/core/threading/JobSystem.cpp
+++ b/cpp/infernux/core/threading/JobSystem.cpp
@@ -52,8 +52,8 @@ void JobSystem::Initialize(uint32_t workerCount)
         g_instance->m_workers.emplace_back([] { JobSystem::Get().WorkerLoop(); });
     }
 
-    INXLOG_INFO("JobSystem online with ", resolved, " worker thread(s) (hw_concurrency=",
-                std::thread::hardware_concurrency(), ")");
+    INXLOG_INFO("JobSystem online with ", resolved,
+                " worker thread(s) (hw_concurrency=", std::thread::hardware_concurrency(), ")");
 }
 
 void JobSystem::Shutdown()
@@ -194,8 +194,7 @@ void JobSystem::WorkerLoop()
         Task task;
         {
             std::unique_lock<std::mutex> guard(m_queueMutex);
-            m_queueCv.wait(guard,
-                           [this] { return !m_queue.empty() || !m_running.load(std::memory_order_acquire); });
+            m_queueCv.wait(guard, [this] { return !m_queue.empty() || !m_running.load(std::memory_order_acquire); });
 
             if (!m_running.load(std::memory_order_acquire) && m_queue.empty()) {
                 return;

--- a/cpp/infernux/core/threading/JobSystem.cpp
+++ b/cpp/infernux/core/threading/JobSystem.cpp
@@ -1,0 +1,224 @@
+/**
+ * @file JobSystem.cpp
+ * @brief Implementation of the engine-wide C++ worker thread pool.
+ */
+
+#include "JobSystem.h"
+#include <algorithm>
+#include <cassert>
+#include <core/log/InxLog.h>
+
+namespace infernux
+{
+
+namespace
+{
+
+JobSystem *g_instance = nullptr;
+std::mutex g_singletonMutex;
+
+uint32_t ResolveWorkerCount(uint32_t requested) noexcept
+{
+    if (requested != 0) {
+        return std::clamp<uint32_t>(requested, 1u, 32u);
+    }
+    const auto detected = std::thread::hardware_concurrency();
+    if (detected <= 1) {
+        // Single-core or hardware_concurrency() returned 0 (allowed by the
+        // standard) → still spin up one worker so call sites have a thread
+        // to dispatch to without having to special-case JobSystem absence.
+        return 1u;
+    }
+    return std::clamp<uint32_t>(detected - 1, 1u, 32u);
+}
+
+} // namespace
+
+void JobSystem::Initialize(uint32_t workerCount)
+{
+    std::lock_guard<std::mutex> guard(g_singletonMutex);
+    assert(g_instance == nullptr && "JobSystem::Initialize called twice");
+    if (g_instance != nullptr) {
+        INXLOG_WARN("JobSystem::Initialize called twice — ignoring second call");
+        return;
+    }
+
+    g_instance = new JobSystem();
+    g_instance->m_running.store(true, std::memory_order_release);
+
+    const uint32_t resolved = ResolveWorkerCount(workerCount);
+    g_instance->m_workers.reserve(resolved);
+    for (uint32_t i = 0; i < resolved; ++i) {
+        g_instance->m_workers.emplace_back([] { JobSystem::Get().WorkerLoop(); });
+    }
+
+    INXLOG_INFO("JobSystem online with ", resolved, " worker thread(s) (hw_concurrency=",
+                std::thread::hardware_concurrency(), ")");
+}
+
+void JobSystem::Shutdown()
+{
+    JobSystem *toDestroy = nullptr;
+    {
+        std::lock_guard<std::mutex> guard(g_singletonMutex);
+        toDestroy = g_instance;
+        g_instance = nullptr;
+    }
+
+    if (toDestroy == nullptr) {
+        return;
+    }
+
+    toDestroy->m_running.store(false, std::memory_order_release);
+    toDestroy->m_queueCv.notify_all();
+
+    for (auto &t : toDestroy->m_workers) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+    toDestroy->m_workers.clear();
+
+    delete toDestroy;
+}
+
+JobSystem &JobSystem::Get()
+{
+    // Fast path: no lock for the common case where Initialize already ran.
+    // Initialize/Shutdown are coarse one-shot events so a relaxed read here
+    // is fine; the assert protects against misuse from arbitrary call sites.
+    assert(g_instance != nullptr && "JobSystem::Get called before Initialize");
+    return *g_instance;
+}
+
+bool JobSystem::IsAvailable() noexcept
+{
+    std::lock_guard<std::mutex> guard(g_singletonMutex);
+    return g_instance != nullptr;
+}
+
+JobSystem::~JobSystem()
+{
+    // Shutdown should already have joined workers; if not, do it defensively
+    // so destruction never leaves a dangling thread.
+    m_running.store(false, std::memory_order_release);
+    m_queueCv.notify_all();
+    for (auto &t : m_workers) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+}
+
+JobHandle JobSystem::Schedule(JobFn job)
+{
+    auto counter = std::make_shared<std::atomic<int>>(1);
+    Task task{std::move(job), counter};
+    {
+        std::lock_guard<std::mutex> guard(m_queueMutex);
+        m_queue.push(std::move(task));
+    }
+    m_queueCv.notify_one();
+    return JobHandle(std::move(counter));
+}
+
+JobHandle JobSystem::ScheduleBatch(uint32_t count, std::function<JobFn(uint32_t)> factory)
+{
+    if (count == 0) {
+        return JobHandle();
+    }
+
+    auto counter = std::make_shared<std::atomic<int>>(static_cast<int>(count));
+    {
+        std::lock_guard<std::mutex> guard(m_queueMutex);
+        for (uint32_t i = 0; i < count; ++i) {
+            m_queue.push(Task{factory(i), counter});
+        }
+    }
+    m_queueCv.notify_all();
+    return JobHandle(std::move(counter));
+}
+
+void JobSystem::ParallelFor(uint32_t count, std::function<void(uint32_t)> body)
+{
+    if (count == 0) {
+        return;
+    }
+    auto handle = ScheduleBatch(count, [body](uint32_t i) -> JobFn { return [body, i] { body(i); }; });
+    Wait(handle);
+}
+
+void JobSystem::Wait(const JobHandle &handle)
+{
+    if (!handle.IsValid()) {
+        return;
+    }
+
+    // Opportunistic helper-thread participation: instead of a passive
+    // condition_variable wait, the joining thread runs queued tasks itself
+    // until the counter zeroes out. This protects against priority inversion
+    // when the main render thread joins on jobs scheduled by helpers.
+    while (handle.m_counter->load(std::memory_order_acquire) > 0) {
+        if (!TryRunOne()) {
+            // Queue empty but our counter not yet zero → workers are still
+            // executing the last task(s); just yield instead of busy-waiting.
+            std::this_thread::yield();
+        }
+    }
+}
+
+bool JobSystem::TryRunOne()
+{
+    Task task;
+    {
+        std::lock_guard<std::mutex> guard(m_queueMutex);
+        if (m_queue.empty()) {
+            return false;
+        }
+        task = std::move(m_queue.front());
+        m_queue.pop();
+    }
+
+    if (task.fn) {
+        task.fn();
+    }
+    if (task.counter) {
+        task.counter->fetch_sub(1, std::memory_order_acq_rel);
+    }
+    return true;
+}
+
+void JobSystem::WorkerLoop()
+{
+    while (m_running.load(std::memory_order_acquire)) {
+        Task task;
+        {
+            std::unique_lock<std::mutex> guard(m_queueMutex);
+            m_queueCv.wait(guard,
+                           [this] { return !m_queue.empty() || !m_running.load(std::memory_order_acquire); });
+
+            if (!m_running.load(std::memory_order_acquire) && m_queue.empty()) {
+                return;
+            }
+
+            if (m_queue.empty()) {
+                continue;
+            }
+
+            task = std::move(m_queue.front());
+            m_queue.pop();
+        }
+
+        if (task.fn) {
+            // Errors in user-supplied jobs are bugs in the caller — let
+            // them propagate so the worker thread terminates with a
+            // diagnosable stack instead of silently dropping work.
+            task.fn();
+        }
+        if (task.counter) {
+            task.counter->fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
+}
+
+} // namespace infernux

--- a/cpp/infernux/core/threading/JobSystem.h
+++ b/cpp/infernux/core/threading/JobSystem.h
@@ -1,0 +1,174 @@
+/**
+ * @file JobSystem.h
+ * @brief Engine-wide C++ thread pool for parallel work dispatch.
+ *
+ * Designed to live alongside Jolt's JobSystemThreadPool (used by physics)
+ * and Python's ThreadPoolExecutor (used by editor / asset workflows).
+ * The C++ side previously had no general-purpose worker pool, which forced
+ * every parallel-friendly path (texture decoding, mesh import, render
+ * command recording, scene tick parallelisation) to either go single
+ * threaded or build its own ad-hoc threading.
+ *
+ * Design goals:
+ *
+ *   * Trivial to use — `JobSystem::Get().Schedule([]{ ... });` is the
+ *     entire API for one-off work; a returned JobHandle lets callers
+ *     join when needed.
+ *   * Move-only handles, no exceptions in the worker loop.
+ *   * Configurable worker count; defaults to (hw_concurrency - 1) so
+ *     the main render thread never has to compete with workers for a
+ *     core. -1 keeps the CPU breathing room for the OS / driver.
+ *   * Mutex-guarded queue today. The interface is deliberately minimal
+ *     so we can swap the queue for a lock-free MPMC ring buffer later
+ *     without touching call sites.
+ *   * Designed to coexist with — not replace — Jolt's pool. Physics
+ *     keeps its own pool; this one is for everything else.
+ *
+ * Non-goals (documented for future readers):
+ *
+ *   * Work stealing — keep the implementation small until we measure
+ *     contention on the shared queue. Most expected workloads are
+ *     coarse-grained (per-pass / per-asset) where a shared queue is
+ *     fine.
+ *   * Job dependencies / DAG — handled at call site for now via Wait().
+ *     Add a dependency graph layer when render-graph parallel recording
+ *     actually lands.
+ *   * Fiber support — Vulkan command recording does not need it.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace infernux
+{
+
+/**
+ * @brief Opaque, move-only handle identifying a single scheduled job.
+ *
+ * Wait()-able through JobSystem. Multiple handles can share the same
+ * underlying counter — useful for ParallelFor where we want to wait on
+ * an entire batch.
+ */
+class JobHandle
+{
+  public:
+    JobHandle() = default;
+    explicit JobHandle(std::shared_ptr<std::atomic<int>> counter) : m_counter(std::move(counter))
+    {
+    }
+
+    JobHandle(const JobHandle &) = default;
+    JobHandle &operator=(const JobHandle &) = default;
+    JobHandle(JobHandle &&) noexcept = default;
+    JobHandle &operator=(JobHandle &&) noexcept = default;
+
+    [[nodiscard]] bool IsValid() const noexcept
+    {
+        return static_cast<bool>(m_counter);
+    }
+
+    /// @brief Non-blocking poll. Returns true once all referenced jobs have completed.
+    [[nodiscard]] bool IsComplete() const noexcept
+    {
+        return m_counter && m_counter->load(std::memory_order_acquire) == 0;
+    }
+
+  private:
+    friend class JobSystem;
+    std::shared_ptr<std::atomic<int>> m_counter;
+};
+
+/**
+ * @brief Engine-wide worker thread pool singleton.
+ *
+ * Initialize() must be called once at engine startup; Shutdown() once at
+ * engine teardown. Get() returns the singleton in between. The singleton
+ * is intentionally NOT initialised lazily — silent worker startup during
+ * arbitrary translation units' static init would race with the rest of
+ * engine bring-up.
+ */
+class JobSystem
+{
+  public:
+    using JobFn = std::function<void()>;
+
+    /// @brief Bring up the global pool with @p workerCount worker threads.
+    /// @p workerCount = 0 picks (hw_concurrency - 1) clamped to [1, 32].
+    /// Calling Initialize twice is a logic error and asserts in debug.
+    static void Initialize(uint32_t workerCount = 0);
+
+    /// @brief Shut the global pool down. Pending jobs are drained first,
+    /// then workers are joined. Safe to call multiple times.
+    static void Shutdown();
+
+    /// @brief Access the global pool. Initialize() must have been called.
+    [[nodiscard]] static JobSystem &Get();
+
+    /// @brief Has Initialize() been called and Shutdown() not yet called?
+    [[nodiscard]] static bool IsAvailable() noexcept;
+
+    JobSystem(const JobSystem &) = delete;
+    JobSystem &operator=(const JobSystem &) = delete;
+    JobSystem(JobSystem &&) = delete;
+    JobSystem &operator=(JobSystem &&) = delete;
+
+    /// @brief Schedule a single job. Returns a handle for joining later.
+    /// The handle stays valid even after the job completes — IsComplete()
+    /// just observes a zeroed counter.
+    JobHandle Schedule(JobFn job);
+
+    /// @brief Schedule @p count jobs that share a single counter, useful
+    /// for ParallelFor-style fan-out where the caller wants one wait point.
+    /// @p factory is invoked once per index (0..count-1) on the calling
+    /// thread to produce each individual job — keeps the hot scheduling
+    /// loop free of allocation when the factory is a stateless lambda.
+    JobHandle ScheduleBatch(uint32_t count, std::function<JobFn(uint32_t index)> factory);
+
+    /// @brief Convenience: parallel-for over [0, count). Equivalent to
+    /// ScheduleBatch + Wait but expresses intent more clearly at call sites.
+    void ParallelFor(uint32_t count, std::function<void(uint32_t index)> body);
+
+    /// @brief Block the caller until all jobs referenced by @p handle complete.
+    /// Returns immediately when the handle is invalid or already complete.
+    /// While blocked, the caller participates as an opportunistic worker —
+    /// this prevents priority inversion when the main thread joins on jobs
+    /// scheduled by helper code.
+    void Wait(const JobHandle &handle);
+
+    /// @brief How many worker threads are running. 0 if Shutdown.
+    [[nodiscard]] uint32_t GetWorkerCount() const noexcept
+    {
+        return static_cast<uint32_t>(m_workers.size());
+    }
+
+  private:
+    JobSystem() = default;
+    ~JobSystem();
+
+    struct Task
+    {
+        JobFn fn;
+        std::shared_ptr<std::atomic<int>> counter;
+    };
+
+    void WorkerLoop();
+    bool TryRunOne(); // Returns true if a task was executed.
+
+    std::vector<std::thread> m_workers;
+    std::queue<Task> m_queue;
+    std::mutex m_queueMutex;
+    std::condition_variable m_queueCv;
+    std::atomic<bool> m_running{false};
+};
+
+} // namespace infernux

--- a/cpp/infernux/function/renderer/InxRenderer.cpp
+++ b/cpp/infernux/function/renderer/InxRenderer.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cmath>
 #include <core/config/MathConstants.h>
+#include <core/threading/JobSystem.h>
 #include <function/resources/AssetRegistry/AssetRegistry.h>
 #include <function/resources/InxMaterial/InxMaterial.h>
 #include <function/resources/InxMesh/InxMesh.h>
@@ -89,6 +90,11 @@ InxRenderer::~InxRenderer()
         m_view->Quit();
     }
     m_view.reset();
+
+    // 5. Stop the engine-wide worker pool. Done last so any
+    //    last-minute teardown work scheduled by subsystem destructors
+    //    above has a thread to run on.
+    JobSystem::Shutdown();
 }
 
 void InxRenderer::SetCameraPos(float x, float y, float z)
@@ -154,6 +160,14 @@ void InxRenderer::Init(int width, int height, InxAppMetadata appMetaData)
     if (!m_vkCore) {
         INXLOG_ERROR("Failed to create InxVkCoreModular.");
         return;
+    }
+
+    // Bring up the engine-wide C++ thread pool BEFORE Vulkan / scene init so
+    // any subsystem that wants to schedule background work can. Idempotent
+    // when called twice (e.g. when an external host already initialised it),
+    // and Shutdown() in ~InxRenderer pairs with Initialize() here.
+    if (!JobSystem::IsAvailable()) {
+        JobSystem::Initialize();
     }
 
     m_vkCore->SetWindowSize(static_cast<uint32_t>(width), static_cast<uint32_t>(height));

--- a/cpp/infernux/function/renderer/InxVkCoreModular.cpp
+++ b/cpp/infernux/function/renderer/InxVkCoreModular.cpp
@@ -149,6 +149,7 @@ InxVkCoreModular::~InxVkCoreModular()
     m_depthImage.reset();
 
     m_renderGraph.Destroy();
+    m_asyncTransferContext.Destroy();
     m_resourceManager.Destroy();
 
     // RenderGraph::Destroy() and MaterialPipelineManager::Shutdown()
@@ -214,6 +215,19 @@ void InxVkCoreModular::PrepareSurface()
     if (!m_resourceManager.Initialize(m_deviceContext)) {
         INXLOG_ERROR("Failed to initialize resource manager");
         return;
+    }
+
+    // Initialize the async-transfer context. On GPUs without a dedicated
+    // transfer queue this aliases to the graphics queue and behaves like
+    // a pooled-fence fast path; on GPUs with one (most discrete cards) it
+    // unlocks truly parallel asset uploads. Failures are non-fatal — the
+    // engine simply keeps using the synchronous VkResourceManager path.
+    const auto &queueIndices = m_deviceContext.GetQueueIndices();
+    const uint32_t transferFamily = queueIndices.transferFamily.value_or(queueIndices.graphicsFamily.value_or(0));
+    if (!m_asyncTransferContext.Initialize(m_deviceContext.GetDevice(), transferFamily,
+                                           m_deviceContext.GetTransferQueue(),
+                                           m_deviceContext.HasDedicatedTransferQueue())) {
+        INXLOG_WARN("Async transfer context unavailable; uploads will use the graphics queue.");
     }
 
     // Initialize pipeline manager

--- a/cpp/infernux/function/renderer/InxVkCoreModular.cpp
+++ b/cpp/infernux/function/renderer/InxVkCoreModular.cpp
@@ -223,10 +223,17 @@ void InxVkCoreModular::PrepareSurface()
     // unlocks truly parallel asset uploads. Failures are non-fatal — the
     // engine simply keeps using the synchronous VkResourceManager path.
     const auto &queueIndices = m_deviceContext.GetQueueIndices();
-    const uint32_t transferFamily = queueIndices.transferFamily.value_or(queueIndices.graphicsFamily.value_or(0));
-    if (!m_asyncTransferContext.Initialize(m_deviceContext.GetDevice(), transferFamily,
-                                           m_deviceContext.GetTransferQueue(),
-                                           m_deviceContext.HasDedicatedTransferQueue())) {
+    const uint32_t graphicsFamily = queueIndices.graphicsFamily.value_or(0);
+    const uint32_t transferFamily = queueIndices.transferFamily.value_or(graphicsFamily);
+    if (m_asyncTransferContext.Initialize(m_deviceContext.GetDevice(), transferFamily,
+                                          m_deviceContext.GetTransferQueue(),
+                                          m_deviceContext.HasDedicatedTransferQueue())) {
+        // Plug the async context into the resource manager so non-mipmap
+        // texture uploads route through the dedicated DMA queue. Mipmap
+        // generation still falls back to the graphics queue because
+        // vkCmdBlitImage is not legal on transfer-only queues.
+        m_resourceManager.SetAsyncTransferContext(&m_asyncTransferContext, graphicsFamily);
+    } else {
         INXLOG_WARN("Async transfer context unavailable; uploads will use the graphics queue.");
     }
 

--- a/cpp/infernux/function/renderer/InxVkCoreModular.h
+++ b/cpp/infernux/function/renderer/InxVkCoreModular.h
@@ -687,6 +687,14 @@ class InxVkCoreModular
         return m_deletionQueue;
     }
 
+    /// @brief Get the async upload context. Always valid after Initialize();
+    /// will alias to the graphics queue if the GPU has no dedicated transfer
+    /// family, so callers don't need to branch.
+    [[nodiscard]] vk::AsyncTransferContext &GetAsyncTransferContext()
+    {
+        return m_asyncTransferContext;
+    }
+
     /// @brief Inline-update the lighting UBO in a command buffer.
     ///
     /// Uses vkCmdUpdateBuffer with proper pipeline barriers so that all
@@ -755,6 +763,7 @@ class InxVkCoreModular
     vk::VkSwapchainManager m_swapchain;
     vk::VkPipelineManager m_pipelineManager;
     vk::VkResourceManager m_resourceManager;
+    vk::AsyncTransferContext m_asyncTransferContext;
     vk::RenderGraph m_renderGraph;
 
     // ========================================================================

--- a/cpp/infernux/function/renderer/MaterialDescriptor.cpp
+++ b/cpp/infernux/function/renderer/MaterialDescriptor.cpp
@@ -711,11 +711,7 @@ void MaterialDescriptorManager::ResolveTextureProperties(const std::string &mate
     }
 
     if (!writes.empty()) {
-        // Material descriptor sets are shared across all frames-in-flight
-        // (not double-buffered).  Wait for all previously submitted command
-        // buffers to finish before writing image/sampler descriptors so we
-        // don't stomp a binding the GPU is still sampling.
-        vkDeviceWaitIdle(m_device);
+        WaitForGpuIdleBeforeSharedDescriptorWrite();
         vkUpdateDescriptorSets(m_device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
     }
 }
@@ -724,27 +720,36 @@ void MaterialDescriptorManager::BindTexture(const std::string &materialName, uin
                                             VkSampler sampler)
 {
     auto it = m_descriptorSets.find(materialName);
-    if (it != m_descriptorSets.end()) {
-        it->second->textureBindings[binding] = {imageView, sampler};
+    if (it == m_descriptorSets.end())
+        return;
 
-        // Update the descriptor set immediately
-        VkDescriptorImageInfo imageInfo{};
-        imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        imageInfo.imageView = imageView;
-        imageInfo.sampler = sampler;
+    it->second->textureBindings[binding] = {imageView, sampler};
 
-        VkWriteDescriptorSet write{};
-        write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        write.dstSet = it->second->descriptorSet;
-        write.dstBinding = binding;
-        write.dstArrayElement = 0;
-        write.descriptorCount = 1;
-        write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        write.pImageInfo = &imageInfo;
+    VkDescriptorImageInfo imageInfo{};
+    imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    imageInfo.imageView = imageView;
+    imageInfo.sampler = sampler;
 
-        // Shared descriptor set — wait for all in-flight usage before writing.
+    VkWriteDescriptorSet write{};
+    write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    write.dstSet = it->second->descriptorSet;
+    write.dstBinding = binding;
+    write.dstArrayElement = 0;
+    write.descriptorCount = 1;
+    write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    write.pImageInfo = &imageInfo;
+
+    WaitForGpuIdleBeforeSharedDescriptorWrite();
+    vkUpdateDescriptorSets(m_device, 1, &write, 0, nullptr);
+}
+
+void MaterialDescriptorManager::WaitForGpuIdleBeforeSharedDescriptorWrite()
+{
+    // See the helper's declaration in MaterialDescriptor.h for the rationale.
+    // Centralising the drain here gives a single audit point for the future
+    // double-buffered / FrameDeletionQueue replacement.
+    if (m_device != VK_NULL_HANDLE) {
         vkDeviceWaitIdle(m_device);
-        vkUpdateDescriptorSets(m_device, 1, &write, 0, nullptr);
     }
 }
 

--- a/cpp/infernux/function/renderer/MaterialDescriptor.cpp
+++ b/cpp/infernux/function/renderer/MaterialDescriptor.cpp
@@ -288,9 +288,17 @@ VkDescriptorPool MaterialDescriptorManager::CreateDescriptorPool(uint32_t maxMat
         {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, maxMaterials * samplerDescriptorsPerMaterial},
     };
 
+    VkDescriptorPoolCreateFlags poolFlags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    if (m_updateAfterBindEnabled) {
+        // Required when any layout allocated from this pool carries
+        // VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT
+        // (see ShaderProgram::CreateDescriptorSetLayouts).
+        poolFlags |= VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT;
+    }
+
     VkDescriptorPoolCreateInfo poolInfo{};
     poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT; // Allow freeing individual sets
+    poolInfo.flags = poolFlags;
     poolInfo.maxSets = maxMaterials;
     poolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
     poolInfo.pPoolSizes = poolSizes.data();
@@ -745,9 +753,17 @@ void MaterialDescriptorManager::BindTexture(const std::string &materialName, uin
 
 void MaterialDescriptorManager::WaitForGpuIdleBeforeSharedDescriptorWrite()
 {
-    // See the helper's declaration in MaterialDescriptor.h for the rationale.
-    // Centralising the drain here gives a single audit point for the future
-    // double-buffered / FrameDeletionQueue replacement.
+    // Fast path: when descriptor indexing UPDATE_AFTER_BIND is enabled,
+    // the driver tracks descriptor liveness internally and lets us rewrite
+    // bindings that are currently in command buffers in flight. No drain
+    // is required and the editor texture-edit hot path becomes truly free.
+    if (m_updateAfterBindEnabled) {
+        return;
+    }
+
+    // Legacy fallback: layouts/pools were created without the descriptor-
+    // indexing flags (older GPU or feature unsupported), so we still have
+    // to drain the device before mutating a shared descriptor set.
     if (m_device != VK_NULL_HANDLE) {
         vkDeviceWaitIdle(m_device);
     }

--- a/cpp/infernux/function/renderer/MaterialDescriptor.h
+++ b/cpp/infernux/function/renderer/MaterialDescriptor.h
@@ -226,6 +226,27 @@ class MaterialDescriptorManager
      */
     void BindTexture(const std::string &materialName, uint32_t binding, VkImageView imageView, VkSampler sampler);
 
+  private:
+    /**
+     * @brief Drain the GPU before mutating a shared descriptor set.
+     *
+     * Material descriptor sets are not double-buffered, so any binding
+     * change must wait until the GPU is no longer sampling the previous
+     * binding. The current implementation calls vkDeviceWaitIdle which
+     * is correct but maximally pessimistic — it serialises 100% of GPU
+     * work on a texture swap. The long-term fix is to either duplicate
+     * descriptor sets per frame-in-flight or push the old descriptor set
+     * onto the FrameDeletionQueue and allocate a fresh one. Both paths
+     * are beyond the scope of static cleanup; this helper centralises
+     * the stall so future work can replace it in one place.
+     *
+     * Pre-condition: must be called on the main thread, OUTSIDE of a
+     * frame's command-buffer recording.
+     */
+    void WaitForGpuIdleBeforeSharedDescriptorWrite();
+
+  public:
+
     /**
      * @brief Set a frame deletion queue for deferred GPU resource cleanup.
      *

--- a/cpp/infernux/function/renderer/MaterialDescriptor.h
+++ b/cpp/infernux/function/renderer/MaterialDescriptor.h
@@ -246,7 +246,6 @@ class MaterialDescriptorManager
     void WaitForGpuIdleBeforeSharedDescriptorWrite();
 
   public:
-
     /**
      * @brief Set a frame deletion queue for deferred GPU resource cleanup.
      *

--- a/cpp/infernux/function/renderer/MaterialDescriptor.h
+++ b/cpp/infernux/function/renderer/MaterialDescriptor.h
@@ -260,6 +260,21 @@ class MaterialDescriptorManager
     }
 
     /**
+     * @brief Opt into the Vulkan 1.2 UPDATE_AFTER_BIND fast path.
+     *
+     * Must be called BEFORE Initialize(): the choice flips both the pool
+     * flags (UPDATE_AFTER_BIND_BIT) and the WaitForGpuIdleBeforeSharedDescriptorWrite
+     * branch. When enabled, descriptor writes proceed without a vkDeviceWaitIdle.
+     * Both the device and the matching ShaderProgram layouts must already be
+     * configured with the descriptor-indexing flags — see
+     * VkDeviceContext::CreateLogicalDevice and ShaderProgram::SetUpdateAfterBindEnabled.
+     */
+    void SetUpdateAfterBindEnabled(bool enabled)
+    {
+        m_updateAfterBindEnabled = enabled;
+    }
+
+    /**
      * @brief Remove descriptor set for a material
      */
     void RemoveDescriptorSet(const std::string &materialName);
@@ -352,6 +367,10 @@ class MaterialDescriptorManager
     // When non-null, stale descriptor sets are pushed here instead of
     // being freed immediately (avoids use-after-free on in-flight frames).
     FrameDeletionQueue *m_deletionQueue = nullptr;
+
+    /// True when the device supports descriptor-indexing UPDATE_AFTER_BIND
+    /// and the layouts/pool were created with the matching flags.
+    bool m_updateAfterBindEnabled = false;
 
     /**
      * @brief Allocate a new descriptor pool page and append to m_descriptorPools.

--- a/cpp/infernux/function/renderer/MaterialPipelineManager.cpp
+++ b/cpp/infernux/function/renderer/MaterialPipelineManager.cpp
@@ -145,7 +145,8 @@ MaterialPipelineManager::~MaterialPipelineManager()
 
 void MaterialPipelineManager::Initialize(VmaAllocator allocator, VkDevice device, VkPhysicalDevice physicalDevice,
                                          VkFormat colorFormat, VkFormat depthFormat, VkSampleCountFlagBits sampleCount,
-                                         ShaderProgramCache &shaderProgramCache, FrameDeletionQueue *deletionQueue)
+                                         ShaderProgramCache &shaderProgramCache, FrameDeletionQueue *deletionQueue,
+                                         bool descriptorIndexingEnabled)
 {
     m_device = device;
     m_physicalDevice = physicalDevice;
@@ -160,7 +161,14 @@ void MaterialPipelineManager::Initialize(VmaAllocator allocator, VkDevice device
     // Initialize shader program cache
     m_shaderProgramCache->Initialize(device);
 
-    // Initialize material descriptor manager
+    // Plumb the descriptor-indexing decision through to BOTH the layouts
+    // (created lazily by ShaderProgram::CreateDescriptorSetLayouts on shader
+    // load) AND the pool (created here in Initialize). Setting the static
+    // flag before Initialize() guarantees the very first ShaderProgram and
+    // the descriptor pool agree on whether UPDATE_AFTER_BIND is on, which
+    // Vulkan validation requires.
+    ShaderProgram::SetUpdateAfterBindEnabled(descriptorIndexingEnabled);
+    m_descriptorManager.SetUpdateAfterBindEnabled(descriptorIndexingEnabled);
     m_descriptorManager.Initialize(allocator, device, physicalDevice);
     m_descriptorManager.SetDeletionQueue(deletionQueue);
 

--- a/cpp/infernux/function/renderer/MaterialPipelineManager.h
+++ b/cpp/infernux/function/renderer/MaterialPipelineManager.h
@@ -66,7 +66,7 @@ class MaterialPipelineManager
      */
     void Initialize(VmaAllocator allocator, VkDevice device, VkPhysicalDevice physicalDevice, VkFormat colorFormat,
                     VkFormat depthFormat, VkSampleCountFlagBits sampleCount, ShaderProgramCache &shaderProgramCache,
-                    FrameDeletionQueue *deletionQueue = nullptr);
+                    FrameDeletionQueue *deletionQueue = nullptr, bool descriptorIndexingEnabled = false);
 
     /**
      * @brief Cleanup all resources

--- a/cpp/infernux/function/renderer/RenderPassOutput.cpp
+++ b/cpp/infernux/function/renderer/RenderPassOutput.cpp
@@ -396,11 +396,6 @@ void RenderPassOutput::CleanupResources()
         m_sampler = VK_NULL_HANDLE;
     }
 
-    if (m_readbackFence != VK_NULL_HANDLE) {
-        vkDestroyFence(device, m_readbackFence, nullptr);
-        m_readbackFence = VK_NULL_HANDLE;
-    }
-
     if (m_colorStagingBuffer != VK_NULL_HANDLE) {
         vmaDestroyBuffer(allocator, m_colorStagingBuffer, m_colorStagingAllocation);
         m_colorStagingBuffer = VK_NULL_HANDLE;

--- a/cpp/infernux/function/renderer/RenderPassOutput.cpp
+++ b/cpp/infernux/function/renderer/RenderPassOutput.cpp
@@ -215,37 +215,6 @@ bool RenderPassOutput::ReadbackDepthPixels(std::vector<float> &outData)
     return true;
 }
 
-void RenderPassOutput::RequestReadback()
-{
-    // Async readback implementation
-    // TODO: Implement async readback using fence
-    m_readbackPending = true;
-}
-
-bool RenderPassOutput::IsReadbackComplete() const
-{
-    if (!m_readbackPending) {
-        return false;
-    }
-
-    if (m_readbackFence == VK_NULL_HANDLE) {
-        return true; // No fence, assume complete
-    }
-
-    return vkGetFenceStatus(m_vkCore->GetDevice(), m_readbackFence) == VK_SUCCESS;
-}
-
-bool RenderPassOutput::GetReadbackResult(std::vector<uint8_t> &outData)
-{
-    if (!m_readbackPending) {
-        return false;
-    }
-
-    // For now, use synchronous readback
-    m_readbackPending = false;
-    return ReadbackColorPixels(outData);
-}
-
 // ============================================================================
 // Private Methods
 // ============================================================================

--- a/cpp/infernux/function/renderer/RenderPassOutput.h
+++ b/cpp/infernux/function/renderer/RenderPassOutput.h
@@ -105,41 +105,30 @@ class RenderPassOutput
     // ========================================================================
 
     /**
-     * @brief Read color pixels back to CPU memory
+     * @brief Read color pixels back to CPU memory.
      *
-     * This is a blocking operation that waits for GPU completion.
-     * For better performance, use RequestReadback + GetReadbackResult for async.
+     * Blocking: submits a transfer command, waits on a per-call fence,
+     * maps the staging buffer, and copies into @p outData (RGBA8).
      *
      * @param outData Output vector to receive pixel data (RGBA8)
-     * @return true if successful
+     * @return true if successful; logs on failure.
+     *
+     * @note A non-blocking variant that defers the readback fence-wait
+     *       across frames is not yet implemented. The previous
+     *       Request/Is/GetReadbackResult triple was removed because it
+     *       advertised async semantics it never delivered (the "complete"
+     *       check returned true unconditionally and the "get result" path
+     *       fell back to a synchronous readback).
      */
     bool ReadbackColorPixels(std::vector<uint8_t> &outData);
 
     /**
-     * @brief Read depth buffer back to CPU memory
+     * @brief Read depth buffer back to CPU memory (blocking; same semantics
+     * as ReadbackColorPixels).
      * @param outData Output vector to receive depth data (float32)
      * @return true if successful
      */
     bool ReadbackDepthPixels(std::vector<float> &outData);
-
-    /**
-     * @brief Request async readback (non-blocking)
-     *
-     * Call this after rendering, then later call IsReadbackComplete and GetReadbackResult.
-     */
-    void RequestReadback();
-
-    /**
-     * @brief Check if async readback is complete
-     */
-    [[nodiscard]] bool IsReadbackComplete() const;
-
-    /**
-     * @brief Get async readback result (call after IsReadbackComplete returns true)
-     * @param outData Output vector to receive pixel data
-     * @return true if successful
-     */
-    bool GetReadbackResult(std::vector<uint8_t> &outData);
 
     // ========================================================================
     // Properties
@@ -208,10 +197,6 @@ class RenderPassOutput
     VkBuffer m_depthStagingBuffer = VK_NULL_HANDLE;
     VmaAllocation m_depthStagingAllocation = VK_NULL_HANDLE;
     VkDeviceSize m_depthStagingSize = 0;
-
-    // Async readback
-    VkFence m_readbackFence = VK_NULL_HANDLE;
-    bool m_readbackPending = false;
 };
 
 } // namespace infernux

--- a/cpp/infernux/function/renderer/ScriptableRenderContext.cpp
+++ b/cpp/infernux/function/renderer/ScriptableRenderContext.cpp
@@ -13,6 +13,8 @@
 #include <core/log/InxLog.h>
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <chrono>
 #include <stdexcept>
 
@@ -439,6 +441,56 @@ void ScriptableRenderContext::ExecuteCommandBuffer(CommandBuffer &cmd)
     m_pendingCommandBuffers.push_back(&cmd);
 }
 
+// Names for the unsupported command types so the once-per-process warning is
+// readable. Keep in lockstep with RenderCommandType (CommandBuffer.h).
+namespace
+{
+const char *RenderCommandTypeName(RenderCommandType type)
+{
+    switch (type) {
+    case RenderCommandType::GetTemporaryRT:
+        return "GetTemporaryRT";
+    case RenderCommandType::ReleaseTemporaryRT:
+        return "ReleaseTemporaryRT";
+    case RenderCommandType::SetRenderTarget:
+        return "SetRenderTarget";
+    case RenderCommandType::ClearRenderTarget:
+        return "ClearRenderTarget";
+    case RenderCommandType::DrawMesh:
+        return "DrawMesh";
+    case RenderCommandType::SetGlobalTexture:
+        return "SetGlobalTexture";
+    case RenderCommandType::SetGlobalFloat:
+        return "SetGlobalFloat";
+    case RenderCommandType::SetGlobalVector:
+        return "SetGlobalVector";
+    case RenderCommandType::SetGlobalMatrix:
+        return "SetGlobalMatrix";
+    case RenderCommandType::RequestAsyncReadback:
+        return "RequestAsyncReadback";
+    }
+    return "Unknown";
+}
+
+void WarnUnimplementedCommand(RenderCommandType type)
+{
+    // Per-type latch so each unsupported command logs exactly once per process,
+    // instead of either spamming or silently swallowing after a global cap.
+    constexpr size_t kCommandCount = 16; // bounded by RenderCommandType (uint8_t enum); plenty of slack
+    static std::array<std::atomic<bool>, kCommandCount> warned{};
+    const auto idx = static_cast<size_t>(type);
+    if (idx >= warned.size())
+        return;
+    bool expected = false;
+    if (warned[idx].compare_exchange_strong(expected, true)) {
+        INXLOG_WARN("[SRP] CommandBuffer command '", RenderCommandTypeName(type),
+                    "' is not yet implemented in the Vulkan backend — ignoring all "
+                    "subsequent invocations of this command type for the rest of the process. "
+                    "Subsequent rendering may behave unexpectedly until the backend lands.");
+    }
+}
+} // namespace
+
 void ScriptableRenderContext::ProcessPendingCommandBuffers()
 {
     for (CommandBuffer *cmd : m_pendingCommandBuffers) {
@@ -448,7 +500,6 @@ void ScriptableRenderContext::ProcessPendingCommandBuffers()
         for (const auto &command : cmd->GetCommands()) {
             switch (command.type) {
             case RenderCommandType::GetTemporaryRT: {
-                // Allocate from transient pool
                 if (m_transientPool) {
                     const auto &params = std::get<GetTemporaryRTParams>(command.data);
                     uint32_t slotId =
@@ -488,25 +539,39 @@ void ScriptableRenderContext::ProcessPendingCommandBuffers()
                 break;
             }
 
+            // Commands that still need the Vulkan command-buffer integration.
+            // See ScriptableRenderContext::IsCommandImplemented for the
+            // canonical "is this safe to call" predicate exposed to bindings.
             case RenderCommandType::ClearRenderTarget:
             case RenderCommandType::SetRenderTarget:
             case RenderCommandType::DrawMesh:
             case RenderCommandType::SetGlobalMatrix:
             case RenderCommandType::RequestAsyncReadback:
-                // These commands require actual Vulkan command buffer integration.
-                // They are stubbed for now and will be fully implemented when
-                // InxVkCoreModular gains multi-RT support.
-                // For MVP: log and skip.
-                static int stubWarnCount = 0;
-                if (stubWarnCount++ < 5) {
-                    INXLOG_WARN("CommandBuffer command type ", static_cast<int>(command.type),
-                                " is not yet fully implemented in the Vulkan backend");
-                }
+                WarnUnimplementedCommand(command.type);
                 break;
             }
         }
     }
     m_pendingCommandBuffers.clear();
+}
+
+bool ScriptableRenderContext::IsCommandImplemented(RenderCommandType type) noexcept
+{
+    switch (type) {
+    case RenderCommandType::GetTemporaryRT:
+    case RenderCommandType::ReleaseTemporaryRT:
+    case RenderCommandType::SetGlobalFloat:
+    case RenderCommandType::SetGlobalVector:
+    case RenderCommandType::SetGlobalTexture:
+        return true;
+    case RenderCommandType::ClearRenderTarget:
+    case RenderCommandType::SetRenderTarget:
+    case RenderCommandType::DrawMesh:
+    case RenderCommandType::SetGlobalMatrix:
+    case RenderCommandType::RequestAsyncReadback:
+        return false;
+    }
+    return false;
 }
 
 // ============================================================================

--- a/cpp/infernux/function/renderer/ScriptableRenderContext.h
+++ b/cpp/infernux/function/renderer/ScriptableRenderContext.h
@@ -8,6 +8,7 @@
 #include <function/scene/SceneSystem.h>
 
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -26,6 +27,7 @@ class InxMaterial;
 class CommandBuffer;
 class TransientResourcePool;
 struct RenderTargetHandle;
+enum class RenderCommandType : uint8_t;
 
 // ============================================================================
 // CullingResults
@@ -162,6 +164,15 @@ class ScriptableRenderContext
     /// @brief Execute a deferred CommandBuffer.
     /// Commands are buffered and actually executed during Submit().
     void ExecuteCommandBuffer(CommandBuffer &cmd);
+
+    /// @brief Static predicate: does the Vulkan backend currently honour @p type?
+    ///
+    /// The Python-facing CommandBuffer API exposes commands that have not yet
+    /// been wired to the Vulkan backend (multi-RT bind, async readback, etc.).
+    /// Bindings and tools can call this before recording to surface the
+    /// limitation up front instead of relying on the post-hoc warning emitted
+    /// inside ProcessPendingCommandBuffers.
+    [[nodiscard]] static bool IsCommandImplemented(RenderCommandType type) noexcept;
 
     // ====================================================================
     // Render target operations

--- a/cpp/infernux/function/renderer/VkCoreMaterial.cpp
+++ b/cpp/infernux/function/renderer/VkCoreMaterial.cpp
@@ -415,7 +415,8 @@ void InxVkCoreModular::InitializeMaterialSystem()
         VkFormat depthFormat = m_deviceContext.FindDepthFormat();
         m_materialPipelineManager.Initialize(m_deviceContext.GetVmaAllocator(), GetDevice(), GetPhysicalDevice(),
                                              colorFormat, depthFormat, m_msaaSampleCount,
-                                             m_shaderCache.GetProgramCache(), &m_deletionQueue);
+                                             m_shaderCache.GetProgramCache(), &m_deletionQueue,
+                                             m_deviceContext.IsDescriptorIndexingEnabled());
         m_materialPipelineManagerInitialized = true;
 
         auto *whiteTex = m_textureCache.Find("white");
@@ -504,7 +505,7 @@ void InxVkCoreModular::ReinitializeMaterialPipelines(VkSampleCountFlagBits newSa
     VkFormat depthFormat = m_deviceContext.FindDepthFormat();
     m_materialPipelineManager.Initialize(m_deviceContext.GetVmaAllocator(), GetDevice(), GetPhysicalDevice(),
                                          colorFormat, depthFormat, newSampleCount, m_shaderCache.GetProgramCache(),
-                                         &m_deletionQueue);
+                                         &m_deletionQueue, m_deviceContext.IsDescriptorIndexingEnabled());
     m_materialPipelineManagerInitialized = true;
 
     // Restore default textures

--- a/cpp/infernux/function/renderer/shader/ShaderProgram.cpp
+++ b/cpp/infernux/function/renderer/shader/ShaderProgram.cpp
@@ -363,12 +363,33 @@ bool ShaderProgram::CreateDescriptorSetLayouts()
         setBindings[merged.set].push_back(binding);
     }
 
-    // Create a layout for each set
+    // Create a layout for each set.
+    //
+    // For the material set (set 0) we opt into VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
+    // on every binding when the device supports descriptor indexing. This is what
+    // lets MaterialDescriptorManager rewrite a sampler/UBO binding while the GPU is
+    // sampling the descriptor set, eliminating the per-edit vkDeviceWaitIdle stall.
+    //
+    // Sets 1, 2 (per-view, globals) keep the legacy layout — they are written once
+    // per frame on the CPU before any submission and have no live-update concern.
+    const bool enableUpdateAfterBind = IsUpdateAfterBindEnabled();
     for (auto &[setIndex, bindings] : setBindings) {
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
         layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
         layoutInfo.pBindings = bindings.data();
+
+        std::vector<VkDescriptorBindingFlags> bindingFlags;
+        VkDescriptorSetLayoutBindingFlagsCreateInfo bindingFlagsInfo{};
+        if (enableUpdateAfterBind && setIndex == 0) {
+            bindingFlags.assign(bindings.size(), VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT |
+                                                     VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT);
+            bindingFlagsInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
+            bindingFlagsInfo.bindingCount = static_cast<uint32_t>(bindingFlags.size());
+            bindingFlagsInfo.pBindingFlags = bindingFlags.data();
+            layoutInfo.pNext = &bindingFlagsInfo;
+            layoutInfo.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+        }
 
         VkDescriptorSetLayout layout;
         if (vkCreateDescriptorSetLayout(m_device, &layoutInfo, nullptr, &layout) != VK_SUCCESS) {
@@ -377,7 +398,8 @@ bool ShaderProgram::CreateDescriptorSetLayouts()
         }
 
         m_descriptorSetLayouts[setIndex] = layout;
-        INXLOG_DEBUG("Created descriptor set layout for set ", setIndex, " with ", bindings.size(), " bindings");
+        INXLOG_DEBUG("Created descriptor set layout for set ", setIndex, " with ", bindings.size(), " bindings",
+                     (enableUpdateAfterBind && setIndex == 0) ? " (UPDATE_AFTER_BIND)" : "");
     }
 
     // If no bindings, create an empty layout for set 0

--- a/cpp/infernux/function/renderer/shader/ShaderProgram.h
+++ b/cpp/infernux/function/renderer/shader/ShaderProgram.h
@@ -181,11 +181,29 @@ class ShaderProgram
         return s_globalsDescSetLayout;
     }
 
+    /**
+     * @brief Globally enable VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND on
+     * material-set sampler bindings. Set once at startup based on the
+     * device's Vulkan 1.2 descriptor-indexing support; when true, the
+     * material descriptor pool/layout pair is created with the matching
+     * UPDATE_AFTER_BIND_POOL bit so MaterialDescriptorManager can rewrite
+     * bindings without a full GPU drain.
+     */
+    static void SetUpdateAfterBindEnabled(bool enabled)
+    {
+        s_updateAfterBindEnabled = enabled;
+    }
+    static bool IsUpdateAfterBindEnabled()
+    {
+        return s_updateAfterBindEnabled;
+    }
+
   private:
     VkDevice m_device = VK_NULL_HANDLE;
     std::string m_shaderId;
 
     static inline VkDescriptorSetLayout s_globalsDescSetLayout = VK_NULL_HANDLE;
+    static inline bool s_updateAfterBindEnabled = false;
 
     // Shader modules
     VkShaderModule m_vertModule = VK_NULL_HANDLE;

--- a/cpp/infernux/function/renderer/vk/AsyncTransferContext.cpp
+++ b/cpp/infernux/function/renderer/vk/AsyncTransferContext.cpp
@@ -1,0 +1,365 @@
+/**
+ * @file AsyncTransferContext.cpp
+ * @brief Implementation of the pooled async-upload pipeline.
+ */
+
+#include "AsyncTransferContext.h"
+#include "VkDeviceContext.h"
+#include <core/log/InxLog.h>
+
+namespace infernux
+{
+namespace vk
+{
+
+namespace
+{
+
+constexpr uint64_t kPollTimeoutNs = 50'000'000; // 50 ms
+
+void WaitFence(VkDevice device, VkFence fence)
+{
+    while (true) {
+        VkResult result = vkWaitForFences(device, 1, &fence, VK_TRUE, kPollTimeoutNs);
+        if (result == VK_SUCCESS) {
+            return;
+        }
+        if (result != VK_TIMEOUT) {
+            INXLOG_ERROR("AsyncTransferContext::WaitFence vkWaitForFences failed: ", VkResultToString(result));
+            return;
+        }
+        // Pumping events here is intentionally omitted — async transfer
+        // rarely takes anywhere near 50 ms; if it does, the OS already has
+        // the main thread's loop pumping events on its own cadence.
+    }
+}
+
+} // namespace
+
+AsyncTransferContext::~AsyncTransferContext()
+{
+    Destroy();
+}
+
+bool AsyncTransferContext::Initialize(VkDevice device, uint32_t transferQueueFamily, VkQueue transferQueue,
+                                      bool hasDedicatedTransferQueue)
+{
+    if (device == VK_NULL_HANDLE || transferQueue == VK_NULL_HANDLE) {
+        INXLOG_ERROR("AsyncTransferContext::Initialize: null device or queue");
+        return false;
+    }
+
+    m_device = device;
+    m_queue = transferQueue;
+    m_queueFamily = transferQueueFamily;
+    m_hasDedicatedQueue = hasDedicatedTransferQueue;
+
+    // Pool flags:
+    //   - TRANSIENT_BIT: hint that command buffers are short-lived (driver
+    //     can choose a faster allocation strategy)
+    //   - RESET_COMMAND_BUFFER_BIT: required for vkResetCommandBuffer in
+    //     the recycling path (otherwise we'd have to reset the entire pool
+    //     on every reuse)
+    VkCommandPoolCreateInfo poolInfo{};
+    poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    poolInfo.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    poolInfo.queueFamilyIndex = transferQueueFamily;
+
+    if (vkCreateCommandPool(device, &poolInfo, nullptr, &m_pool) != VK_SUCCESS) {
+        INXLOG_ERROR("AsyncTransferContext::Initialize: vkCreateCommandPool failed (family ", transferQueueFamily, ")");
+        m_device = VK_NULL_HANDLE;
+        return false;
+    }
+
+    INXLOG_INFO("AsyncTransferContext initialized on queue family ", transferQueueFamily,
+                hasDedicatedTransferQueue ? " (dedicated DMA queue)" : " (aliased to graphics queue)");
+    return true;
+}
+
+void AsyncTransferContext::Destroy() noexcept
+{
+    if (m_device == VK_NULL_HANDLE) {
+        return;
+    }
+
+    // Anything still in flight at teardown is a logic bug, but be defensive:
+    // wait on each in-flight fence so we don't try to destroy a fence the
+    // GPU is still signalling.
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        for (const auto &up : m_inFlight) {
+            if (up.fence != VK_NULL_HANDLE) {
+                WaitFence(m_device, up.fence);
+            }
+        }
+        m_inFlight.clear();
+
+        for (VkFence fence : m_allFences) {
+            if (fence != VK_NULL_HANDLE) {
+                vkDestroyFence(m_device, fence, nullptr);
+            }
+        }
+        m_allFences.clear();
+        m_freeFences.clear();
+
+        // Command buffers are owned by the pool; destroying the pool below
+        // frees them implicitly.
+        m_allCmdBuffers.clear();
+        m_freeCmdBuffers.clear();
+    }
+
+    if (m_pool != VK_NULL_HANDLE) {
+        vkDestroyCommandPool(m_device, m_pool, nullptr);
+        m_pool = VK_NULL_HANDLE;
+    }
+
+    m_device = VK_NULL_HANDLE;
+    m_queue = VK_NULL_HANDLE;
+    m_queueFamily = 0;
+    m_hasDedicatedQueue = false;
+}
+
+VkCommandBuffer AsyncTransferContext::AcquireCommandBufferLocked()
+{
+    if (!m_freeCmdBuffers.empty()) {
+        VkCommandBuffer cmd = m_freeCmdBuffers.back();
+        m_freeCmdBuffers.pop_back();
+        vkResetCommandBuffer(cmd, 0);
+        return cmd;
+    }
+
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    VkCommandBufferAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    allocInfo.commandPool = m_pool;
+    allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    allocInfo.commandBufferCount = 1;
+
+    if (vkAllocateCommandBuffers(m_device, &allocInfo, &cmd) != VK_SUCCESS) {
+        INXLOG_ERROR("AsyncTransferContext: vkAllocateCommandBuffers failed");
+        return VK_NULL_HANDLE;
+    }
+
+    m_allCmdBuffers.push_back(cmd);
+    return cmd;
+}
+
+VkFence AsyncTransferContext::AcquireFenceLocked()
+{
+    if (!m_freeFences.empty()) {
+        VkFence fence = m_freeFences.back();
+        m_freeFences.pop_back();
+        vkResetFences(m_device, 1, &fence);
+        return fence;
+    }
+
+    VkFence fence = VK_NULL_HANDLE;
+    VkFenceCreateInfo fenceInfo{};
+    fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+
+    if (vkCreateFence(m_device, &fenceInfo, nullptr, &fence) != VK_SUCCESS) {
+        INXLOG_ERROR("AsyncTransferContext: vkCreateFence failed");
+        return VK_NULL_HANDLE;
+    }
+
+    m_allFences.push_back(fence);
+    return fence;
+}
+
+VkCommandBuffer AsyncTransferContext::Begin()
+{
+    if (m_device == VK_NULL_HANDLE) {
+        INXLOG_ERROR("AsyncTransferContext::Begin called on uninitialised context");
+        return VK_NULL_HANDLE;
+    }
+
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        // Reap completed uploads opportunistically — most frames there will
+        // be a handful of small uploads in flight, and reaping here keeps
+        // the free-list warm without a dedicated background thread.
+        ReapCompletedLocked();
+        cmd = AcquireCommandBufferLocked();
+    }
+
+    if (cmd == VK_NULL_HANDLE) {
+        return VK_NULL_HANDLE;
+    }
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS) {
+        INXLOG_ERROR("AsyncTransferContext::Begin: vkBeginCommandBuffer failed");
+        std::lock_guard<std::mutex> guard(m_mutex);
+        m_freeCmdBuffers.push_back(cmd);
+        return VK_NULL_HANDLE;
+    }
+
+    return cmd;
+}
+
+void AsyncTransferContext::EndSync(VkCommandBuffer cmd)
+{
+    if (cmd == VK_NULL_HANDLE) {
+        return;
+    }
+
+    vkEndCommandBuffer(cmd);
+
+    VkFence fence = VK_NULL_HANDLE;
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        fence = AcquireFenceLocked();
+    }
+    if (fence == VK_NULL_HANDLE) {
+        return;
+    }
+
+    VkSubmitInfo submit{};
+    submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &cmd;
+
+    vkQueueSubmit(m_queue, 1, &submit, fence);
+    WaitFence(m_device, fence);
+
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_freeFences.push_back(fence);
+    m_freeCmdBuffers.push_back(cmd);
+}
+
+AsyncUploadHandle AsyncTransferContext::EndAsync(VkCommandBuffer cmd)
+{
+    AsyncUploadHandle handle{};
+    if (cmd == VK_NULL_HANDLE) {
+        return handle;
+    }
+
+    vkEndCommandBuffer(cmd);
+
+    VkFence fence = VK_NULL_HANDLE;
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        fence = AcquireFenceLocked();
+    }
+    if (fence == VK_NULL_HANDLE) {
+        return handle;
+    }
+
+    VkSubmitInfo submit{};
+    submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &cmd;
+
+    if (vkQueueSubmit(m_queue, 1, &submit, fence) != VK_SUCCESS) {
+        INXLOG_ERROR("AsyncTransferContext::EndAsync: vkQueueSubmit failed");
+        std::lock_guard<std::mutex> guard(m_mutex);
+        m_freeFences.push_back(fence);
+        m_freeCmdBuffers.push_back(cmd);
+        return handle;
+    }
+
+    handle.id = m_nextId.fetch_add(1, std::memory_order_relaxed);
+
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_inFlight.push_back({handle.id, fence, cmd});
+    return handle;
+}
+
+void AsyncTransferContext::ReapCompletedLocked()
+{
+    for (auto it = m_inFlight.begin(); it != m_inFlight.end();) {
+        VkResult result = vkGetFenceStatus(m_device, it->fence);
+        if (result == VK_SUCCESS) {
+            m_freeFences.push_back(it->fence);
+            m_freeCmdBuffers.push_back(it->cmd);
+            it = m_inFlight.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void AsyncTransferContext::RetireLocked(uint64_t id, VkFence &fence, VkCommandBuffer &cmd)
+{
+    fence = VK_NULL_HANDLE;
+    cmd = VK_NULL_HANDLE;
+    for (auto it = m_inFlight.begin(); it != m_inFlight.end(); ++it) {
+        if (it->id == id) {
+            fence = it->fence;
+            cmd = it->cmd;
+            m_inFlight.erase(it);
+            return;
+        }
+    }
+}
+
+bool AsyncTransferContext::IsComplete(AsyncUploadHandle handle)
+{
+    if (!handle.IsValid() || m_device == VK_NULL_HANDLE) {
+        return true;
+    }
+
+    std::lock_guard<std::mutex> guard(m_mutex);
+    for (const auto &up : m_inFlight) {
+        if (up.id == handle.id) {
+            VkResult result = vkGetFenceStatus(m_device, up.fence);
+            if (result == VK_SUCCESS) {
+                VkFence fence = VK_NULL_HANDLE;
+                VkCommandBuffer cmd = VK_NULL_HANDLE;
+                RetireLocked(handle.id, fence, cmd);
+                if (fence != VK_NULL_HANDLE) {
+                    m_freeFences.push_back(fence);
+                }
+                if (cmd != VK_NULL_HANDLE) {
+                    m_freeCmdBuffers.push_back(cmd);
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+    // Not found → already reaped.
+    return true;
+}
+
+void AsyncTransferContext::Wait(AsyncUploadHandle handle)
+{
+    if (!handle.IsValid() || m_device == VK_NULL_HANDLE) {
+        return;
+    }
+
+    VkFence fence = VK_NULL_HANDLE;
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        for (const auto &up : m_inFlight) {
+            if (up.id == handle.id) {
+                fence = up.fence;
+                break;
+            }
+        }
+    }
+
+    if (fence == VK_NULL_HANDLE) {
+        return; // Already retired.
+    }
+
+    WaitFence(m_device, fence);
+
+    std::lock_guard<std::mutex> guard(m_mutex);
+    VkFence retiredFence = VK_NULL_HANDLE;
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    RetireLocked(handle.id, retiredFence, cmd);
+    if (retiredFence != VK_NULL_HANDLE) {
+        m_freeFences.push_back(retiredFence);
+    }
+    if (cmd != VK_NULL_HANDLE) {
+        m_freeCmdBuffers.push_back(cmd);
+    }
+}
+
+} // namespace vk
+} // namespace infernux

--- a/cpp/infernux/function/renderer/vk/AsyncTransferContext.h
+++ b/cpp/infernux/function/renderer/vk/AsyncTransferContext.h
@@ -1,0 +1,204 @@
+/**
+ * @file AsyncTransferContext.h
+ * @brief Pooled, optionally-async upload pipeline backed by a dedicated
+ *        transfer queue when the device exposes one.
+ *
+ * Designed as a thin successor to VkResourceManager::BeginSingleTimeCommands
+ * / EndSingleTimeCommands. Where the latter always submits on the graphics
+ * queue (and therefore steals throughput from the renderer), this context
+ * routes work to the dedicated DMA queue advertised by modern discrete GPUs.
+ *
+ * Architectural shape (matches what UE5 / Frostbite / Unity HDRP do for
+ * texture streaming):
+ *
+ *   * One VkCommandPool per worker thread (today: a single shared pool
+ *     guarded by std::mutex; the per-thread split lands in Phase 5d once
+ *     multi-threaded recording goes online).
+ *   * Free-list pools of VkFence / VkCommandBuffer mirror the Phase 5b
+ *     pattern in VkResourceManager so steady-state uploads hit zero
+ *     kernel allocations.
+ *   * Submission goes to the transfer queue if HasDedicatedTransferQueue();
+ *     otherwise it transparently falls back to the graphics queue so call
+ *     sites never need to branch.
+ *
+ * Queue family ownership transfer is the caller's responsibility. The
+ * recommended pattern is documented on Begin/End below: emit a release
+ * barrier with srcQueueFamilyIndex = transferFamily,
+ * dstQueueFamilyIndex = graphicsFamily before EndAsync(), then on the
+ * graphics queue (typically inside the next render frame) emit the
+ * matching acquire barrier with the same family pair before the first
+ * sample/draw that uses the resource.
+ */
+
+#pragma once
+
+#include "VkTypes.h"
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+#include <vulkan/vulkan.h>
+
+namespace infernux
+{
+namespace vk
+{
+
+class VkDeviceContext;
+
+/**
+ * @brief Opaque handle returned from EndAsync() for caller-side completion polling.
+ *
+ * Holds a raw pointer to a context-owned tracker. Querying / waiting goes
+ * back through AsyncTransferContext::IsComplete / Wait so the context can
+ * recycle the underlying fence + command buffer once the GPU signals.
+ */
+struct AsyncUploadHandle
+{
+    uint64_t id = 0; ///< Monotonic id, 0 == invalid
+
+    [[nodiscard]] bool IsValid() const noexcept
+    {
+        return id != 0;
+    }
+};
+
+/**
+ * @brief Pooled async-upload command recorder + submitter.
+ */
+class AsyncTransferContext
+{
+  public:
+    AsyncTransferContext() = default;
+    ~AsyncTransferContext();
+
+    // Non-copyable, non-movable — held by VkDeviceContext.
+    AsyncTransferContext(const AsyncTransferContext &) = delete;
+    AsyncTransferContext &operator=(const AsyncTransferContext &) = delete;
+    AsyncTransferContext(AsyncTransferContext &&) = delete;
+    AsyncTransferContext &operator=(AsyncTransferContext &&) = delete;
+
+    /**
+     * @brief Initialize against a fully-created device context.
+     *
+     * Builds the upload command pool against the transfer queue family if
+     * the device advertises a dedicated one, otherwise against the graphics
+     * family (legacy fallback path).
+     */
+    bool Initialize(VkDevice device, uint32_t transferQueueFamily, VkQueue transferQueue,
+                    bool hasDedicatedTransferQueue);
+
+    /**
+     * @brief Tear down all pooled fences / command buffers.
+     *
+     * Must be called BEFORE the owning device is destroyed. Idempotent.
+     */
+    void Destroy() noexcept;
+
+    /**
+     * @brief Start recording an upload command buffer.
+     *
+     * The returned VkCommandBuffer is in the recording state (the
+     * vkBeginCommandBuffer call has already happened). Callers append
+     * vkCmdCopyBuffer / vkCmdCopyBufferToImage / vkCmdPipelineBarrier as
+     * usual.
+     *
+     * If the upload targets a resource that will be sampled on the graphics
+     * queue, callers MUST end recording with a release barrier
+     * (srcQueueFamilyIndex = transferFamily, dstQueueFamilyIndex =
+     * graphicsFamily, srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+     * dstAccessMask = 0) and then arrange for the matching acquire barrier
+     * on the graphics queue before first use. The acquire barrier should
+     * use srcAccessMask = 0, dstAccessMask = VK_ACCESS_SHADER_READ_BIT
+     * (or whatever the consumer needs), srcStageMask = TOP_OF_PIPE_BIT,
+     * dstStageMask = the consumer's stage. See the Vulkan spec
+     * §7.7.4 "Queue Family Ownership Transfer" for the canonical example.
+     */
+    [[nodiscard]] VkCommandBuffer Begin();
+
+    /**
+     * @brief Submit a recorded command buffer and block until the GPU
+     *        signals completion. Use for the legacy synchronous path.
+     */
+    void EndSync(VkCommandBuffer cmd);
+
+    /**
+     * @brief Submit asynchronously. Returns a handle that can be polled
+     *        via IsComplete() or blocked on via Wait(). The caller is
+     *        responsible for keeping any source CPU staging memory alive
+     *        until completion.
+     */
+    [[nodiscard]] AsyncUploadHandle EndAsync(VkCommandBuffer cmd);
+
+    /**
+     * @brief Non-blocking completion poll. Returns true once the GPU has
+     *        signalled the upload's fence (also recycles the fence + cmd
+     *        buffer back into the free list as a side effect).
+     */
+    [[nodiscard]] bool IsComplete(AsyncUploadHandle handle);
+
+    /**
+     * @brief Block until the upload completes. Returns immediately if the
+     *        handle is invalid or already retired.
+     */
+    void Wait(AsyncUploadHandle handle);
+
+    /**
+     * @brief True iff the underlying queue is on a different family than
+     *        graphics — implies submissions actually run in parallel.
+     */
+    [[nodiscard]] bool IsAsyncCapable() const noexcept
+    {
+        return m_hasDedicatedQueue;
+    }
+
+    /**
+     * @brief Queue family the upload command buffers are recorded against.
+     *
+     * Callers building queue-family-ownership-transfer barriers need this
+     * for srcQueueFamilyIndex on the release side.
+     */
+    [[nodiscard]] uint32_t GetQueueFamily() const noexcept
+    {
+        return m_queueFamily;
+    }
+
+  private:
+    struct InFlightUpload
+    {
+        uint64_t id = 0;
+        VkFence fence = VK_NULL_HANDLE;
+        VkCommandBuffer cmd = VK_NULL_HANDLE;
+    };
+
+    /// @brief Recycle (or lazily create) a fence ready for re-submission.
+    [[nodiscard]] VkFence AcquireFenceLocked();
+
+    /// @brief Recycle (or lazily create + record-prep) a command buffer.
+    [[nodiscard]] VkCommandBuffer AcquireCommandBufferLocked();
+
+    /// @brief Reap any in-flight uploads whose fence has signalled.
+    void ReapCompletedLocked();
+
+    /// @brief Drop the in-flight tracker for `id` (called when the caller
+    ///        observes completion or explicitly waits). Returns the cmd
+    ///        buffer + fence so the caller can recycle them under the lock.
+    void RetireLocked(uint64_t id, VkFence &fence, VkCommandBuffer &cmd);
+
+    VkDevice m_device = VK_NULL_HANDLE;
+    VkCommandPool m_pool = VK_NULL_HANDLE;
+    VkQueue m_queue = VK_NULL_HANDLE;
+    uint32_t m_queueFamily = 0;
+    bool m_hasDedicatedQueue = false;
+
+    std::mutex m_mutex;
+    std::vector<VkFence> m_freeFences;
+    std::vector<VkFence> m_allFences;
+    std::vector<VkCommandBuffer> m_freeCmdBuffers;
+    std::vector<VkCommandBuffer> m_allCmdBuffers;
+    std::vector<InFlightUpload> m_inFlight;
+    std::atomic<uint64_t> m_nextId{1};
+};
+
+} // namespace vk
+} // namespace infernux

--- a/cpp/infernux/function/renderer/vk/VkCore.h
+++ b/cpp/infernux/function/renderer/vk/VkCore.h
@@ -94,9 +94,9 @@
 #include "VkSwapchainManager.h"
 
 // Resource management
+#include "AsyncTransferContext.h"
 #include "VkPipelineManager.h"
 #include "VkResourceManager.h"
-#include "AsyncTransferContext.h"
 
 // Advanced rendering
 #include "RenderGraph.h"

--- a/cpp/infernux/function/renderer/vk/VkCore.h
+++ b/cpp/infernux/function/renderer/vk/VkCore.h
@@ -96,6 +96,7 @@
 // Resource management
 #include "VkPipelineManager.h"
 #include "VkResourceManager.h"
+#include "AsyncTransferContext.h"
 
 // Advanced rendering
 #include "RenderGraph.h"

--- a/cpp/infernux/function/renderer/vk/VkDeviceContext.cpp
+++ b/cpp/infernux/function/renderer/vk/VkDeviceContext.cpp
@@ -147,7 +147,9 @@ VkDeviceContext::VkDeviceContext(VkDeviceContext &&other) noexcept
       m_physicalDevice(other.m_physicalDevice), m_device(other.m_device), m_vmaAllocator(other.m_vmaAllocator),
       m_graphicsQueue(other.m_graphicsQueue), m_presentQueue(other.m_presentQueue),
       m_queueIndices(other.m_queueIndices), m_deviceProperties(other.m_deviceProperties),
-      m_deviceFeatures(other.m_deviceFeatures), m_validationEnabled(other.m_validationEnabled)
+      m_deviceFeatures(other.m_deviceFeatures),
+      m_descriptorIndexingEnabled(other.m_descriptorIndexingEnabled),
+      m_timelineSemaphoreEnabled(other.m_timelineSemaphoreEnabled), m_validationEnabled(other.m_validationEnabled)
 {
     other.m_instance = VK_NULL_HANDLE;
     other.m_debugMessenger = VK_NULL_HANDLE;
@@ -157,6 +159,8 @@ VkDeviceContext::VkDeviceContext(VkDeviceContext &&other) noexcept
     other.m_vmaAllocator = VK_NULL_HANDLE;
     other.m_graphicsQueue = VK_NULL_HANDLE;
     other.m_presentQueue = VK_NULL_HANDLE;
+    other.m_descriptorIndexingEnabled = false;
+    other.m_timelineSemaphoreEnabled = false;
 }
 
 VkDeviceContext &VkDeviceContext::operator=(VkDeviceContext &&other) noexcept
@@ -175,6 +179,8 @@ VkDeviceContext &VkDeviceContext::operator=(VkDeviceContext &&other) noexcept
         m_queueIndices = other.m_queueIndices;
         m_deviceProperties = other.m_deviceProperties;
         m_deviceFeatures = other.m_deviceFeatures;
+        m_descriptorIndexingEnabled = other.m_descriptorIndexingEnabled;
+        m_timelineSemaphoreEnabled = other.m_timelineSemaphoreEnabled;
         m_validationEnabled = other.m_validationEnabled;
 
         other.m_instance = VK_NULL_HANDLE;
@@ -185,6 +191,8 @@ VkDeviceContext &VkDeviceContext::operator=(VkDeviceContext &&other) noexcept
         other.m_vmaAllocator = VK_NULL_HANDLE;
         other.m_graphicsQueue = VK_NULL_HANDLE;
         other.m_presentQueue = VK_NULL_HANDLE;
+        other.m_descriptorIndexingEnabled = false;
+        other.m_timelineSemaphoreEnabled = false;
     }
     return *this;
 }
@@ -583,16 +591,56 @@ bool VkDeviceContext::CreateLogicalDevice(const DeviceConfig &config)
         queueCreateInfos.push_back(queueCreateInfo);
     }
 
-    // Device features
+    // ────────────────────────────────────────────────────────────────────
+    // Device features — use the Vulkan 1.2 pNext chain so we can opt into
+    // descriptor-indexing capabilities (UPDATE_AFTER_BIND, partially bound,
+    // etc.) that let mid-frame descriptor writes proceed without a full
+    // GPU drain.
+    // ────────────────────────────────────────────────────────────────────
+
+    // Query everything the GPU supports through the Vulkan 1.2 chain so we
+    // can selectively enable only what we need.
+    VkPhysicalDeviceVulkan12Features supported12{};
+    supported12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+    VkPhysicalDeviceFeatures2 supportedFeatures2{};
+    supportedFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    supportedFeatures2.pNext = &supported12;
+    vkGetPhysicalDeviceFeatures2(m_physicalDevice, &supportedFeatures2);
+    const VkPhysicalDeviceFeatures &supportedFeatures = supportedFeatures2.features;
+
     VkPhysicalDeviceFeatures deviceFeatures{};
     deviceFeatures.samplerAnisotropy = VK_TRUE;
     deviceFeatures.fillModeNonSolid = VK_TRUE; // For wireframe
     deviceFeatures.depthBiasClamp = VK_TRUE;   // For shadow depth bias clamping
-
-    // Query supported features — wideLines is unavailable on MoltenVK (macOS)
-    VkPhysicalDeviceFeatures supportedFeatures;
-    vkGetPhysicalDeviceFeatures(m_physicalDevice, &supportedFeatures);
     deviceFeatures.wideLines = supportedFeatures.wideLines; // For debug lines (when available)
+
+    // Vulkan 1.2 features — opt into descriptor-indexing capabilities only
+    // when the driver advertises them. UPDATE_AFTER_BIND is what unlocks
+    // non-stalling material descriptor updates (see MaterialDescriptor.cpp).
+    VkPhysicalDeviceVulkan12Features features12{};
+    features12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+    features12.descriptorIndexing = supported12.descriptorIndexing;
+    features12.descriptorBindingPartiallyBound = supported12.descriptorBindingPartiallyBound;
+    features12.descriptorBindingVariableDescriptorCount = supported12.descriptorBindingVariableDescriptorCount;
+    features12.descriptorBindingSampledImageUpdateAfterBind =
+        supported12.descriptorBindingSampledImageUpdateAfterBind;
+    features12.descriptorBindingUniformBufferUpdateAfterBind =
+        supported12.descriptorBindingUniformBufferUpdateAfterBind;
+    features12.descriptorBindingStorageBufferUpdateAfterBind =
+        supported12.descriptorBindingStorageBufferUpdateAfterBind;
+    features12.descriptorBindingUpdateUnusedWhilePending = supported12.descriptorBindingUpdateUnusedWhilePending;
+    features12.runtimeDescriptorArray = supported12.runtimeDescriptorArray;
+    // Timeline semaphores enable lock-free producer/consumer sync between
+    // upload tasks and the render thread without per-fence allocation.
+    features12.timelineSemaphore = supported12.timelineSemaphore;
+
+    m_descriptorIndexingEnabled = (features12.descriptorBindingSampledImageUpdateAfterBind == VK_TRUE);
+    m_timelineSemaphoreEnabled = (features12.timelineSemaphore == VK_TRUE);
+
+    VkPhysicalDeviceFeatures2 enabledFeatures2{};
+    enabledFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    enabledFeatures2.features = deviceFeatures;
+    enabledFeatures2.pNext = &features12;
 
     // Build device extension list
     std::vector<const char *> deviceExtensions(DEVICE_EXTENSIONS.begin(), DEVICE_EXTENSIONS.end());
@@ -600,12 +648,14 @@ bool VkDeviceContext::CreateLogicalDevice(const DeviceConfig &config)
     deviceExtensions.push_back("VK_KHR_portability_subset");
 #endif
 
-    // Device create info
+    // Device create info — enabledFeatures lives inside pNext (features2),
+    // so pEnabledFeatures must be NULL per the Vulkan spec.
     VkDeviceCreateInfo createInfo{};
     createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    createInfo.pNext = &enabledFeatures2;
     createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
     createInfo.pQueueCreateInfos = queueCreateInfos.data();
-    createInfo.pEnabledFeatures = &deviceFeatures;
+    createInfo.pEnabledFeatures = nullptr;
     createInfo.enabledExtensionCount = static_cast<uint32_t>(deviceExtensions.size());
     createInfo.ppEnabledExtensionNames = deviceExtensions.data();
 

--- a/cpp/infernux/function/renderer/vk/VkDeviceContext.cpp
+++ b/cpp/infernux/function/renderer/vk/VkDeviceContext.cpp
@@ -146,6 +146,7 @@ VkDeviceContext::VkDeviceContext(VkDeviceContext &&other) noexcept
     : m_instance(other.m_instance), m_debugMessenger(other.m_debugMessenger), m_surface(other.m_surface),
       m_physicalDevice(other.m_physicalDevice), m_device(other.m_device), m_vmaAllocator(other.m_vmaAllocator),
       m_graphicsQueue(other.m_graphicsQueue), m_presentQueue(other.m_presentQueue),
+      m_transferQueue(other.m_transferQueue), m_hasDedicatedTransferQueue(other.m_hasDedicatedTransferQueue),
       m_queueIndices(other.m_queueIndices), m_deviceProperties(other.m_deviceProperties),
       m_deviceFeatures(other.m_deviceFeatures),
       m_descriptorIndexingEnabled(other.m_descriptorIndexingEnabled),
@@ -159,6 +160,8 @@ VkDeviceContext::VkDeviceContext(VkDeviceContext &&other) noexcept
     other.m_vmaAllocator = VK_NULL_HANDLE;
     other.m_graphicsQueue = VK_NULL_HANDLE;
     other.m_presentQueue = VK_NULL_HANDLE;
+    other.m_transferQueue = VK_NULL_HANDLE;
+    other.m_hasDedicatedTransferQueue = false;
     other.m_descriptorIndexingEnabled = false;
     other.m_timelineSemaphoreEnabled = false;
 }
@@ -176,6 +179,8 @@ VkDeviceContext &VkDeviceContext::operator=(VkDeviceContext &&other) noexcept
         m_vmaAllocator = other.m_vmaAllocator;
         m_graphicsQueue = other.m_graphicsQueue;
         m_presentQueue = other.m_presentQueue;
+        m_transferQueue = other.m_transferQueue;
+        m_hasDedicatedTransferQueue = other.m_hasDedicatedTransferQueue;
         m_queueIndices = other.m_queueIndices;
         m_deviceProperties = other.m_deviceProperties;
         m_deviceFeatures = other.m_deviceFeatures;
@@ -191,6 +196,8 @@ VkDeviceContext &VkDeviceContext::operator=(VkDeviceContext &&other) noexcept
         other.m_vmaAllocator = VK_NULL_HANDLE;
         other.m_graphicsQueue = VK_NULL_HANDLE;
         other.m_presentQueue = VK_NULL_HANDLE;
+        other.m_transferQueue = VK_NULL_HANDLE;
+        other.m_hasDedicatedTransferQueue = false;
         other.m_descriptorIndexingEnabled = false;
         other.m_timelineSemaphoreEnabled = false;
     }
@@ -677,6 +684,20 @@ bool VkDeviceContext::CreateLogicalDevice(const DeviceConfig &config)
     vkGetDeviceQueue(m_device, m_queueIndices.graphicsFamily.value(), 0, &m_graphicsQueue);
     vkGetDeviceQueue(m_device, m_queueIndices.presentFamily.value(), 0, &m_presentQueue);
 
+    // Transfer queue: if the GPU advertised a dedicated transfer-only family
+    // (FindQueueFamilies's second pass), grab that queue handle so async
+    // upload work runs in parallel with the 3D queue. Otherwise alias to
+    // the graphics queue so call sites can always dispatch uploads through
+    // GetTransferQueue() without branching.
+    const uint32_t transferFamily = m_queueIndices.transferFamily.value_or(m_queueIndices.graphicsFamily.value());
+    m_hasDedicatedTransferQueue = (transferFamily != m_queueIndices.graphicsFamily.value());
+    if (m_hasDedicatedTransferQueue) {
+        vkGetDeviceQueue(m_device, transferFamily, 0, &m_transferQueue);
+        INXLOG_INFO("Async transfer queue enabled (family ", transferFamily, ", dedicated DMA path)");
+    } else {
+        m_transferQueue = m_graphicsQueue;
+    }
+
     return true;
 }
 
@@ -690,31 +711,53 @@ QueueFamilyIndices VkDeviceContext::FindQueueFamilies(VkPhysicalDevice device) c
     std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
     vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
 
+    // First pass: pick the canonical graphics+present queue family. Most
+    // discrete GPUs put graphics, present, transfer and compute on family 0.
     for (uint32_t i = 0; i < queueFamilyCount; i++) {
-        // Check for graphics support
-        if (queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-            indices.graphicsFamily = i;
-        }
+        const auto flags = queueFamilies[i].queueFlags;
 
-        // Check for compute support
-        if (queueFamilies[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
+        if ((flags & VK_QUEUE_GRAPHICS_BIT) && !indices.graphicsFamily.has_value()) {
+            indices.graphicsFamily = i;
+            // The graphics queue is always implicitly transfer+compute capable
+            // per the Vulkan spec — seed those as the conservative fallback so
+            // FindQueueFamilies always returns a complete set even on devices
+            // that expose only a single queue family.
+            indices.transferFamily = i;
             indices.computeFamily = i;
         }
 
-        // Check for transfer support
-        if (queueFamilies[i].queueFlags & VK_QUEUE_TRANSFER_BIT) {
-            indices.transferFamily = i;
-        }
-
-        // Check for present support
         VkBool32 presentSupport = VK_FALSE;
         vkGetPhysicalDeviceSurfaceSupportKHR(device, i, m_surface, &presentSupport);
-        if (presentSupport) {
+        if (presentSupport && !indices.presentFamily.has_value()) {
             indices.presentFamily = i;
         }
+    }
 
-        // Early exit if we have everything
-        if (indices.IsComplete()) {
+    // Second pass: prefer a DEDICATED transfer-only family if one exists.
+    // Discrete NVIDIA GPUs typically expose family index 1 (or 2) as a
+    // pure DMA / copy engine — using it for asset uploads runs in true
+    // parallel with the main 3D queue. Falls back to the graphics family
+    // (already seeded above) when no dedicated family is advertised.
+    for (uint32_t i = 0; i < queueFamilyCount; i++) {
+        const auto flags = queueFamilies[i].queueFlags;
+        const bool hasTransfer = (flags & VK_QUEUE_TRANSFER_BIT) != 0;
+        const bool hasGraphics = (flags & VK_QUEUE_GRAPHICS_BIT) != 0;
+        const bool hasCompute = (flags & VK_QUEUE_COMPUTE_BIT) != 0;
+        if (hasTransfer && !hasGraphics && !hasCompute) {
+            indices.transferFamily = i;
+            break;
+        }
+    }
+
+    // Third pass: prefer an async-compute family (compute-only, no graphics).
+    // Reserved for future Phase 5e compute work; today the engine still uses
+    // the graphics queue for compute dispatches.
+    for (uint32_t i = 0; i < queueFamilyCount; i++) {
+        const auto flags = queueFamilies[i].queueFlags;
+        const bool hasCompute = (flags & VK_QUEUE_COMPUTE_BIT) != 0;
+        const bool hasGraphics = (flags & VK_QUEUE_GRAPHICS_BIT) != 0;
+        if (hasCompute && !hasGraphics) {
+            indices.computeFamily = i;
             break;
         }
     }

--- a/cpp/infernux/function/renderer/vk/VkDeviceContext.cpp
+++ b/cpp/infernux/function/renderer/vk/VkDeviceContext.cpp
@@ -148,8 +148,7 @@ VkDeviceContext::VkDeviceContext(VkDeviceContext &&other) noexcept
       m_graphicsQueue(other.m_graphicsQueue), m_presentQueue(other.m_presentQueue),
       m_transferQueue(other.m_transferQueue), m_hasDedicatedTransferQueue(other.m_hasDedicatedTransferQueue),
       m_queueIndices(other.m_queueIndices), m_deviceProperties(other.m_deviceProperties),
-      m_deviceFeatures(other.m_deviceFeatures),
-      m_descriptorIndexingEnabled(other.m_descriptorIndexingEnabled),
+      m_deviceFeatures(other.m_deviceFeatures), m_descriptorIndexingEnabled(other.m_descriptorIndexingEnabled),
       m_timelineSemaphoreEnabled(other.m_timelineSemaphoreEnabled), m_validationEnabled(other.m_validationEnabled)
 {
     other.m_instance = VK_NULL_HANDLE;
@@ -617,8 +616,8 @@ bool VkDeviceContext::CreateLogicalDevice(const DeviceConfig &config)
 
     VkPhysicalDeviceFeatures deviceFeatures{};
     deviceFeatures.samplerAnisotropy = VK_TRUE;
-    deviceFeatures.fillModeNonSolid = VK_TRUE; // For wireframe
-    deviceFeatures.depthBiasClamp = VK_TRUE;   // For shadow depth bias clamping
+    deviceFeatures.fillModeNonSolid = VK_TRUE;              // For wireframe
+    deviceFeatures.depthBiasClamp = VK_TRUE;                // For shadow depth bias clamping
     deviceFeatures.wideLines = supportedFeatures.wideLines; // For debug lines (when available)
 
     // Vulkan 1.2 features — opt into descriptor-indexing capabilities only
@@ -629,8 +628,7 @@ bool VkDeviceContext::CreateLogicalDevice(const DeviceConfig &config)
     features12.descriptorIndexing = supported12.descriptorIndexing;
     features12.descriptorBindingPartiallyBound = supported12.descriptorBindingPartiallyBound;
     features12.descriptorBindingVariableDescriptorCount = supported12.descriptorBindingVariableDescriptorCount;
-    features12.descriptorBindingSampledImageUpdateAfterBind =
-        supported12.descriptorBindingSampledImageUpdateAfterBind;
+    features12.descriptorBindingSampledImageUpdateAfterBind = supported12.descriptorBindingSampledImageUpdateAfterBind;
     features12.descriptorBindingUniformBufferUpdateAfterBind =
         supported12.descriptorBindingUniformBufferUpdateAfterBind;
     features12.descriptorBindingStorageBufferUpdateAfterBind =

--- a/cpp/infernux/function/renderer/vk/VkDeviceContext.h
+++ b/cpp/infernux/function/renderer/vk/VkDeviceContext.h
@@ -185,6 +185,22 @@ class VkDeviceContext
         return m_deviceFeatures;
     }
 
+    /// @brief Whether descriptor-indexing UPDATE_AFTER_BIND was enabled at
+    /// device creation time. Callers should branch on this before opting in
+    /// to non-stalling descriptor updates so headless/legacy GPUs continue
+    /// to fall back to the GPU-drain path.
+    [[nodiscard]] bool IsDescriptorIndexingEnabled() const
+    {
+        return m_descriptorIndexingEnabled;
+    }
+
+    /// @brief Whether timeline semaphores were enabled at device creation —
+    /// reserved for future async-transfer / async-compute integrations.
+    [[nodiscard]] bool IsTimelineSemaphoreEnabled() const
+    {
+        return m_timelineSemaphoreEnabled;
+    }
+
     /// @brief Get the VMA allocator handle
     [[nodiscard]] VmaAllocator GetVmaAllocator() const
     {
@@ -294,6 +310,12 @@ class VkDeviceContext
     QueueFamilyIndices m_queueIndices{};
     VkPhysicalDeviceProperties m_deviceProperties{};
     VkPhysicalDeviceFeatures m_deviceFeatures{};
+
+    // Vulkan 1.2 capability flags resolved at device creation. Callers gate
+    // optional fast paths on these so the engine still runs correctly on
+    // older / restricted GPUs that do not advertise the features.
+    bool m_descriptorIndexingEnabled = false;
+    bool m_timelineSemaphoreEnabled = false;
 
     // ========================================================================
     // Configuration

--- a/cpp/infernux/function/renderer/vk/VkDeviceContext.h
+++ b/cpp/infernux/function/renderer/vk/VkDeviceContext.h
@@ -167,6 +167,26 @@ class VkDeviceContext
         return m_presentQueue;
     }
 
+    /// @brief Get the transfer queue handle.
+    /// On GPUs with a dedicated transfer-only queue family this returns
+    /// a queue from that family (parallel with graphics). On GPUs without
+    /// dedicated transfer this returns the graphics queue itself, so call
+    /// sites can always dispatch uploads through here without branching.
+    /// Use HasDedicatedTransferQueue() to know whether async submission is
+    /// actually parallel.
+    [[nodiscard]] VkQueue GetTransferQueue() const
+    {
+        return m_transferQueue;
+    }
+
+    /// @brief True iff the transfer queue is on a different family than
+    /// graphics — i.e. submissions to it run truly in parallel with the
+    /// main 3D queue and do NOT contend for graphics throughput.
+    [[nodiscard]] bool HasDedicatedTransferQueue() const
+    {
+        return m_hasDedicatedTransferQueue;
+    }
+
     /// @brief Get queue family indices
     [[nodiscard]] const QueueFamilyIndices &GetQueueIndices() const
     {
@@ -302,6 +322,8 @@ class VkDeviceContext
     // Queue handles (not destroyed - owned by device)
     VkQueue m_graphicsQueue = VK_NULL_HANDLE;
     VkQueue m_presentQueue = VK_NULL_HANDLE;
+    VkQueue m_transferQueue = VK_NULL_HANDLE; ///< Either dedicated DMA queue or alias for m_graphicsQueue
+    bool m_hasDedicatedTransferQueue = false; ///< True iff transferFamily != graphicsFamily
 
     // ========================================================================
     // Device Information Cache

--- a/cpp/infernux/function/renderer/vk/VkHandle.cpp
+++ b/cpp/infernux/function/renderer/vk/VkHandle.cpp
@@ -281,9 +281,8 @@ bool VkImageHandle::Create(VmaAllocator allocator, VkDevice device, uint32_t wid
 
 bool VkImageHandle::CreateConcurrent(VmaAllocator allocator, VkDevice device, uint32_t width, uint32_t height,
                                      VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage,
-                                     VkMemoryPropertyFlags properties,
-                                     const std::vector<uint32_t> &sharedQueueFamilies, VkSampleCountFlagBits samples,
-                                     uint32_t mipLevels)
+                                     VkMemoryPropertyFlags properties, const std::vector<uint32_t> &sharedQueueFamilies,
+                                     VkSampleCountFlagBits samples, uint32_t mipLevels)
 {
     // CONCURRENT sharing requires at least 2 distinct queue families per
     // the Vulkan spec; silently downgrade if the caller can't actually
@@ -686,8 +685,7 @@ bool VkTexture::CreateFromPixelsAsync(VmaAllocator allocator, VkDevice device, V
     // ────────────────────────────────────────────────────────────────────
 
     const uint32_t transferQueueFamily = transfer.GetQueueFamily();
-    const bool wantAsync =
-        transfer.IsAsyncCapable() && transferQueueFamily != graphicsQueueFamily && !generateMipmaps;
+    const bool wantAsync = transfer.IsAsyncCapable() && transferQueueFamily != graphicsQueueFamily && !generateMipmaps;
 
     if (!wantAsync) {
         // Either no dedicated transfer queue, or we need mipmap blits which

--- a/cpp/infernux/function/renderer/vk/VkHandle.cpp
+++ b/cpp/infernux/function/renderer/vk/VkHandle.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "VkHandle.h"
+#include "AsyncTransferContext.h"
 #include <SDL3/SDL.h>
 #include <algorithm>
 #include <cmath>
@@ -270,6 +271,64 @@ bool VkImageHandle::Create(VmaAllocator allocator, VkDevice device, uint32_t wid
     VkResult result = vmaCreateImage(allocator, &imageInfo, &allocCreateInfo, &m_image, &m_allocation, nullptr);
     if (result != VK_SUCCESS) {
         INXLOG_ERROR("Failed to create image with VMA (VkResult: {})", static_cast<int>(result));
+        m_image = VK_NULL_HANDLE;
+        m_allocation = VK_NULL_HANDLE;
+        return false;
+    }
+
+    return true;
+}
+
+bool VkImageHandle::CreateConcurrent(VmaAllocator allocator, VkDevice device, uint32_t width, uint32_t height,
+                                     VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage,
+                                     VkMemoryPropertyFlags properties,
+                                     const std::vector<uint32_t> &sharedQueueFamilies, VkSampleCountFlagBits samples,
+                                     uint32_t mipLevels)
+{
+    // CONCURRENT sharing requires at least 2 distinct queue families per
+    // the Vulkan spec; silently downgrade if the caller can't actually
+    // satisfy that (e.g. iGPU with a single queue family). Same fast path
+    // as Create() below for that case.
+    if (sharedQueueFamilies.size() < 2) {
+        return Create(allocator, device, width, height, format, tiling, usage, properties, samples, mipLevels);
+    }
+
+    Destroy();
+
+    m_allocator = allocator;
+    m_device = device;
+    m_width = width;
+    m_height = height;
+    m_format = format;
+    m_mipLevels = mipLevels;
+
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.format = format;
+    imageInfo.extent.width = width;
+    imageInfo.extent.height = height;
+    imageInfo.extent.depth = 1;
+    imageInfo.mipLevels = mipLevels;
+    imageInfo.arrayLayers = 1;
+    imageInfo.tiling = tiling;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    imageInfo.usage = usage;
+    imageInfo.sharingMode = VK_SHARING_MODE_CONCURRENT;
+    imageInfo.queueFamilyIndexCount = static_cast<uint32_t>(sharedQueueFamilies.size());
+    imageInfo.pQueueFamilyIndices = sharedQueueFamilies.data();
+    imageInfo.samples = samples;
+
+    VmaAllocationCreateInfo allocCreateInfo{};
+    if (properties & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+        allocCreateInfo.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+    } else {
+        allocCreateInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    }
+
+    VkResult result = vmaCreateImage(allocator, &imageInfo, &allocCreateInfo, &m_image, &m_allocation, nullptr);
+    if (result != VK_SUCCESS) {
+        INXLOG_ERROR("Failed to create concurrent image with VMA (VkResult: ", static_cast<int>(result), ")");
         m_image = VK_NULL_HANDLE;
         m_allocation = VK_NULL_HANDLE;
         return false;
@@ -596,6 +655,126 @@ bool VkTexture::CreateFromPixels(VmaAllocator allocator, VkDevice device, VkPhys
 
     // Create sampler with mip LOD range
     if (!m_sampler.Create(device, physicalDevice, filter, addressMode, mipLevels, aniso)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool VkTexture::CreateFromPixelsAsync(VmaAllocator allocator, VkDevice device, VkPhysicalDevice physicalDevice,
+                                      AsyncTransferContext &transfer, uint32_t graphicsQueueFamily,
+                                      const unsigned char *pixels, uint32_t width, uint32_t height, VkFormat format,
+                                      bool generateMipmaps, VkFilter filter, VkSamplerAddressMode addressMode,
+                                      int aniso)
+{
+    // ────────────────────────────────────────────────────────────────────
+    // Phase 5d-1: route texture upload through the dedicated transfer
+    // queue when the GPU exposes one. The image itself is created with
+    // VK_SHARING_MODE_CONCURRENT across [graphics, transfer] so the
+    // renderer can sample it without a queue family ownership transfer
+    // barrier — the small driver-side cost is dwarfed by no longer
+    // contending with the 3D queue for upload bandwidth.
+    //
+    // Mipmap blits use vkCmdBlitImage which the Vulkan spec only
+    // guarantees on graphics-capable queues; on a dedicated DMA queue
+    // (transfer-only) blits are not supported. The current wrapper
+    // bails out of the async path and falls back to graphics-queue
+    // upload when generateMipmaps is requested AND the transfer queue
+    // is a dedicated DMA queue. Phase 5d-2 should split mipmap
+    // generation into its own graphics-side compute / blit pass so
+    // the transfer queue can keep doing pure copies.
+    // ────────────────────────────────────────────────────────────────────
+
+    const uint32_t transferQueueFamily = transfer.GetQueueFamily();
+    const bool wantAsync =
+        transfer.IsAsyncCapable() && transferQueueFamily != graphicsQueueFamily && !generateMipmaps;
+
+    if (!wantAsync) {
+        // Either no dedicated transfer queue, or we need mipmap blits which
+        // aren't legal on a transfer-only queue — defer to the legacy path
+        // by routing through AsyncTransferContext's pooled fence pool but
+        // still on the graphics queue if AsyncTransferContext aliased to it.
+        // For simplicity here, return false and let callers retry with the
+        // graphics-queue overload above; this keeps the code path linear.
+        return false;
+    }
+
+    uint32_t bytesPerPixel = 4;
+    if (format == VK_FORMAT_R32G32B32A32_SFLOAT) {
+        bytesPerPixel = 16;
+    } else if (format == VK_FORMAT_R16G16B16A16_SFLOAT) {
+        bytesPerPixel = 8;
+    }
+    VkDeviceSize imageSize = static_cast<VkDeviceSize>(width) * height * bytesPerPixel;
+
+    VkBufferHandle stagingBuffer;
+    if (!stagingBuffer.Create(allocator, device, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
+        return false;
+    }
+    stagingBuffer.CopyFrom(pixels, imageSize, 0);
+
+    VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    std::vector<uint32_t> sharedFamilies = {graphicsQueueFamily, transferQueueFamily};
+    if (!m_image.CreateConcurrent(allocator, device, width, height, format, VK_IMAGE_TILING_OPTIMAL, usage,
+                                  VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, sharedFamilies, VK_SAMPLE_COUNT_1_BIT,
+                                  /* mipLevels */ 1)) {
+        return false;
+    }
+
+    VkCommandBuffer cmdBuffer = transfer.Begin();
+    if (cmdBuffer == VK_NULL_HANDLE) {
+        return false;
+    }
+
+    // Transition mip 0 to TRANSFER_DST.
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = m_image.GetImage();
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = 1;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = 1;
+    barrier.srcAccessMask = 0;
+    barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+    vkCmdPipelineBarrier(cmdBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                         nullptr, 1, &barrier);
+
+    VkBufferImageCopy region{};
+    region.bufferOffset = 0;
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.mipLevel = 0;
+    region.imageSubresource.baseArrayLayer = 0;
+    region.imageSubresource.layerCount = 1;
+    region.imageExtent = {width, height, 1};
+
+    vkCmdCopyBufferToImage(cmdBuffer, stagingBuffer.GetBuffer(), m_image.GetImage(),
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    // Transition to SHADER_READ_ONLY. Pure transfer queues can only target
+    // VK_PIPELINE_STAGE_TRANSFER_BIT on the dst stage; the consumer's actual
+    // stage mask becomes a no-op acquire on first sample, which is exactly
+    // what CONCURRENT sharing models for free.
+    barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier.dstAccessMask = 0; // Acquire happens implicitly on graphics-side first sample.
+    vkCmdPipelineBarrier(cmdBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                         nullptr, 1, &barrier);
+
+    transfer.EndSync(cmdBuffer);
+
+    if (!m_image.CreateView(format, VK_IMAGE_ASPECT_COLOR_BIT, 1)) {
+        return false;
+    }
+
+    if (!m_sampler.Create(device, physicalDevice, filter, addressMode, 1, aniso)) {
         return false;
     }
 

--- a/cpp/infernux/function/renderer/vk/VkHandle.h
+++ b/cpp/infernux/function/renderer/vk/VkHandle.h
@@ -16,6 +16,7 @@
 
 #include "VkTypes.h"
 #include <core/log/InxLog.h>
+#include <vector>
 #include <vk_mem_alloc.h>
 
 namespace infernux
@@ -327,6 +328,27 @@ class VkImageHandle
                 VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT, uint32_t mipLevels = 1);
 
     /**
+     * @brief Create an image with explicit cross-queue concurrent sharing.
+     *
+     * Identical to Create() above except the resulting VkImage uses
+     * VK_SHARING_MODE_CONCURRENT across @p sharedQueueFamilies, which
+     * lets transfer-queue uploads be sampled from the graphics queue
+     * without an explicit queue family ownership transfer barrier. Pays
+     * a small driver-level performance cost (variable by vendor) in
+     * exchange for that simplicity. Recommended ONLY for resources that
+     * actually cross queues — purely graphics-side render targets should
+     * stick to the EXCLUSIVE overload.
+     *
+     * Pre: @p sharedQueueFamilies must contain at least 2 distinct
+     * family indices; otherwise CONCURRENT is not legal and the call
+     * silently downgrades to EXCLUSIVE.
+     */
+    bool CreateConcurrent(VmaAllocator allocator, VkDevice device, uint32_t width, uint32_t height, VkFormat format,
+                          VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties,
+                          const std::vector<uint32_t> &sharedQueueFamilies,
+                          VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT, uint32_t mipLevels = 1);
+
+    /**
      * @brief Create an image view for this image
      * @param format View format
      * @param aspectFlags Image aspect flags
@@ -486,22 +508,42 @@ class VkTexture
     VkTexture &operator=(VkTexture &&) noexcept = default;
 
     /**
-     * @brief Create a texture from raw pixel data
-     * @param device Vulkan device
-     * @param physicalDevice Physical device
-     * @param cmdBuffer Command buffer for upload operations
-     * @param graphicsQueue Queue for command submission
-     * @param pixels RGBA pixel data
-     * @param width Image width
-     * @param height Image height
-     * @param format Image format
-     * @return true if creation succeeded
+     * @brief Create a texture from raw pixel data (legacy synchronous path)
+     *
+     * Submits all transfer + layout-transition + mipmap-blit work to a
+     * single-time command buffer on the supplied graphics queue and blocks
+     * the caller until the GPU signals completion. Allocates and destroys
+     * its own VkFence per upload — for hot-path texture loading prefer the
+     * pooled overload below.
      */
     bool CreateFromPixels(VmaAllocator allocator, VkDevice device, VkPhysicalDevice physicalDevice,
                           VkCommandPool cmdPool, VkQueue graphicsQueue, const unsigned char *pixels, uint32_t width,
                           uint32_t height, VkFormat format = VK_FORMAT_R8G8B8A8_SRGB, bool generateMipmaps = false,
                           VkFilter filter = VK_FILTER_LINEAR,
                           VkSamplerAddressMode addressMode = VK_SAMPLER_ADDRESS_MODE_REPEAT, int aniso = -1);
+
+    /**
+     * @brief Create a texture from raw pixel data using an async transfer context.
+     *
+     * Routes the upload through AsyncTransferContext (pooled fences + cmd
+     * buffers, optionally submitted on the dedicated DMA queue when the
+     * GPU exposes one). When async is capable the image is created with
+     * VK_SHARING_MODE_CONCURRENT across [graphicsFamily, transferFamily]
+     * so the renderer can sample it without an explicit queue family
+     * ownership transfer barrier.
+     *
+     * Falls back to the legacy graphics-queue path below the layer when
+     * @p transfer.IsAsyncCapable() is false (single-queue-family GPUs).
+     *
+     * Currently still blocks the caller until the upload completes — full
+     * deferred / streaming loading is the next step on top of this API.
+     */
+    bool CreateFromPixelsAsync(VmaAllocator allocator, VkDevice device, VkPhysicalDevice physicalDevice,
+                               class AsyncTransferContext &transfer, uint32_t graphicsQueueFamily,
+                               const unsigned char *pixels, uint32_t width, uint32_t height,
+                               VkFormat format = VK_FORMAT_R8G8B8A8_SRGB, bool generateMipmaps = false,
+                               VkFilter filter = VK_FILTER_LINEAR,
+                               VkSamplerAddressMode addressMode = VK_SAMPLER_ADDRESS_MODE_REPEAT, int aniso = -1);
 
     /**
      * @brief Create a solid color texture

--- a/cpp/infernux/function/renderer/vk/VkResourceManager.cpp
+++ b/cpp/infernux/function/renderer/vk/VkResourceManager.cpp
@@ -148,6 +148,22 @@ void VkResourceManager::Destroy() noexcept
     }
     m_descriptorPools.clear();
 
+    // Tear down the single-time-command pools.
+    // m_allSingleTimeCmdBuffers is owned by m_commandPool — destroying the
+    // pool below frees them implicitly, so we only need to clear the lists.
+    {
+        std::lock_guard<std::mutex> guard(m_singleTimeMutex);
+        for (VkFence fence : m_allSingleTimeFences) {
+            if (fence != VK_NULL_HANDLE) {
+                vkDestroyFence(m_device, fence, nullptr);
+            }
+        }
+        m_allSingleTimeFences.clear();
+        m_freeSingleTimeFences.clear();
+        m_allSingleTimeCmdBuffers.clear();
+        m_freeSingleTimeCmdBuffers.clear();
+    }
+
     // Destroy command pool
     if (m_commandPool != VK_NULL_HANDLE) {
         vkDestroyCommandPool(m_device, m_commandPool, nullptr);
@@ -554,14 +570,34 @@ void VkResourceManager::FreeCommandBuffer(const CommandBufferAllocation &allocat
 
 VkCommandBuffer VkResourceManager::BeginSingleTimeCommands()
 {
-    VkCommandBufferAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-    allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-    allocInfo.commandPool = m_commandPool;
-    allocInfo.commandBufferCount = 1;
+    // ────────────────────────────────────────────────────────────────────
+    // Phase 5b: pool command buffers and fences instead of churning them
+    // per upload. Hot path now hits zero kernel allocations after the
+    // first few warm-up uploads — see VkResourceManager.h for rationale.
+    // ────────────────────────────────────────────────────────────────────
+    VkCommandBuffer cmdBuffer = VK_NULL_HANDLE;
+    {
+        std::lock_guard<std::mutex> guard(m_singleTimeMutex);
+        if (!m_freeSingleTimeCmdBuffers.empty()) {
+            cmdBuffer = m_freeSingleTimeCmdBuffers.back();
+            m_freeSingleTimeCmdBuffers.pop_back();
+        }
+    }
 
-    VkCommandBuffer cmdBuffer;
-    vkAllocateCommandBuffers(m_device, &allocInfo, &cmdBuffer);
+    if (cmdBuffer == VK_NULL_HANDLE) {
+        VkCommandBufferAllocateInfo allocInfo{};
+        allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        allocInfo.commandPool = m_commandPool;
+        allocInfo.commandBufferCount = 1;
+        vkAllocateCommandBuffers(m_device, &allocInfo, &cmdBuffer);
+
+        std::lock_guard<std::mutex> guard(m_singleTimeMutex);
+        m_allSingleTimeCmdBuffers.push_back(cmdBuffer);
+    } else {
+        // Recycled buffer carries left-over recording state — reset before reuse.
+        vkResetCommandBuffer(cmdBuffer, 0);
+    }
 
     VkCommandBufferBeginInfo beginInfo{};
     beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
@@ -576,10 +612,27 @@ void VkResourceManager::EndSingleTimeCommands(VkCommandBuffer cmdBuffer)
 {
     vkEndCommandBuffer(cmdBuffer);
 
-    VkFenceCreateInfo fenceInfo{};
-    fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    // Acquire (or lazily create) a recycled fence.
     VkFence submitFence = VK_NULL_HANDLE;
-    vkCreateFence(m_device, &fenceInfo, nullptr, &submitFence);
+    {
+        std::lock_guard<std::mutex> guard(m_singleTimeMutex);
+        if (!m_freeSingleTimeFences.empty()) {
+            submitFence = m_freeSingleTimeFences.back();
+            m_freeSingleTimeFences.pop_back();
+        }
+    }
+    if (submitFence == VK_NULL_HANDLE) {
+        VkFenceCreateInfo fenceInfo{};
+        fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        if (vkCreateFence(m_device, &fenceInfo, nullptr, &submitFence) != VK_SUCCESS) {
+            INXLOG_ERROR("VkResourceManager::EndSingleTimeCommands: vkCreateFence failed");
+            return;
+        }
+        std::lock_guard<std::mutex> guard(m_singleTimeMutex);
+        m_allSingleTimeFences.push_back(submitFence);
+    } else {
+        vkResetFences(m_device, 1, &submitFence);
+    }
 
     VkSubmitInfo submitInfo{};
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
@@ -589,11 +642,14 @@ void VkResourceManager::EndSingleTimeCommands(VkCommandBuffer cmdBuffer)
     vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, submitFence);
     WaitForFencePumpingEvents(m_device, submitFence);
 
-    if (submitFence != VK_NULL_HANDLE) {
-        vkDestroyFence(m_device, submitFence, nullptr);
+    // Return both objects to the free list — the fence is reusable after
+    // vkResetFences (above) and the command buffer is reusable after the
+    // GPU has signalled (which is what WaitForFencePumpingEvents proved).
+    {
+        std::lock_guard<std::mutex> guard(m_singleTimeMutex);
+        m_freeSingleTimeFences.push_back(submitFence);
+        m_freeSingleTimeCmdBuffers.push_back(cmdBuffer);
     }
-
-    vkFreeCommandBuffers(m_device, m_commandPool, 1, &cmdBuffer);
 }
 
 // ============================================================================

--- a/cpp/infernux/function/renderer/vk/VkResourceManager.cpp
+++ b/cpp/infernux/function/renderer/vk/VkResourceManager.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "VkResourceManager.h"
+#include "AsyncTransferContext.h"
 #include "VkDeviceContext.h"
 #include <SDL3/SDL.h>
 #include <core/error/InxError.h>
@@ -396,6 +397,23 @@ std::unique_ptr<VkTexture> VkResourceManager::CreateTextureFromPixels(const unsi
                                                                       VkSamplerAddressMode addressMode, int aniso)
 {
     auto texture = std::make_unique<VkTexture>();
+
+    // Phase 5d-1: prefer the async transfer queue when the device exposes
+    // a dedicated DMA family AND we don't need graphics-queue features
+    // (e.g. mipmap blits). CreateFromPixelsAsync returns false when it
+    // can't satisfy the request, in which case we transparently fall
+    // through to the legacy synchronous graphics-queue path so callers
+    // never observe the difference beyond perf.
+    if (m_asyncTransfer != nullptr && m_asyncTransfer->IsAsyncCapable()) {
+        if (texture->CreateFromPixelsAsync(m_vmaAllocator, m_device, m_physicalDevice, *m_asyncTransfer,
+                                           m_graphicsQueueFamily, pixels, width, height, format, generateMipmaps,
+                                           filter, addressMode, aniso)) {
+            return texture;
+        }
+        // Reset the in-progress texture so the synchronous fallback below
+        // gets a clean handle to write into.
+        texture = std::make_unique<VkTexture>();
+    }
 
     if (!texture->CreateFromPixels(m_vmaAllocator, m_device, m_physicalDevice, m_commandPool, m_graphicsQueue, pixels,
                                    width, height, format, generateMipmaps, filter, addressMode, aniso)) {

--- a/cpp/infernux/function/renderer/vk/VkResourceManager.h
+++ b/cpp/infernux/function/renderer/vk/VkResourceManager.h
@@ -402,6 +402,25 @@ class VkResourceManager
         m_skipWaitIdle = v;
     }
 
+    /**
+     * @brief Plug an AsyncTransferContext for opt-in async-queue uploads.
+     *
+     * When set, CreateTextureFromPixels first attempts the async path
+     * (VK_SHARING_MODE_CONCURRENT image + transfer-queue submit). On
+     * single-queue-family GPUs, when async upload isn't legal (e.g. mipmap
+     * generation requires graphics-queue blit), or when the async submit
+     * itself fails, we transparently fall back to the legacy graphics-queue
+     * synchronous path so behaviour is identical from the caller's view.
+     *
+     * Pass nullptr to disable; resource manager is independent of the
+     * async-transfer subsystem.
+     */
+    void SetAsyncTransferContext(class AsyncTransferContext *transfer, uint32_t graphicsQueueFamily)
+    {
+        m_asyncTransfer = transfer;
+        m_graphicsQueueFamily = graphicsQueueFamily;
+    }
+
   private:
     bool m_skipWaitIdle = false;
     VmaAllocator m_vmaAllocator = VK_NULL_HANDLE;
@@ -409,6 +428,12 @@ class VkResourceManager
     VkPhysicalDevice m_physicalDevice = VK_NULL_HANDLE;
     VkQueue m_graphicsQueue = VK_NULL_HANDLE;
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
+
+    // Optional plug-in async-transfer context. Lifetime is owned externally
+    // (typically InxVkCoreModular::m_asyncTransferContext) — VkResourceManager
+    // never destroys it. nullptr means "always use the synchronous path".
+    class AsyncTransferContext *m_asyncTransfer = nullptr;
+    uint32_t m_graphicsQueueFamily = 0;
 
     // Cached samplers
     VkSampler m_linearSampler = VK_NULL_HANDLE;

--- a/cpp/infernux/function/renderer/vk/VkResourceManager.h
+++ b/cpp/infernux/function/renderer/vk/VkResourceManager.h
@@ -461,7 +461,7 @@ class VkResourceManager
     // ────────────────────────────────────────────────────────────────────
     std::vector<VkCommandBuffer> m_freeSingleTimeCmdBuffers;
     std::vector<VkFence> m_freeSingleTimeFences;
-    std::vector<VkFence> m_allSingleTimeFences;          // owned, destroyed in Destroy()
+    std::vector<VkFence> m_allSingleTimeFences;             // owned, destroyed in Destroy()
     std::vector<VkCommandBuffer> m_allSingleTimeCmdBuffers; // owned via m_commandPool
     std::mutex m_singleTimeMutex;
 };

--- a/cpp/infernux/function/renderer/vk/VkResourceManager.h
+++ b/cpp/infernux/function/renderer/vk/VkResourceManager.h
@@ -30,6 +30,7 @@
 #include "VkHandle.h"
 #include "VkTypes.h"
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -415,6 +416,29 @@ class VkResourceManager
 
     // Tracked descriptor pools for cleanup
     std::vector<VkDescriptorPool> m_descriptorPools;
+
+    // ────────────────────────────────────────────────────────────────────
+    // Single-time-command pools.
+    //
+    // Pre Phase 5b every BeginSingleTimeCommands / EndSingleTimeCommands
+    // pair did vkAllocateCommandBuffers + vkCreateFence + vkQueueSubmit +
+    // vkWaitForFences + vkDestroyFence + vkFreeCommandBuffers, which is
+    // 4 kernel-driver round-trips PER tiny upload. Texture-heavy scenes
+    // were spending hundreds of microseconds per asset in driver allocation
+    // alone before any actual GPU work happened.
+    //
+    // The free-list below recycles fences and command buffers so steady-state
+    // usage hits the kernel exactly twice per submit (vkBeginCommandBuffer +
+    // vkQueueSubmit) and the wait itself.
+    //
+    // The mutex protects against concurrent uploads from background asset
+    // loading threads (Phase 5d will widen this to per-thread pools).
+    // ────────────────────────────────────────────────────────────────────
+    std::vector<VkCommandBuffer> m_freeSingleTimeCmdBuffers;
+    std::vector<VkFence> m_freeSingleTimeFences;
+    std::vector<VkFence> m_allSingleTimeFences;          // owned, destroyed in Destroy()
+    std::vector<VkCommandBuffer> m_allSingleTimeCmdBuffers; // owned via m_commandPool
+    std::mutex m_singleTimeMutex;
 };
 
 } // namespace vk

--- a/cpp/infernux/function/scene/BoxCollider.cpp
+++ b/cpp/infernux/function/scene/BoxCollider.cpp
@@ -13,6 +13,7 @@
 #include "GameObject.h"
 #include "MeshRenderer.h"
 #include "Transform.h"
+#include <InxLog.h>
 
 #include <nlohmann/json.hpp>
 
@@ -106,7 +107,8 @@ bool BoxCollider::Deserialize(const std::string &jsonStr)
         // Safe during scene load: RebuildShape() is a no-op when bodyId == 0xFFFFFFFF.
         RebuildShape();
         return true;
-    } catch (...) {
+    } catch (const std::exception &e) {
+        INXLOG_ERROR("BoxCollider::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/Camera.cpp
+++ b/cpp/infernux/function/scene/Camera.cpp
@@ -1,6 +1,7 @@
 #include "Camera.h"
 #include "ComponentFactory.h"
 #include "GameObject.h"
+#include <InxLog.h>
 #include <cmath>
 #include <nlohmann/json.hpp>
 
@@ -91,6 +92,7 @@ bool Camera::Deserialize(const std::string &jsonStr)
 
         return true;
     } catch (const std::exception &e) {
+        INXLOG_ERROR("Camera::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/CapsuleCollider.cpp
+++ b/cpp/infernux/function/scene/CapsuleCollider.cpp
@@ -13,6 +13,7 @@
 #include "GameObject.h"
 #include "MeshRenderer.h"
 #include "Transform.h"
+#include <InxLog.h>
 
 #include <algorithm>
 #include <cmath>
@@ -154,7 +155,8 @@ bool CapsuleCollider::Deserialize(const std::string &jsonStr)
             m_direction = j["direction"].get<int>();
         RebuildShape();
         return true;
-    } catch (...) {
+    } catch (const std::exception &e) {
+        INXLOG_ERROR("CapsuleCollider::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/Collider.cpp
+++ b/cpp/infernux/function/scene/Collider.cpp
@@ -12,6 +12,7 @@
 #include "Transform.h"
 #include "physics/PhysicsECSStore.h"
 #include "physics/PhysicsWorld.h"
+#include <InxLog.h>
 
 #include <algorithm>
 #include <nlohmann/json.hpp>

--- a/cpp/infernux/function/scene/Collider.cpp
+++ b/cpp/infernux/function/scene/Collider.cpp
@@ -610,7 +610,8 @@ bool Collider::Deserialize(const std::string &jsonStr)
         // fields are deserialized (so both base + derived changes are applied
         // in a single shape rebuild).
         return true;
-    } catch (...) {
+    } catch (const std::exception &e) {
+        INXLOG_ERROR("Collider::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/Component.cpp
+++ b/cpp/infernux/function/scene/Component.cpp
@@ -247,6 +247,7 @@ bool Component::Deserialize(const std::string &jsonStr)
         // instance_guid is now derived from component_id; ignore legacy string values
         return true;
     } catch (const std::exception &e) {
+        INXLOG_ERROR("Component::Deserialize failed for '", GetTypeName(), "' (id=", m_componentId, "): ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/GameObject.cpp
+++ b/cpp/infernux/function/scene/GameObject.cpp
@@ -826,6 +826,7 @@ bool GameObject::Deserialize(const std::string &jsonStr)
 
         return true;
     } catch (const std::exception &e) {
+        INXLOG_ERROR("GameObject::Deserialize failed for '", m_name, "' (id=", m_id, "): ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/Light.cpp
+++ b/cpp/infernux/function/scene/Light.cpp
@@ -3,6 +3,7 @@
 #include "GameObject.h"
 #include "SceneManager.h"
 #include "Transform.h"
+#include <InxLog.h>
 #include <nlohmann/json.hpp>
 
 using json = nlohmann::json;
@@ -138,6 +139,7 @@ bool Light::Deserialize(const std::string &jsonStr)
 
         return true;
     } catch (const std::exception &e) {
+        INXLOG_ERROR("Light::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/MeshCollider.cpp
+++ b/cpp/infernux/function/scene/MeshCollider.cpp
@@ -410,7 +410,8 @@ bool MeshCollider::Deserialize(const std::string &jsonStr)
         m_convex = j.value("convex", false);
         RebuildShape();
         return true;
-    } catch (...) {
+    } catch (const std::exception &e) {
+        INXLOG_ERROR("MeshCollider::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/MeshRenderer.cpp
+++ b/cpp/infernux/function/scene/MeshRenderer.cpp
@@ -778,6 +778,7 @@ bool MeshRenderer::Deserialize(const std::string &jsonStr)
 
         return true;
     } catch (const std::exception &e) {
+        INXLOG_ERROR("MeshRenderer::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/Rigidbody.cpp
+++ b/cpp/infernux/function/scene/Rigidbody.cpp
@@ -952,7 +952,8 @@ bool Rigidbody::Deserialize(const std::string &jsonStr)
         NotifyCollidersBodyTypeChanged();
 
         return true;
-    } catch (...) {
+    } catch (const std::exception &e) {
+        INXLOG_ERROR("Rigidbody::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/Scene.cpp
+++ b/cpp/infernux/function/scene/Scene.cpp
@@ -748,13 +748,14 @@ bool Scene::Deserialize(const std::string &jsonStr)
             m_isPlaying = j["isPlaying"].get<bool>();
         }
 
-        // Clear existing objects and pending destroys
-        m_mainCamera = nullptr; // Reset before clearing objects to avoid dangling pointer
+        // ── Step 1: drop main camera reference (raw pointer into m_rootObjects). ──
+        m_mainCamera = nullptr;
 
-        // Clear physics/renderer registries BEFORE destroying old GameObjects so
-        // that no stale component pointers remain in the iteration vectors while
-        // destructors run.  Each old component's destructor will find empty
-        // registries (safe no-op), and new components will re-register in OnEnable.
+        // ── Step 2: clear physics/renderer registries BEFORE old GameObjects die. ──
+        // See the Scene Rebuild Contract in Scene.h::Deserialize for the full
+        // ordering rationale: the registries hold raw component pointers and must
+        // be empty when destructors fire so no stale pointers leak into the
+        // iteration vectors.
         SceneManager::Instance().ClearComponentRegistries();
 
         m_rootObjects.clear();
@@ -781,15 +782,12 @@ bool Scene::Deserialize(const std::string &jsonStr)
             }
         }
 
-        // Always awake all C++ components after deserialization so they initialize
-        // correctly regardless of play state.  This populates the MeshRenderer /
-        // Rigidbody / Collider registries that CollectRenderables() and the physics
-        // system rely on.
-        //
-        // NOTE: Python proxy components (PyComponentProxy) are NOT present in
-        // m_rootObjects at this point — they are stored as PendingPyComponent and
-        // added by _restore_py_components() AFTER Deserialize() returns.  So this
-        // loop never touches Python lifecycle methods; it only affects C++ components.
+        // ── Step 5: native Awake pass. ──
+        // PyComponentProxy instances are NOT in m_rootObjects yet — they live
+        // in m_pendingPyComponents and the Python side restores them after we
+        // return.  This loop touches C++ components only and re-populates the
+        // MeshRenderer/Rigidbody/Collider registries that the renderer and
+        // physics step rely on.
         for (const auto &root : m_rootObjects) {
             AwakeObject(root.get());
         }

--- a/cpp/infernux/function/scene/Scene.cpp
+++ b/cpp/infernux/function/scene/Scene.cpp
@@ -675,7 +675,8 @@ GameObject *Scene::InstantiateFromJson(const std::string &jsonStr, GameObject *p
     json j;
     try {
         j = json::parse(jsonStr);
-    } catch (const std::exception &) {
+    } catch (const std::exception &e) {
+        INXLOG_ERROR("Scene::InstantiateFromJson: JSON parse error: ", e.what());
         return nullptr;
     }
 
@@ -810,6 +811,7 @@ bool Scene::Deserialize(const std::string &jsonStr)
 
         return true;
     } catch (const std::exception &e) {
+        INXLOG_ERROR("Scene::Deserialize failed for scene '", m_name, "': ", e.what());
         return false;
     }
 }
@@ -820,12 +822,14 @@ bool Scene::SaveToFile(const std::string &path) const
         std::string jsonStr = Serialize();
         std::ofstream file = OpenOutputFile(path, std::ios::out | std::ios::trunc);
         if (!file.is_open()) {
+            INXLOG_ERROR("Scene::SaveToFile: cannot open '", path, "' for writing");
             return false;
         }
         file << jsonStr;
         file.close();
         return true;
     } catch (const std::exception &e) {
+        INXLOG_ERROR("Scene::SaveToFile failed for '", path, "': ", e.what());
         return false;
     }
 }
@@ -835,6 +839,7 @@ bool Scene::LoadFromFile(const std::string &path)
     try {
         std::ifstream file = OpenInputFile(path);
         if (!file.is_open()) {
+            INXLOG_ERROR("Scene::LoadFromFile: cannot open '", path, "' for reading");
             return false;
         }
 
@@ -843,6 +848,7 @@ bool Scene::LoadFromFile(const std::string &path)
 
         return Deserialize(jsonStr);
     } catch (const std::exception &e) {
+        INXLOG_ERROR("Scene::LoadFromFile failed for '", path, "': ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/Scene.h
+++ b/cpp/infernux/function/scene/Scene.h
@@ -229,19 +229,41 @@ class Scene
     /// @return JSON string representation of the scene
     [[nodiscard]] std::string Serialize() const;
 
-    /// @brief Deserialize scene from JSON string
+    /// @brief Deserialize scene from JSON string and rebuild the entire scene graph.
+    ///
+    /// **Scene Rebuild Contract** (canonical reference for all deserialize paths):
+    ///
+    ///   1. Caller MUST clear any Python/RenderStack singleton state that holds
+    ///      raw pointers into the old scene BEFORE calling Deserialize() — see
+    ///      `Infernux.engine.play_mode._rebuild_active_scene` for the editor
+    ///      precedent (it nils `RenderStack._active_instance`).
+    ///   2. Deserialize() then invokes `SceneManager::ClearComponentRegistries()`
+    ///      so MeshRenderer/Light/PhysicsECS pending queues do not retain stale
+    ///      pointers into the about-to-be-destroyed GameObjects.
+    ///   3. Old root objects are dropped (their destructors run with empty
+    ///      registries — safe no-op unregisters).
+    ///   4. New GameObjects are built from JSON with `preserveIds=true`, then
+    ///      registered via `RegisterObjectSubtree`.
+    ///   5. `AwakeObject()` runs over every new root: this is a NATIVE-only pass
+    ///      and never touches Python lifecycle methods. PyComponentProxy
+    ///      instances are NOT in `m_rootObjects` yet — they live in
+    ///      `m_pendingPyComponents` and are restored by Python via
+    ///      `restore_pending_py_components()` AFTER this call returns.
+    ///   6. `m_structureVersion` is bumped, invalidating any caches keyed on it.
+    ///
     /// @param jsonStr JSON string to deserialize from
-    /// @return true if successful
+    /// @return true if successful, false on JSON parse / schema errors
+    ///         (errors are logged via INXLOG_ERROR; check the log when this
+    ///         returns false).
     bool Deserialize(const std::string &jsonStr);
 
-    /// @brief Save scene to file
-    /// @param path File path to save to
-    /// @return true if successful
+    /// @brief Save scene to file (writes Serialize() output to *path*).
+    /// @return true on success; logs INXLOG_ERROR on failure.
     bool SaveToFile(const std::string &path) const;
 
-    /// @brief Load scene from file
-    /// @param path File path to load from
-    /// @return true if successful
+    /// @brief Load scene from file by reading *path* and calling Deserialize().
+    /// See Deserialize() for the rebuild contract that runs after the read.
+    /// @return true on success; logs INXLOG_ERROR on failure.
     bool LoadFromFile(const std::string &path);
 
     // ========================================================================

--- a/cpp/infernux/function/scene/SceneManager.cpp
+++ b/cpp/infernux/function/scene/SceneManager.cpp
@@ -587,16 +587,19 @@ void SceneManager::SyncExternalRigidbodyMoves()
 
 void SceneManager::ClearComponentRegistries()
 {
+    // Renderer-facing registries: MeshRenderer/Light keep raw component
+    // pointers, so we must drop them before the owning GameObjects die during
+    // a Scene::Deserialize() rebuild (see the Scene Rebuild Contract).
     m_activeMeshRenderers.clear();
     m_activeMeshRendererSet.clear();
     m_activeLights.clear();
     ++m_meshRendererVersion;
 
-    // Flush stale physics pending queues.  During scene rebuild, edit-mode
-    // Collider::Awake() queues body creations whose handle.index entries linger
-    // in the dedup set.  If pool slots are reused on the next deserialize, the
-    // new QueueBodyCreation() silently fails the set insert, preventing body
-    // creation entirely.
+    // Physics pending queues: edit-mode Collider::Awake() may have queued
+    // body creations whose handle.index entries are about to be reused for
+    // freshly-allocated colliders. If we leave the dedup set populated, the
+    // new QueueBodyCreation() silently fails its insert and the body is never
+    // created, leading to invisible collisions/missing rigidbodies post-load.
     PhysicsECSStore::Instance().ClearPendingQueues();
 }
 

--- a/cpp/infernux/function/scene/SceneManager.h
+++ b/cpp/infernux/function/scene/SceneManager.h
@@ -122,11 +122,17 @@ class SceneManager
     // ========================================================================
 
     /// @brief Mark a root GameObject so it survives scene switches.
-    /// The object is moved to an internal persistent list owned by SceneManager.
+    ///
+    /// The object stays inside its current scene during normal operation;
+    /// `UnloadScene` and `SetActiveScene` migrate persistent roots out of the
+    /// dying scene into `m_persistentObjects`, then attach them to the new
+    /// active scene. `Stop()` drops them — DontDestroyOnLoad survives scene
+    /// switches but does NOT survive a play-session boundary.
     /// Unity: Object.DontDestroyOnLoad(gameObject)
     void DontDestroyOnLoad(GameObject *gameObject);
 
-    /// @brief Get all persistent (DontDestroyOnLoad) objects
+    /// @brief Get all persistent (DontDestroyOnLoad) roots currently parked
+    /// outside any scene (between Unload and the next SetActiveScene).
     [[nodiscard]] const std::vector<std::unique_ptr<GameObject>> &GetPersistentObjects() const
     {
         return m_persistentObjects;
@@ -148,10 +154,21 @@ class SceneManager
         return m_isPlaying;
     }
 
-    /// @brief Enter play mode
+    /// @brief Enter play mode.
+    ///
+    /// Resets the fixed-step accumulator (only on a fresh Play, not on resume),
+    /// flips internal flags, calls `Scene::Start()` on the active scene, and
+    /// force-syncs every Jolt body to its current Transform so the first frame
+    /// runs against authored positions instead of stale editor values.
     void Play();
 
-    /// @brief Stop play mode
+    /// @brief Exit play mode.
+    ///
+    /// Flips `m_isPlaying`/`m_isPaused` to false, fires the play-state-changed
+    /// callback, and clears `m_persistentObjects` (DontDestroyOnLoad does NOT
+    /// outlive a play session). Scene snapshot restore is the responsibility
+    /// of the Python `PlayModeManager.exit_play_mode` flow — Stop() itself
+    /// does not deserialize anything.
     void Stop();
 
     /// @brief Set a callback that fires when Play()/Stop() transitions occur.

--- a/cpp/infernux/function/scene/SphereCollider.cpp
+++ b/cpp/infernux/function/scene/SphereCollider.cpp
@@ -13,6 +13,7 @@
 #include "MeshRenderer.h"
 #include "SphereCollider.h"
 #include "Transform.h"
+#include <InxLog.h>
 
 #include <algorithm>
 #include <cmath>
@@ -90,7 +91,8 @@ bool SphereCollider::Deserialize(const std::string &jsonStr)
             m_radius = j["radius"].get<float>();
         RebuildShape();
         return true;
-    } catch (...) {
+    } catch (const std::exception &e) {
+        INXLOG_ERROR("SphereCollider::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/SpriteRenderer.cpp
+++ b/cpp/infernux/function/scene/SpriteRenderer.cpp
@@ -1,5 +1,6 @@
 #include "SpriteRenderer.h"
 #include "ComponentFactory.h"
+#include <InxLog.h>
 #include <function/resources/AssetRegistry/AssetRegistry.h>
 #include <function/scene/PrimitiveMeshes.h>
 #include <nlohmann/json.hpp>
@@ -84,7 +85,8 @@ bool SpriteRenderer::Deserialize(const std::string &jsonStr)
         }
 
         return true;
-    } catch (const std::exception &) {
+    } catch (const std::exception &e) {
+        INXLOG_ERROR("SpriteRenderer::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/Transform.cpp
+++ b/cpp/infernux/function/scene/Transform.cpp
@@ -3,6 +3,7 @@
 #include "GameObject.h"
 #include "Scene.h"
 #include "TransformECSStore.h"
+#include <InxLog.h>
 #include <algorithm>
 #include <climits>
 #include <cmath>
@@ -551,6 +552,7 @@ bool Transform::Deserialize(const std::string &jsonStr)
         InvalidateWorldMatrix(false);
         return true;
     } catch (const std::exception &e) {
+        INXLOG_ERROR("Transform::Deserialize failed: ", e.what());
         return false;
     }
 }

--- a/cpp/infernux/function/scene/physics/PhysicsECSStore.cpp
+++ b/cpp/infernux/function/scene/physics/PhysicsECSStore.cpp
@@ -1,6 +1,21 @@
 /**
  * @file PhysicsECSStore.cpp
  * @brief Contiguous memory pools for Collider and Rigidbody data.
+ *
+ * Lifecycle invariants enforced by this file:
+ *
+ *   * Allocate*() always zero-initialises the entry before stamping the owner,
+ *     so reused pool slots never inherit stale state from a previous owner.
+ *   * Release*() always nulls the owner pointer first, then frees the slot;
+ *     callers may safely observe a half-released entry (owner == nullptr,
+ *     IsAlive == false).
+ *   * Releasing a Rigidbody invalidates every ColliderECSData::cachedRigidbody
+ *     pointer that references it. Rigidbody::OnDisable() is the primary cleaner;
+ *     ScrubCachedRigidbody() is the safety net for paths that bypass it
+ *     (editor undo/redo on inactive objects, scene rebuild order anomalies).
+ *   * The pending-queue dedup sets MUST be cleared whenever pool slots may be
+ *     recycled; ClearPendingQueues() is the single chokepoint for that — see
+ *     SceneManager::ClearComponentRegistries.
  */
 
 #include "PhysicsECSStore.h"
@@ -65,25 +80,32 @@ PhysicsECSStore::RigidbodyHandle PhysicsECSStore::AllocateRigidbody(Rigidbody *o
     return handle;
 }
 
+// Walk every alive Collider entry and null out cachedRigidbody pointers
+// matching *dying*. Used by ReleaseRigidbody to keep collider hot paths
+// (SyncTransformToPhysics, RebuildShape, AddToBroadphase) safe even when
+// the normal Rigidbody::OnDisable cleanup did not fire.
+void PhysicsECSStore::ScrubCachedRigidbody(Rigidbody *dying)
+{
+    if (!dying)
+        return;
+    for (auto ch : m_colliderPool.GetAliveHandles()) {
+        auto &cd = m_colliderPool.Get(ch);
+        if (cd.cachedRigidbody == dying)
+            cd.cachedRigidbody = nullptr;
+    }
+}
+
 void PhysicsECSStore::ReleaseRigidbody(RigidbodyHandle handle)
 {
     if (!m_rigidbodyPool.IsAlive(handle))
         return;
-    Rigidbody *dying = m_rigidbodyPool.Get(handle).owner;
-    // Safety net: clear cachedRigidbody on every alive collider that still
-    // references this Rigidbody.  Rigidbody::OnDisable() normally handles
-    // this, but during editor undo/redo the lifecycle may not fire if the
-    // component was never enabled (inactive hierarchy) or the destroy order
-    // bypasses the normal CallOnDestroy path.  Without this, collider hot
-    // paths (SyncTransformToPhysics, RebuildShape, AddToBroadphase) would
-    // dereference a dangling pointer → crash.
-    if (dying) {
-        for (auto ch : m_colliderPool.GetAliveHandles()) {
-            auto &cd = m_colliderPool.Get(ch);
-            if (cd.cachedRigidbody == dying)
-                cd.cachedRigidbody = nullptr;
-        }
-    }
+
+    // Safety net: see ScrubCachedRigidbody. Rigidbody::OnDisable() is the
+    // primary cleaner, but editor undo/redo on inactive components and other
+    // bypass paths reach Release without going through OnDisable; without this
+    // scrub, sibling colliders would dereference a freed Rigidbody.
+    ScrubCachedRigidbody(m_rigidbodyPool.Get(handle).owner);
+
     m_rigidbodyPool.Get(handle).owner = nullptr;
     m_rigidbodyPool.Free(handle);
 }

--- a/cpp/infernux/function/scene/physics/PhysicsECSStore.h
+++ b/cpp/infernux/function/scene/physics/PhysicsECSStore.h
@@ -195,6 +195,12 @@ class PhysicsECSStore
         return m_rigidbodyPool.GetAliveHandles();
     }
 
+    /// Null out cachedRigidbody on every alive collider that references *dying*.
+    /// Idempotent and safe to call with a Rigidbody* that no other collider
+    /// references — used both as part of ReleaseRigidbody and as a public hook
+    /// for paths that need to invalidate caches before a Rigidbody is destroyed.
+    void ScrubCachedRigidbody(Rigidbody *dying);
+
     /// Zero-allocation iteration over all alive rigidbodies.
     template <typename Func> void ForEachAliveRigidbody(Func &&func)
     {

--- a/cpp/infernux/function/scene/physics/PhysicsWorld.cpp
+++ b/cpp/infernux/function/scene/physics/PhysicsWorld.cpp
@@ -304,15 +304,24 @@ void PhysicsWorld::Shutdown()
         return;
 
     INXLOG_INFO("PhysicsWorld: Shutting down...");
+
+    // Step 1: drop contact pair tracking and the body→collider lookup before
+    // any body dies, so callbacks racing the teardown can't dereference
+    // freed Collider* pointers.
     if (m_contactListener)
         m_contactListener->ClearAll();
     m_bodyToCollider.clear();
+
+    // Step 2: tear down subsystems in dependency order (newest first).
     m_contactListener.reset();
     m_physicsSystem.reset();
     m_jobSystem.reset();
     m_tempAllocator.reset();
     m_layers.reset();
 
+    // Step 3: drop Jolt's process-global state. Safe because every owned
+    // unique_ptr above has been released, so no Jolt object outlives the
+    // factory.
     JPH::UnregisterTypes();
     delete JPH::Factory::sInstance;
     JPH::Factory::sInstance = nullptr;
@@ -547,11 +556,11 @@ void PhysicsWorld::DestroyBody(Collider *collider)
     if (id == 0xFFFFFFFF)
         return;
 
-    JPH::BodyID bodyId(id);
+    // Contract: caller (Collider::UnregisterBody) must have already removed
+    // this body from the broadphase. See PhysicsWorld.h::DestroyBody for the
+    // full ordering invariant.
     JPH::BodyInterface &bodyInterface = m_physicsSystem->GetBodyInterface();
-    // NOTE: Caller (Collider::UnregisterBody) must have already called
-    // RemoveFromBroadphase() before reaching here.
-    bodyInterface.DestroyBody(bodyId);
+    bodyInterface.DestroyBody(JPH::BodyID(id));
 
     m_bodyToCollider.erase(id);
 }

--- a/cpp/infernux/function/scene/physics/PhysicsWorld.h
+++ b/cpp/infernux/function/scene/physics/PhysicsWorld.h
@@ -63,7 +63,15 @@ class PhysicsWorld
     /// Initialise Jolt (call once after engine starts)
     void Initialize();
 
-    /// Shut down Jolt (call on engine cleanup)
+    /// Shut down Jolt (call on engine cleanup).
+    ///
+    /// Tear-down order is fixed:
+    ///   1. ContactListener::ClearAll() — drop pair tracking before bodies die.
+    ///   2. m_bodyToCollider cleared — no caller may resolve a Collider* now.
+    ///   3. ContactListener / PhysicsSystem / JobSystem / TempAllocator / Layers
+    ///      destroyed in dependency order.
+    ///   4. Jolt globals (Factory, registered types) torn down.
+    /// Idempotent: subsequent calls are no-ops.
     void Shutdown();
 
     /// @return true if initialised
@@ -83,6 +91,12 @@ class PhysicsWorld
     uint32_t CreateBody(Collider *collider, bool isStatic, bool isTrigger);
 
     /// Remove a body by collider pointer.
+    ///
+    /// Caller MUST first call RemoveBodyFromBroadphase(bodyId) — DestroyBody
+    /// only releases the body slot and drops the body→collider mapping.
+    /// Calling this on a body that is still in the broadphase will leave a
+    /// stale handle dangling inside Jolt. Collider::UnregisterBody is the
+    /// canonical caller and already enforces this ordering.
     void DestroyBody(Collider *collider);
 
     /// Inform the physics world that a body has moved (kinematic / editor move).

--- a/python/Infernux/components/_component_native.py
+++ b/python/Infernux/components/_component_native.py
@@ -40,8 +40,8 @@ class ComponentNativeMixin:
             return False
         try:
             return isinstance(game_object, GameObject) and int(game_object.id) > 0
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("_component_native.is_valid_game_object", exc)
             return False
 
     @staticmethod
@@ -51,8 +51,8 @@ class ComponentNativeMixin:
             return False
         try:
             return int(component.component_id) > 0
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("_component_native.is_valid_native_component", exc)
             return False
 
     def _try_get_game_object(self) -> Optional['GameObject']:

--- a/python/Infernux/components/ref_wrappers.py
+++ b/python/Infernux/components/ref_wrappers.py
@@ -33,18 +33,16 @@ def _get_prefab_asset_database():
         db = _get_asset_database()
         if db is not None:
             return db
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-        pass
+    except Exception as exc:
+        Debug.log_suppressed("ref_wrappers._get_asset_database.editor_path", exc)
 
     try:
         from Infernux.lib import AssetRegistry
         registry = AssetRegistry.instance()
         if registry is not None:
             return registry.get_asset_database()
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-        pass
+    except Exception as exc:
+        Debug.log_suppressed("ref_wrappers._get_asset_database.registry_path", exc)
 
     return None
 
@@ -99,9 +97,11 @@ class GameObjectRef:
                 obj = scene.find_by_id(self._persistent_id)
                 self._cached_obj = obj
                 return obj
-        except (ImportError, RuntimeError) as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass  # pybind11 raises RuntimeError when C++ object is destroyed
+        except (ImportError, RuntimeError):
+            # pybind11 raises RuntimeError when the C++ object behind a
+            # GameObjectRef has been destroyed — that's the normal
+            # "reference is dead" path, no need to log.
+            pass
         except Exception as exc:
             _log.warning("GameObjectRef._resolve failed: %s", exc)
         self._cached_obj = None
@@ -223,8 +223,9 @@ class PrefabRef:
         try:
             stat = os.stat(file_path)
             return (stat.st_mtime_ns, stat.st_size)
-        except OSError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except OSError:
+            # Missing file is the expected signal for "no cache stamp" —
+            # callers treat None as a re-read trigger.
             return None
 
     def _read_prefab_root_name(self, file_path: str) -> str:
@@ -371,8 +372,8 @@ def _iter_live_components_on_game_object(game_object) -> list[Any]:
             comp_go = getattr(comp, "game_object", None)
             if comp_go is None or int(comp_go.id) != go_id:
                 continue
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("ref_wrappers.collect_components.iter", exc)
             continue
         if comp not in result:
             result.append(comp)
@@ -399,9 +400,8 @@ def _resolve_component_on_game_object(game_object, component_type: str = ""):
                 cpp_comp = game_object.get_cpp_component(cpp_type)
                 if cpp_comp is not None:
                     return builtin_cls._get_or_create_wrapper(cpp_comp, game_object)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("ref_wrappers.resolve_component.builtin_wrapper", exc)
 
         try:
             from .registry import get_type
@@ -410,14 +410,13 @@ def _resolve_component_on_game_object(game_object, component_type: str = ""):
                 py_comp = game_object.get_py_component(component_cls)
                 if py_comp is not None:
                     return py_comp
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("ref_wrappers.resolve_component.py_component_lookup", exc)
 
         try:
             return game_object.get_cpp_component(component_type)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("ref_wrappers.resolve_component.get_cpp_component", exc)
             return None
 
     if live_components:
@@ -431,9 +430,8 @@ def _resolve_component_on_game_object(game_object, component_type: str = ""):
             resolved = _resolve_component_on_game_object(game_object, type_name)
             if resolved is not None:
                 return resolved
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-        pass
+    except Exception as exc:
+        Debug.log_suppressed("ref_wrappers.resolve_runtime_field_value", exc)
 
     return None
 

--- a/python/Infernux/components/serialized_field.py
+++ b/python/Infernux/components/serialized_field.py
@@ -278,8 +278,9 @@ def _get_asset_db():
     try:
         from Infernux.core.asset_ref import _get_asset_database
         return _get_asset_database()
-    except ImportError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except ImportError:
+        # AssetManager is unavailable in standalone player builds where the
+        # editor-only asset database is excluded from the bundle.
         return None
 
 
@@ -292,8 +293,8 @@ def _guid_from_path(path: str) -> str:
     try:
         guid = db.get_guid_from_path(path)
         return guid or ""
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("serialized_field._guid_for_path", exc)
         return ""
 
 
@@ -580,13 +581,15 @@ def _infer_field_type(python_type: Optional[Type], default: Any) -> FieldType:
         if hasattr(python_type, '__origin__') and python_type.__origin__ in (list, tuple):
             return FieldType.LIST
 
-        # SerializableObject subclass detection
+        # SerializableObject subclass detection.
+        # ImportError is benign: SerializableObject may not be importable
+        # yet during early module load — the field will be classified on
+        # the next inspection pass.
         try:
             from .serializable_object import SerializableObject as _SO
             if isinstance(python_type, type) and issubclass(python_type, _SO):
                 return FieldType.SERIALIZABLE_OBJECT
-        except ImportError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except ImportError:
             pass
 
         # InxComponent subclass → COMPONENT (e.g. ``text: UIText``)
@@ -594,8 +597,7 @@ def _infer_field_type(python_type: Optional[Type], default: Any) -> FieldType:
             from .component import InxComponent as _IC
             if isinstance(python_type, type) and issubclass(python_type, _IC) and python_type is not _IC:
                 return FieldType.COMPONENT
-        except ImportError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except ImportError:
             pass
 
     # Infer from default value
@@ -605,8 +607,7 @@ def _infer_field_type(python_type: Optional[Type], default: Any) -> FieldType:
             from .serializable_object import SerializableObject as _SO
             if isinstance(default, _SO):
                 return FieldType.SERIALIZABLE_OBJECT
-        except ImportError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except ImportError:
             pass
 
         # ComponentRef instance
@@ -614,8 +615,7 @@ def _infer_field_type(python_type: Optional[Type], default: Any) -> FieldType:
             from .ref_wrappers import ComponentRef
             if isinstance(default, ComponentRef):
                 return FieldType.COMPONENT
-        except ImportError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except ImportError:
             pass
 
         # Order matters: Enum before int (IntEnum is both), bool before int
@@ -708,9 +708,11 @@ def resolve_annotation(annotation) -> Optional['FieldMetadata']:
             resolved = get_type(simple_name)
             if resolved is not None:
                 return resolve_annotation(resolved)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed(
+                f"serialized_field.resolve_annotation.registry_lookup[{simple_name}]",
+                exc,
+            )
         return None
 
     # ── list[X] / List[X] generics ──
@@ -761,8 +763,9 @@ def resolve_annotation(annotation) -> Optional['FieldMetadata']:
                 default=ComponentRef(component_type=type_name),
                 component_type=type_name,
             )
-    except ImportError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except ImportError:
+        # InxComponent not yet importable during early module load — the
+        # annotation will be reclassified on the next inspection pass.
         pass
 
     # ── Known reference / asset types ──

--- a/python/Infernux/core/assets.py
+++ b/python/Infernux/core/assets.py
@@ -76,10 +76,6 @@ class AssetManager:
     # Key = normalized file path, value = serialized JSON string.
     _material_save_snapshots: Dict[str, str] = {}
 
-    # Pre-captured material JSON snapshots for async save.
-    # Key = normalized file path, value = serialized JSON string.
-    _material_save_snapshots: Dict[str, str] = {}
-
     # Cached reference to C++ AssetRegistry singleton
     _registry = None
 

--- a/python/Infernux/core/assets.py
+++ b/python/Infernux/core/assets.py
@@ -158,8 +158,10 @@ class AssetManager:
             if hasattr(asset, "_guid"):
                 try:
                     asset._guid = guid
-                except (AttributeError, TypeError) as _exc:
-                    Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+                except (AttributeError, TypeError):
+                    # Some asset wrappers expose _guid as a property without
+                    # a setter; the underlying GUID lookup still works via the
+                    # cache key, so a missing setter is benign here.
                     pass
             cls._put_cache(guid, asset)
         return asset
@@ -289,8 +291,8 @@ class AssetManager:
         try:
             guid = adb.import_asset(path)
             return bool(guid)
-        except (RuntimeError, OSError) as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except (RuntimeError, OSError) as exc:
+            Debug.log_suppressed("AssetManager.reimport_asset", exc)
             return False
 
     @classmethod
@@ -313,8 +315,8 @@ class AssetManager:
             return False
         try:
             return bool(adb.move_asset(old_path, new_path))
-        except (RuntimeError, OSError) as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except (RuntimeError, OSError) as exc:
+            Debug.log_suppressed("AssetManager.move_asset", exc)
             return False
 
     @classmethod
@@ -393,8 +395,8 @@ class AssetManager:
                     if ok:
                         cls.on_material_saved(file_path)
                         return True
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed("AssetManager.schedule_material_save_async.native_path", exc)
 
         # Fallback for older native builds — run synchronous save on the
         # IO thread pool to avoid blocking the main/render thread.
@@ -407,8 +409,8 @@ class AssetManager:
         def _fallback_save():
             try:
                 return save()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed("AssetManager.schedule_material_save_async.fallback_save", exc)
                 return False
 
         _io_pool.submit(_fallback_save)
@@ -499,8 +501,8 @@ class AssetManager:
         try:
             from Infernux.lib import AssetRegistry
             return AssetRegistry.instance()
-        except (ImportError, RuntimeError, AttributeError) as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except (ImportError, RuntimeError, AttributeError) as exc:
+            Debug.log_suppressed("AssetManager._resolve_registry", exc)
             return None
 
     @classmethod
@@ -555,9 +557,10 @@ class AssetManager:
             cls._texture_cache[guid] = asset
         try:
             cls._cache[guid] = weakref.ref(asset)
-        except TypeError as _exc:
-            # Object doesn't support weakref — skip caching
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except TypeError:
+            # Object doesn't support weakref (e.g. some pybind types) —
+            # caching is best-effort and the asset will simply be reloaded
+            # next time it is requested.
             pass
 
     @classmethod
@@ -661,9 +664,8 @@ class AssetManager:
             for ident in identifiers:
                 if ident:
                     cache.invalidate(ident)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("AssetManager._invalidate_texture_ui_cache.shared_cache", exc)
 
         native = cls._native_engine()
 
@@ -673,16 +675,17 @@ class AssetManager:
                     continue
                 try:
                     native.invalidate_texture_preview_task(f"ui_img|{ident}")
-                except Exception as _exc:
-                    Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                    pass
+                except Exception as exc:
+                    Debug.log_suppressed(
+                        "AssetManager._invalidate_texture_ui_cache.native_preview_task",
+                        exc,
+                    )
 
         try:
             from Infernux.engine.ui.asset_resource_preview import invalidate_resource_preview
             invalidate_resource_preview(path)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("AssetManager._invalidate_texture_ui_cache.resource_preview", exc)
 
         try:
             from Infernux.engine.ui.window_manager import WindowManager
@@ -692,9 +695,8 @@ class AssetManager:
                     invalidate = getattr(panel, "invalidate_texture_thumbnail", None)
                     if callable(invalidate):
                         invalidate(path)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("AssetManager._invalidate_texture_ui_cache.panels", exc)
 
     @classmethod
     def _invalidate_material_ui_cache(cls, path: str) -> None:
@@ -718,9 +720,8 @@ class AssetManager:
                     invalidate = getattr(panel, "invalidate_material_thumbnail", None)
                     if callable(invalidate):
                         invalidate(path)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("AssetManager._invalidate_material_ui_cache.panels", exc)
 
     @classmethod
     def _remove_material_pipeline(cls, material_key: str) -> None:
@@ -771,8 +772,8 @@ class AssetManager:
                         continue
                     setattr(py_comp, "texture_path", "")
                     changed = True
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("AssetManager._clear_deleted_texture_from_active_ui.scan", exc)
             return False
 
         if changed:
@@ -782,9 +783,11 @@ class AssetManager:
                 sfm = SceneFileManager.instance()
                 if sfm is not None:
                     sfm.mark_dirty()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed(
+                    "AssetManager._clear_deleted_texture_from_active_ui.mark_dirty",
+                    exc,
+                )
 
         return changed
 

--- a/python/Infernux/debug.py
+++ b/python/Infernux/debug.py
@@ -387,6 +387,26 @@ class Debug:
         DebugConsole.instance().log(entry)
     
     @staticmethod
+    def log_suppressed(where: str, exc: BaseException, context: Any = None):
+        """Log an exception that was deliberately swallowed by the caller.
+
+        Standardises the legacy
+        ``Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")`` pattern
+        and routes it through ``log_warning`` so suppressed-but-bug-shaped
+        events are visible in the editor console by default. The previous
+        ``Debug.log`` (info-level) variant made these invisible behind log
+        filters and effectively hid recurring state corruption.
+
+        Args:
+            where: Short human-readable label of the suppression site
+                (e.g. ``"DeferredTaskRunner.tick"``).
+            exc: The caught exception instance.
+            context: Optional context object forwarded to the console entry.
+        """
+        message = f"[Suppressed @ {where}] {type(exc).__name__}: {exc}"
+        Debug.log_warning(message, context=context)
+
+    @staticmethod
     def log_assert(condition: bool, message: Any = "Assertion failed", context: Any = None):
         """
         Log an assertion failure if condition is False.

--- a/python/Infernux/debug.pyi
+++ b/python/Infernux/debug.pyi
@@ -118,6 +118,18 @@ class Debug:
         """Log an exception to the console."""
         ...
     @staticmethod
+    def log_suppressed(
+        where: str,
+        exc: BaseException,
+        context: Any = ...,
+    ) -> None:
+        """Log an exception that was deliberately swallowed by the caller.
+
+        Routes through ``log_warning`` so suppressed events are visible
+        in the editor console.
+        """
+        ...
+    @staticmethod
     def log_assert(
         condition: bool, message: Any = ..., context: Any = ...
     ) -> None:

--- a/python/Infernux/engine/_scene_prefab.py
+++ b/python/Infernux/engine/_scene_prefab.py
@@ -47,7 +47,8 @@ class ScenePrefabMixin:
             return False
 
         from Infernux.lib import SceneManager
-        from Infernux.engine.prefab_manager import _restore_pending_py_components, _strip_prefab_runtime_fields
+        from Infernux.engine.component_restore import restore_pending_py_components
+        from Infernux.engine.prefab_manager import _strip_prefab_runtime_fields
         from Infernux.engine.ui.selection_manager import SelectionManager
 
         active_scene = SceneManager.instance().get_active_scene()
@@ -115,7 +116,7 @@ class ScenePrefabMixin:
 
         if new_scene.has_pending_py_components():
             try:
-                _restore_pending_py_components(new_scene, self._asset_database)
+                restore_pending_py_components(new_scene, asset_database=self._asset_database)
             except Exception as exc:
                 Debug.log_error(f"Failed to restore prefab Python components: {exc}")
 
@@ -191,7 +192,7 @@ class ScenePrefabMixin:
             return False
 
         from Infernux.lib import SceneManager
-        from Infernux.engine.prefab_manager import _restore_pending_py_components
+        from Infernux.engine.component_restore import restore_pending_py_components
 
         # Always save the prefab on exit
         if self.prefab_mode_path:
@@ -237,7 +238,7 @@ class ScenePrefabMixin:
             scene.deserialize(self._previous_scene_json)
             if scene.has_pending_py_components():
                 try:
-                    _restore_pending_py_components(scene, self._asset_database)
+                    restore_pending_py_components(scene, asset_database=self._asset_database)
                 except Exception as exc:
                     Debug.log_error(f"Failed to restore scene Python components: {exc}")
 

--- a/python/Infernux/engine/_scene_prefab.py
+++ b/python/Infernux/engine/_scene_prefab.py
@@ -206,9 +206,8 @@ class ScenePrefabMixin:
                 saved_prefab_guid = self._asset_database.get_guid_from_path(
                     self.prefab_mode_path
                 ) or None
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("ScenePrefabMixin.exit_prefab_mode.resolve_prefab_guid", exc)
 
         # Clear the RenderStack singleton before the swap — matches the
         # pattern in _do_open_scene / _do_new_scene to avoid stale refs.
@@ -359,9 +358,11 @@ class ScenePrefabMixin:
                         p = self._asset_database.get_path_from_guid(guid)
                         if p and os.path.isfile(p):
                             guid_to_path[guid] = p
-                    except Exception as _exc:
-                        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                        pass
+                    except Exception as exc:
+                        Debug.log_suppressed(
+                            f"ScenePrefabMixin.refresh_prefab_instances.resolve[{guid[:8]}]",
+                            exc,
+                        )
                 children = list(obj.get_children()) if hasattr(obj, 'get_children') else []
                 _walk(children)
 

--- a/python/Infernux/engine/bootstrap.py
+++ b/python/Infernux/engine/bootstrap.py
@@ -53,9 +53,8 @@ def _signal_progress(current_step: int, total: int, message: str) -> None:
             f.write(f"LOADING:{current_step}/{total}:{message}\n")
             f.flush()
             os.fsync(f.fileno())
-    except OSError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-        pass
+    except OSError as exc:
+        Debug.log_suppressed("EditorBootstrap.write_loading_progress", exc)
 
 from ._bootstrap_panels import BootstrapPanelsMixin
 from ._bootstrap_selection import BootstrapSelectionMixin
@@ -213,8 +212,8 @@ class EditorBootstrap(BootstrapPanelsMixin, BootstrapSelectionMixin, BootstrapWi
         # Route through the same preview cache API used by inspector.
         try:
             from Infernux.engine.ui.asset_resource_preview import get_resource_preview_texture_id
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("EditorBootstrap.material_preview_prewarm.import", exc)
             return
 
         class _BootstrapPreviewPanel:
@@ -239,8 +238,11 @@ class EditorBootstrap(BootstrapPanelsMixin, BootstrapSelectionMixin, BootstrapWi
                 ))
                 if tex_id:
                     warmed += 1
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed(
+                    f"EditorBootstrap.material_preview_prewarm[{os.path.basename(mat_path)}]",
+                    exc,
+                )
                 continue
 
         Debug.log_internal(f"Material preview prewarm: {warmed}/{len(material_paths)}")
@@ -252,8 +254,8 @@ class EditorBootstrap(BootstrapPanelsMixin, BootstrapSelectionMixin, BootstrapWi
             try:
                 native.flush_all_material_previews()
                 Debug.log_internal("Material preview prewarm: flush complete")
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed("EditorBootstrap.material_preview_prewarm.flush_all", exc)
 
     def _create_managers(self):
         from Infernux.engine.undo import UndoManager

--- a/python/Infernux/engine/bootstrap_hierarchy/_prefab_clipboard.py
+++ b/python/Infernux/engine/bootstrap_hierarchy/_prefab_clipboard.py
@@ -196,7 +196,8 @@ def wire_clipboard(ctx):
             return False
         from Infernux.lib import SceneManager
         from Infernux.engine.undo import CompoundCommand, CreateGameObjectCommand, UndoManager
-        from Infernux.engine.prefab_manager import _restore_pending_py_components, _strip_prefab_runtime_fields
+        from Infernux.engine.component_restore import restore_pending_py_components
+        from Infernux.engine.prefab_manager import _strip_prefab_runtime_fields
         import json
         scene = SceneManager.instance().get_active_scene()
         if not scene:
@@ -223,7 +224,7 @@ def wire_clipboard(ctx):
         if created and scene.has_pending_py_components():
             sfm2 = bs.scene_file_manager
             adb = getattr(sfm2, "_asset_database", None) if sfm2 else None
-            _restore_pending_py_components(scene, asset_database=adb)
+            restore_pending_py_components(scene, asset_database=adb)
         if not created:
             return False
         cids = [o.id for o in created]

--- a/python/Infernux/engine/bootstrap_project.py
+++ b/python/Infernux/engine/bootstrap_project.py
@@ -7,6 +7,7 @@ callbacks to a C++ ``ProjectPanel`` instance.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -271,8 +272,11 @@ def wire_project_callbacks(bs: EditorBootstrap) -> None:
                 load_component_from_file, ScriptLoadError)
             load_component_from_file(file_path)
             return True
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed(
+                f"bootstrap_project.validate_script_component[{os.path.basename(file_path)}]",
+                exc,
+            )
             return False
 
     pp.validate_script_component = _validate_script_component
@@ -283,9 +287,8 @@ def wire_project_callbacks(bs: EditorBootstrap) -> None:
             from Infernux.engine.ui.asset_details_renderer import (
                 invalidate_asset)
             invalidate_asset(path)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("bootstrap_project.invalidate_asset_inspector", exc)
 
     pp.invalidate_asset_inspector = _invalidate_asset_inspector
 
@@ -303,9 +306,8 @@ def wire_project_callbacks(bs: EditorBootstrap) -> None:
                 files = im.get_dropped_files()
                 if files and pp.get_current_path():
                     pp.receive_dropped_files(files)
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("bootstrap_project.ExternalDropForwarder.on_render", exc)
 
     bs._external_drop_forwarder = _ExternalDropForwarder()
     bs.engine.register_gui("project_drop_forwarder", bs._external_drop_forwarder)

--- a/python/Infernux/engine/component_restore.py
+++ b/python/Infernux/engine/component_restore.py
@@ -195,9 +195,8 @@ def restore_pending_py_components(
             from Infernux.renderstack.discovery import discover_passes, discover_pipelines
             discover_passes()
             discover_pipelines()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("restore_pending_py_components.pre_warm_renderstack", exc)
 
     restored = 0
     deferred_callbacks: List[Any] = []
@@ -258,9 +257,11 @@ def restore_pending_py_components(
                     broken = _make_broken_component(pc, None)
                     broken._broken_error = f"Restore failed: {exc}"
                     go.add_py_component(broken)
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed(
+                    f"restore_pending_py_components.broken_fallback[{pc.type_name}]",
+                    exc,
+                )
 
     # Batch on_after_deserialize
     for comp in deferred_callbacks:

--- a/python/Infernux/engine/engine.py
+++ b/python/Infernux/engine/engine.py
@@ -172,17 +172,15 @@ class Engine():
             from Infernux.engine.deferred_task import DeferredTaskRunner
             try:
                 DeferredTaskRunner.instance().tick()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("Engine.pre_gui_tick.DeferredTaskRunner", exc)
             try:
                 from Infernux.engine.ui.window_manager import WindowManager
                 manager = WindowManager.instance()
                 if manager is not None:
                     manager.process_pending_actions()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("Engine.pre_gui_tick.WindowManager", exc)
         self._engine.set_pre_gui_callback(_pre_gui_tick)
 
         # Install a post-draw callback that runs AFTER GPU submit + present.
@@ -203,14 +201,12 @@ class Engine():
             if sfm is not None:
                 try:
                     sfm.poll_pending_save()
-                except Exception as _exc:
-                    Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                    pass
+                except Exception as exc:
+                    Debug.log_suppressed("Engine.post_draw_tick.poll_pending_save", exc)
                 try:
                     sfm.poll_deferred_load()
-                except Exception as _exc:
-                    Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                    pass
+                except Exception as exc:
+                    Debug.log_suppressed("Engine.post_draw_tick.poll_deferred_load", exc)
             # Periodic manual GC: gen0 every 120 frames (~1s at 120fps),
             # gen1 every 600 frames (~5s), full every 3000 frames (~25s).
             _gc_frame[0] += 1
@@ -292,9 +288,8 @@ class Engine():
         try:
             from Infernux.core.material import Material
             Material.flush_all_pending()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("Engine._flush_pending_material_saves", exc)
 
     def _clear_uploaded_gizmos(self):
         """Clear uploaded gizmo buffers once when Scene View is hidden."""
@@ -349,9 +344,8 @@ class Engine():
         if callable(self._before_exit_callback):
             try:
                 self._before_exit_callback()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("Engine.exit.before_exit_callback", exc)
 
         # Safety net: if cleanup hangs (C++ deadlock, thread stuck), force-kill
         # the process after a generous timeout so we never leave zombie procs.
@@ -409,9 +403,8 @@ class Engine():
             sm = _NativeSceneMgr.instance()
             if sm:
                 sm.stop()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("Engine._shutdown_play_mode.SceneManager.stop", exc)
 
         # 2. Destroy all live Python components (on_destroy + GC helpers)
         try:
@@ -420,13 +413,14 @@ class Engine():
                 for comp in list(comp_list):
                     try:
                         comp._call_on_destroy()
-                    except Exception as _exc:
-                        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                        pass
+                    except Exception as exc:
+                        Debug.log_suppressed(
+                            f"Engine._shutdown_play_mode.on_destroy[{type(comp).__name__}]",
+                            exc,
+                        )
             InxComponent._clear_all_instances()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("Engine._shutdown_play_mode.clear_all_instances", exc)
 
         # 3. Flip state to EDIT so nothing else treats us as playing
         pmm._state = PlayModeState.EDIT
@@ -463,15 +457,18 @@ class Engine():
                     return False
                 try:
                     save_handler()
-                except Exception as _exc:
-                    Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+                except Exception as exc:
+                    Debug.log_suppressed(
+                        f"Engine._confirm_dirty_panels_before_exit.save_handler[{panel_id}]",
+                        exc,
+                    )
                     return False
                 if is_panel_dirty(panel_id):
                     # Save was cancelled or failed.
                     return False
             return True
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("Engine._confirm_dirty_panels_before_exit", exc)
             return True
 
     def set_gui_font(self, font_path, font_size=18):

--- a/python/Infernux/engine/play_mode.py
+++ b/python/Infernux/engine/play_mode.py
@@ -128,8 +128,8 @@ class PlayModeManager(PlayModeSerializationMixin):
             return
         try:
             object_id = int(game_object.id)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("PlayModeManager.register_runtime_hidden_object", exc)
             return
         if object_id > 0:
             self._runtime_hidden_object_ids.add(object_id)
@@ -140,8 +140,8 @@ class PlayModeManager(PlayModeSerializationMixin):
     def is_runtime_hidden_object_id(self, object_id: int) -> bool:
         try:
             return int(object_id) in self._runtime_hidden_object_ids
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("PlayModeManager.is_runtime_hidden_object_id", exc)
             return False
     
     # ========================================================================
@@ -186,9 +186,9 @@ class PlayModeManager(PlayModeSerializationMixin):
         try:
             from Infernux.timing import Time
             Time._time_scale = self._time_scale
-        except ImportError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass  # Time module not available yet during early init
+        except ImportError:
+            # Benign during early bootstrap before Infernux.timing is reachable.
+            pass
         except Exception as exc:
             Debug.log_warning(f"Failed to sync time_scale to Time class: {exc}")
     
@@ -282,9 +282,8 @@ class PlayModeManager(PlayModeSerializationMixin):
             try:
                 from Infernux.components.builtin.sprite_renderer import SpriteRenderer
                 SpriteRenderer.init_all_in_scene()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("PlayModeManager.step_enter.SpriteRenderer.init_all_in_scene", exc)
             # 1. Serialize scene + init timing (do not clear undo — asset editors keep history)
             self._save_scene_state()
             self._last_frame_time = time.time()
@@ -293,9 +292,11 @@ class PlayModeManager(PlayModeSerializationMixin):
             try:
                 from Infernux.timing import Time
                 Time._reset()
-            except (ImportError, Exception) as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except ImportError:
+                # Time module not yet importable during early bootstrap — benign.
                 pass
+            except Exception as exc:
+                Debug.log_suppressed("PlayModeManager.step_enter.Time._reset", exc)
             from Infernux.components.builtin_component import BuiltinComponent
             BuiltinComponent._clear_cache()
 
@@ -307,8 +308,8 @@ class PlayModeManager(PlayModeSerializationMixin):
             try:
                 from Infernux.core.material import Material
                 Material._suppress_auto_save = True
-            except ImportError as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except ImportError:
+                # Material module not yet importable — benign during bootstrap.
                 pass
             self._notify_state_change(old_state, self._state)
 
@@ -389,8 +390,8 @@ class PlayModeManager(PlayModeSerializationMixin):
         try:
             from Infernux.core.material import Material
             Material._suppress_auto_save = False
-        except ImportError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except ImportError:
+            # Material module not yet importable — benign during teardown.
             pass
 
         # 3. Discard any pending runtime scene load queued by user scripts
@@ -398,9 +399,8 @@ class PlayModeManager(PlayModeSerializationMixin):
         try:
             from Infernux.scene import SceneManager as _SceneMgr
             _SceneMgr._pending_scene_load = None
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("PlayModeManager.exit_play_mode.discard_pending_load", exc)
 
         from Infernux.components.builtin_component import BuiltinComponent
         BuiltinComponent._clear_cache()
@@ -566,9 +566,8 @@ class PlayModeManager(PlayModeSerializationMixin):
             if self._native_engine is not None:
                 try:
                     Time._game_delta_time = self._native_engine.get_game_only_frame_ms() / 1000.0
-                except Exception as _exc:
-                    Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                    pass
+                except Exception as exc:
+                    Debug.log_suppressed("PlayModeManager.tick.read_game_only_frame_ms", exc)
         except ImportError:
             self._delta_time = min(raw_dt * self._time_scale, 0.1)
             self._total_play_time += self._delta_time
@@ -779,9 +778,8 @@ class PlayModeManager(PlayModeSerializationMixin):
             try:
                 from Infernux.engine.undo import _bump_inspector_structure
                 _bump_inspector_structure()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("PlayModeManager.reload_components.bump_inspector_structure", exc)
             Debug.log_internal(f"Reloaded {reloaded_count} component(s) from {os.path.basename(script_path_abs)}")
 
     # ========================================================================
@@ -867,9 +865,8 @@ class PlayModeManager(PlayModeSerializationMixin):
         if self._native_engine is not None:
             try:
                 self._native_engine.set_play_mode_rendering(is_playing)
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("PlayModeManager._notify_state_change.set_play_mode_rendering", exc)
 
         event = PlayModeEvent(
             old_state=old_state,

--- a/python/Infernux/engine/player_bootstrap.py
+++ b/python/Infernux/engine/player_bootstrap.py
@@ -46,9 +46,8 @@ def _plog(msg):
     try:
         with open(path, "a", encoding="utf-8") as f:
             f.write(str(msg) + "\n")
-    except OSError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-        pass
+    except OSError as exc:
+        Debug.log_suppressed("player_bootstrap.write_player_log", exc)
 
 
 class PlayerBootstrap:
@@ -92,8 +91,9 @@ class PlayerBootstrap:
             from Infernux.engine.project_requirements import ensure_project_requirements
 
             ensure_project_requirements(self.project_path, auto_install=False)
-        except ImportError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except ImportError:
+            # Optional packaging helper missing — runtime continues without
+            # auto-install; happens in slim distribution variants.
             pass
 
     def _init_engine(self):
@@ -162,9 +162,8 @@ class PlayerBootstrap:
             try:
                 with open(bs_path, "r", encoding="utf-8", errors="replace") as _f:
                     data = _json.load(_f)
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("player_bootstrap.load_build_manifest", exc)
         scenes = data.get("scenes", [])
         if not scenes:
             Debug.log_warning("No scenes in BuildSettings.json — starting with empty scene")

--- a/python/Infernux/engine/prefab_manager.py
+++ b/python/Infernux/engine/prefab_manager.py
@@ -11,6 +11,7 @@ import os
 import copy
 
 from Infernux.debug import Debug
+from Infernux.engine.component_restore import restore_pending_py_components
 
 PREFAB_EXTENSION = ".prefab"
 PREFAB_VERSION = 1
@@ -116,7 +117,7 @@ def _get_cached_prefab_template(file_path: str, resolved_guid: str, asset_databa
         return None
 
     try:
-        _restore_pending_py_components(template_scene, asset_database)
+        restore_pending_py_components(template_scene, asset_database=asset_database)
     except Exception as exc:
         Debug.log_error(f"Failed to restore cached prefab Python components: {exc}")
         template_scene.destroy_game_object(template)
@@ -263,7 +264,7 @@ def instantiate_prefab(file_path: str = None, guid: str = None,
 
     # Restore Python components that were collected as pending during native clone.
     try:
-        _restore_pending_py_components(scene, asset_database)
+        restore_pending_py_components(scene, asset_database=asset_database)
     except Exception as exc:
         Debug.log_error(f"Failed to restore prefab Python components: {exc}")
 
@@ -285,9 +286,3 @@ def _strip_prefab_fields(obj_data: dict):
     obj_data.pop("prefab_root", None)
     for child in obj_data.get("children", []):
         _strip_prefab_fields(child)
-
-
-def _restore_pending_py_components(scene, asset_database=None):
-    """Restore any pending Python components after prefab instantiation."""
-    from Infernux.engine.component_restore import restore_pending_py_components
-    restore_pending_py_components(scene, asset_database=asset_database)

--- a/python/Infernux/engine/prefab_manager.py
+++ b/python/Infernux/engine/prefab_manager.py
@@ -44,8 +44,10 @@ def _get_file_stamp(file_path: str):
     try:
         stat = os.stat(file_path)
         return (stat.st_mtime_ns, stat.st_size)
-    except OSError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except OSError:
+        # Missing file is not an error in the cache-stamp probe path; the
+        # caller (cached prefab template lookup) treats None as "no cache
+        # entry" and re-reads the prefab from disk if it exists.
         return None
 
 
@@ -107,9 +109,8 @@ def _get_cached_prefab_template(file_path: str, resolved_guid: str, asset_databa
         try:
             template_scene.destroy_game_object(old_template)
             template_scene.process_pending_destroys()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except Exception as exc:
+            Debug.log_suppressed("prefab_manager._get_cached_prefab_template.destroy_old", exc)
 
     template = template_scene.instantiate_from_json(json.dumps(template_payload), None)
     if template is None:

--- a/python/Infernux/engine/preferences_store.py
+++ b/python/Infernux/engine/preferences_store.py
@@ -30,9 +30,8 @@ def _prefs_path() -> str:
             ctypes.windll.shell32.SHGetFolderPathW(None, 5, None, 0, buf)
             if buf.value:
                 docs = pathlib.Path(buf.value)
-        except (OSError, ValueError) as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except (OSError, ValueError) as exc:
+            Debug.log_suppressed("preferences_store.resolve_documents_dir", exc)
     else:
         docs = pathlib.Path.home() / "Documents"
 
@@ -67,8 +66,8 @@ class PreferencesStore:
             with open(self._path, "r", encoding="utf-8") as f:
                 data = json.load(f)
             return data if isinstance(data, dict) else {}
-        except (json.JSONDecodeError, OSError) as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except (json.JSONDecodeError, OSError) as exc:
+            Debug.log_suppressed("preferences_store.load", exc)
             return {}
 
     def save(self, data: dict) -> None:
@@ -76,9 +75,8 @@ class PreferencesStore:
         try:
             with open(self._path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
-        except OSError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except OSError as exc:
+            Debug.log_suppressed("preferences_store.save", exc)
 
     def get(self, key: str, default=None):
         """Return a single preference value."""

--- a/python/Infernux/engine/project_context.py
+++ b/python/Infernux/engine/project_context.py
@@ -149,8 +149,8 @@ def get_script_module_name(path: Optional[str]) -> Optional[str]:
     try:
         if os.path.commonpath([resolved_abs, assets_root]) != assets_root:
             return None
-    except ValueError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except ValueError as exc:
+        Debug.log_suppressed("project_context.normalize_relative_path", exc)
         return None
 
     rel_path = os.path.relpath(resolved_abs, assets_root)
@@ -213,9 +213,8 @@ def get_script_import_paths(path: Optional[str] = None) -> list[str]:
                 if parent_dir and parent_dir not in roots:
                     roots.append(parent_dir)
                 return roots
-        except ValueError as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-            pass
+        except ValueError as exc:
+            Debug.log_suppressed("project_context.collect_assets_roots", exc)
 
     if assets_root:
         roots.append(assets_root)
@@ -284,9 +283,8 @@ def resolve_guid_to_path(guid: str) -> Optional[str]:
                 try:
                     with open(manifest, "r", encoding="utf-8") as f:
                         _guid_manifest = json.load(f)
-                except (json.JSONDecodeError, OSError) as _exc:
-                    Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                    pass
+                except (json.JSONDecodeError, OSError) as exc:
+                    Debug.log_suppressed("project_context.load_guid_manifest", exc)
     if _guid_manifest and guid and guid in _guid_manifest:
         rel = _guid_manifest[guid]
         if _project_root:

--- a/python/Infernux/engine/scene_manager.py
+++ b/python/Infernux/engine/scene_manager.py
@@ -85,9 +85,8 @@ def _effective_project_root() -> Optional[str]:
         services = EditorServices.instance()
         if services and services.project_path and os.path.isdir(services.project_path):
             return os.path.abspath(services.project_path)
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-        pass
+    except Exception as exc:
+        Debug.log_suppressed("scene_manager._effective_project_root.editor_services", exc)
 
     cwd = os.getcwd()
     if os.path.isdir(os.path.join(cwd, "Assets")):
@@ -231,8 +230,8 @@ class SceneFileManager(ScenePrefabMixin, SceneSaveMixin, SceneConfirmationMixin)
             if native is not None:
                 self._engine = native
             return native
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("SceneFileManager._native_engine_for_close.editor_services", exc)
             return None
 
     # ------------------------------------------------------------------
@@ -538,9 +537,8 @@ class SceneFileManager(ScenePrefabMixin, SceneSaveMixin, SceneConfirmationMixin)
         if self._engine:
             try:
                 self._engine.pump_events()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
-                pass
+            except Exception as exc:
+                Debug.log_suppressed("SceneFileManager.pump_events", exc)
 
     def _prepare_native_scene_swap(self):
         """Clear native editor state and drain GPU work before scene replacement."""

--- a/python/Infernux/engine/ui/closable_panel.py
+++ b/python/Infernux/engine/ui/closable_panel.py
@@ -181,6 +181,20 @@ class ClosablePanel(InxGUIRenderable):
             return
 
         ClosablePanel._active_panel_id = self._window_id
+
+        # Canonical channel: EditorEventBus.PANEL_FOCUSED.
+        # The legacy class-level callback is kept for now so existing
+        # bootstrap wiring keeps working, but new subscribers should prefer
+        # EditorEventBus to avoid the dual-channel split that previously
+        # left PANEL_FOCUSED defined-but-never-emitted.
+        try:
+            from .event_bus import EditorEvent, EditorEventBus
+            EditorEventBus.instance().emit(EditorEvent.PANEL_FOCUSED, self._window_id)
+        except Exception:
+            # Event bus unavailable during bootstrap import — fall through to the
+            # legacy callback so the focus signal is never silently lost.
+            pass
+
         cb = ClosablePanel._on_panel_focus_changed
         if cb is not None:
             cb(old_id, self._window_id)

--- a/python/Infernux/engine/ui/editor_panel.py
+++ b/python/Infernux/engine/ui/editor_panel.py
@@ -466,5 +466,8 @@ class EditorPanel(ClosablePanel):
         self._pop_window_style(ctx)
 
         # Fire the close hook when the panel is closed.
-        if not self._is_open:
+        # Also reset _enable_called so a future reopen runs on_enable() again,
+        # matching the documented "created or reopened" contract.
+        if not self._is_open and self._enable_called:
+            self._enable_called = False
             self.on_disable()

--- a/python/Infernux/engine/ui/window_manager.py
+++ b/python/Infernux/engine/ui/window_manager.py
@@ -32,16 +32,29 @@ class WindowInfo:
 
 
 class WindowManager:
-    """
-    Centralized window manager for the editor.
-    
+    """Centralized window manager for the editor.
+
     Features:
-    - Register window types for the Window menu
-    - Track open/closed windows
-    - Create new window instances
-    - Provide window state to panels
+    - Register window types for the Window menu.
+    - Track open/closed state per window_id.
+    - Create new window instances.
+    - Persist panel state across editor restarts.
+
+    Two distinct meanings of "closed" coexist on purpose:
+
+    * **Builtin / singleton panels** stay registered with the native ImGui
+      renderer for the entire editor session and only flip ``_is_open`` to
+      hide their window. This is required because re-registering an
+      ``InxGUIRenderable`` mid-frame races the docking layout.
+    * **Dynamic panels** (e.g. animation / 2D-anim editors opened from the
+      Window menu) are unregistered from the native renderer when closed and
+      lazily re-created on the next ``open_window``.
+
+    Always go through ``set_window_open`` / ``open_window`` / ``close_window``
+    rather than mutating ``_is_open`` directly so persistence and pending
+    register/unregister actions stay consistent.
     """
-    
+
     _instance: Optional['WindowManager'] = None
     _RESET_REQUIRED_PANEL_IDS = {"inspector", "project"}
     

--- a/python/Infernux/engine/undo/_component_commands.py
+++ b/python/Infernux/engine/undo/_component_commands.py
@@ -22,8 +22,8 @@ def _snapshot_py_fields(py_comp: Any) -> str:
         return ""
     try:
         return py_comp._serialize_fields()
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._component_commands._snapshot_py_fields", exc)
         return ""
 
 
@@ -49,16 +49,16 @@ def _find_py_ordinal(object_id: int, py_comp: Any) -> int:
             try:
                 ct = _comp_type_name_of(current)
                 cg = getattr(current, '_script_guid', '') or ''
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed("undo._component_commands._find_py_ordinal.read_meta", exc)
                 continue
             if ct != target_type or cg != target_guid:
                 continue
             if current is py_comp:
                 return ordinal
             ordinal += 1
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._component_commands._find_py_ordinal.iter", exc)
     return 0
 
 
@@ -73,8 +73,8 @@ def _resolve_live_py(obj, type_name: str, script_guid: str,
         for current in obj.get_py_components():
             if current is fallback:
                 return current
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._component_commands._resolve_live_py.fallback_lookup", exc)
     return None
 
 
@@ -115,13 +115,13 @@ def _instantiate_py_snapshot(type_name: str, script_guid: str,
 
     try:
         instance.enabled = enabled
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._component_commands._instantiate_py_snapshot.set_enabled", exc)
     if script_guid:
         try:
             instance._script_guid = script_guid
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._component_commands._instantiate_py_snapshot.set_script_guid", exc)
     return instance
 
 
@@ -135,8 +135,8 @@ def _snapshot_and_remove_native(object_id: int, type_name: str,
     if hasattr(live, "serialize"):
         try:
             json_snap = live.serialize()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._component_commands._snapshot_and_remove_native.serialize", exc)
     obj.remove_component(live)
     _invalidate_builtin_wrapper(live)
     _bump_inspector_structure()
@@ -154,8 +154,8 @@ def _add_native_from_snapshot(object_id: int, type_name: str,
     if json_snapshot and hasattr(result, "deserialize"):
         try:
             result.deserialize(json_snapshot)
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._component_commands._add_native_from_snapshot.deserialize", exc)
     _bump_inspector_structure()
     _notify_gizmos_scene_changed()
 
@@ -184,8 +184,8 @@ def _add_py_from_snapshot(object_id: int, type_name: str, script_guid: str,
     if hasattr(instance, '_call_on_after_deserialize'):
         try:
             instance._call_on_after_deserialize()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._component_commands._add_py_from_snapshot.on_after_deserialize", exc)
     _bump_inspector_structure()
     return instance
 
@@ -228,8 +228,8 @@ class RemoveNativeComponentCommand(UndoCommand):
         if comp_ref is not None and hasattr(comp_ref, "serialize"):
             try:
                 self._json_snapshot = comp_ref.serialize()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed("undo._component_commands.RemoveNativeComponentCommand.snapshot", exc)
 
     def execute(self) -> None:
         self._do_remove()

--- a/python/Infernux/engine/undo/_helpers.py
+++ b/python/Infernux/engine/undo/_helpers.py
@@ -60,14 +60,14 @@ def _resolve_target(stored_ref: Any, game_object_id: int,
         live = obj.get_component(comp_type_name)
         if live is not None:
             return live
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._resolve_target.get_component", exc)
     try:
         for pc in obj.get_py_components():
             if type(pc).__name__ == comp_type_name:
                 return pc
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._resolve_target.get_py_components", exc)
     return None
 
 
@@ -80,14 +80,14 @@ def _find_live_native_component(obj, type_name: str):
             c = obj.get_component(type_name)
             if c is not None:
                 return c
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._find_live_native_component.get_component", exc)
     try:
         for c in obj.get_components():
             if getattr(c, 'type_name', None) == type_name:
                 return c
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._find_live_native_component.get_components", exc)
     return None
 
 
@@ -97,8 +97,8 @@ def _get_current_selection_ids() -> List[int]:
         sel = SelectionManager.instance()
         if sel:
             return sel.get_ids()
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._get_current_selection_ids", exc)
     return []
 
 
@@ -106,16 +106,18 @@ def _bump_inspector_structure():
     try:
         from Infernux.engine.ui.inspector_support import bump_component_structure_version
         bump_component_structure_version()
-    except ImportError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except ImportError:
+        # Inspector module not available (e.g. headless / player mode) — no-op.
+        pass
 
 
 def _bump_inspector_values():
     try:
         from Infernux.engine.ui.inspector_support import bump_inspector_value_generation
         bump_inspector_value_generation()
-    except ImportError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except ImportError:
+        # Inspector module not available (e.g. headless / player mode) — no-op.
+        pass
 
 
 def _require_scene_object(object_id: int, label: str):
@@ -136,8 +138,8 @@ def _notify_gizmos_scene_changed():
 def _invalidate_builtin_wrapper(comp_ref):
     try:
         comp_id = comp_ref.component_id
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._invalidate_builtin_wrapper.read_component_id", exc)
         return
     from Infernux.components.builtin_component import BuiltinComponent
     wrapper = BuiltinComponent._wrapper_cache.get(comp_id)
@@ -148,8 +150,9 @@ def _invalidate_builtin_wrapper(comp_ref):
 def _invalidate_builtin_wrappers_for_tree(obj):
     try:
         from Infernux.components.builtin_component import BuiltinComponent
-    except ImportError as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except ImportError:
+        # BuiltinComponent module not yet available — wrappers will lazily
+        # rebuild themselves the next time they are queried.
         return
     cache = BuiltinComponent._wrapper_cache
     pending = [obj]
@@ -164,12 +167,12 @@ def _invalidate_builtin_wrappers_for_tree(obj):
                     wrapper = cache.get(comp_id)
                     if wrapper is not None:
                         wrapper._invalidate_native_binding()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._invalidate_builtin_wrappers_for_tree.get_components", exc)
         try:
             pending.extend(current.get_children())
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._invalidate_builtin_wrappers_for_tree.get_children", exc)
 
 
 def _destroy_game_object_immediately(scene, obj):
@@ -180,8 +183,8 @@ def _destroy_game_object_immediately(scene, obj):
     if hasattr(scene, "process_pending_destroys"):
         try:
             scene.process_pending_destroys()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._destroy_game_object_immediately.process_pending_destroys", exc)
     _bump_inspector_structure()
     _notify_gizmos_scene_changed()
 

--- a/python/Infernux/engine/undo/_property_commands.py
+++ b/python/Infernux/engine/undo/_property_commands.py
@@ -183,8 +183,8 @@ class MaterialJsonCommand(UndoCommand):
                 try:
                     from Infernux.core.assets import AssetManager
                     AssetManager.on_material_saved(fp)
-                except Exception as _exc:
-                    Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+                except Exception as exc:
+                    Debug.log_suppressed("undo._property_commands.AssetManager.on_material_saved", exc)
         if self._refresh_callback:
             self._refresh_callback(self._material)
 

--- a/python/Infernux/engine/undo/_renderstack.py
+++ b/python/Infernux/engine/undo/_renderstack.py
@@ -73,8 +73,11 @@ def restore_renderstack(stack: Any, json_str: str) -> None:
         for name, val in data["pipeline_params"].items():
             try:
                 setattr(pipeline, name, val)
-            except (AttributeError, TypeError) as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except (AttributeError, TypeError) as exc:
+                Debug.log_suppressed(
+                    f"undo._renderstack.restore_pipeline_param[{name}]",
+                    exc,
+                )
 
     current_names = [e.render_pass.name for e in list(stack.pass_entries)]
     for name in current_names:

--- a/python/Infernux/engine/undo/_snapshots.py
+++ b/python/Infernux/engine/undo/_snapshots.py
@@ -19,8 +19,8 @@ def _get_live_game_object(game_object_id: int):
         return None
     try:
         return scene.find_by_id(game_object_id)
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._snapshots._get_live_game_object.find_by_id", exc)
         return None
 
 
@@ -32,8 +32,8 @@ def _get_live_transform(game_object_id: int):
         t = obj.get_transform()
         if t is not None:
             return t
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._snapshots._get_live_transform.get_transform", exc)
     return getattr(obj, 'transform', None)
 
 
@@ -56,14 +56,14 @@ def _get_nth_live_native_component(game_object_id: int, type_name: str,
                     continue
                 if isinstance(comp, InxComponent) or hasattr(comp, 'get_py_component'):
                     continue
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed("undo._snapshots._get_nth_live_native_component.filter", exc)
                 continue
             if match_index == ordinal:
                 return comp
             match_index += 1
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._snapshots._get_nth_live_native_component.iter", exc)
     return None
 
 
@@ -83,14 +83,14 @@ def _get_nth_live_py_component(game_object_id: int, type_name: str,
                     continue
                 if getattr(comp, '_is_destroyed', False):
                     continue
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed("undo._snapshots._get_nth_live_py_component.filter", exc)
                 continue
             if match_index == ordinal:
                 return comp
             match_index += 1
-    except Exception as _exc:
-        Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+    except Exception as exc:
+        Debug.log_suppressed("undo._snapshots._get_nth_live_py_component.iter", exc)
     return None
 
 

--- a/python/Infernux/engine/undo/_trackers.py
+++ b/python/Infernux/engine/undo/_trackers.py
@@ -101,8 +101,8 @@ class InspectorUndoTracker:
             return
         try:
             pre = snapshot_fn()
-        except Exception as _exc:
-            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+        except Exception as exc:
+            Debug.log_suppressed("undo._trackers.snapshot_fn(pre)", exc)
             return
         entry = _TrackedEntry(pre, snapshot_fn, restore_fn, description, marks_dirty)
         entry.seen_generation = self._frame_generation
@@ -132,8 +132,8 @@ class InspectorUndoTracker:
         for key, entry in self._entries.items():
             try:
                 post = entry.snapshot_fn()
-            except Exception as _exc:
-                Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
+            except Exception as exc:
+                Debug.log_suppressed("undo._trackers.snapshot_fn(post)", exc)
                 continue
             if post != entry.pre_snapshot:
                 cmd = InspectorSnapshotCommand(


### PR DESCRIPTION
# Branch update: `015/fix-tech-debt`

## Summary

This branch pays down cross-cutting technical debt while landing a few substantive engine improvements. Python editor and runtime paths now route suppressed-exception reporting through `Debug.log_suppressed`, the scene and physics layers gained clearer lifecycle invariants and documentation, and several serialization and UI edge cases were tightened (explicit deserialize logging, panel focus semantics, prefab restore cleanup).

On the rendering side, Vulkan work moves toward more realistic async behavior: a dedicated async transfer path for texture uploads, pooled single-use fences and command buffers, descriptor-indexing `UPDATE_AFTER_BIND` fast paths, and centralized GPU drain logic in `MaterialDescriptor`. Fake async readback on `RenderPassOutput` was removed in favor of honest APIs, and unimplemented SRP Vulkan paths are made self-describing. A new C++ `JobSystem` worker pool was added for engine-wide parallel work.

## What changed

- **Core / threading**: Added `JobSystem` (`JobSystem.h` / `JobSystem.cpp`) as an engine-wide C++ worker pool.
- **Vulkan / renderer**: Introduced `AsyncTransferContext` and wired texture uploads through the async transfer queue; extended `VkDeviceContext`, `VkHandle`, and `VkResourceManager` for pooling and transfer-queue usage; enabled descriptor-indexing `UPDATE_AFTER_BIND` fast path where applicable.
- **Materials / SRP**: Centralized GPU drain behavior in `MaterialPipelineManager` / `MaterialDescriptor`; removed the misleading async readback surface from `RenderPassOutput`; improved `ScriptableRenderContext` and shader program handling for incomplete Vulkan paths with clearer behavior.
- **Scene / physics**: Documented the scene rebuild contract in headers; centralized physics ECS/world lifecycle checks; minor collider and scene manager fixes (including missing `InxLog.h` in `Collider.cpp`).
- **Python / editor**: Standardized suppressed-exception logging via `Debug.log_suppressed` across bootstrap, config IO, assets, scene/prefab pipeline, play mode, undo, and components; added `debug.pyi` surface for the new helper.
- **Editor UI**: Unified panel-focus handling and documented Windows message semantics in `closable_panel` / `window_manager` / related UI code.
- **Serialization / prefab**: Surfaced deserialize errors through explicit logging; removed the `_restore_pending_py_components` prefab wrapper indirection.
- **Housekeeping**: Format pass (`check format`); dangling `m_readbackFence` cleanup after async API removal.

## Verification

- [ ] Built the affected targets
- [ ] Ran the relevant tests or static validation
- [ ] Updated docs if behavior or public APIs changed

## Notes for reviewers

- **GPU / threading**: Async transfer queue and fence/CB pooling touch submission ordering and resource lifetime assumptions—pay attention to queue-family ownership, synchronization between graphics and transfer work, and any implicit barriers that moved with texture upload routing.
- **Descriptor indexing**: The `UPDATE_AFTER_BIND` fast path changes binding model expectations; confirm compatibility with shaders and pipeline layouts that still assume dynamic offsets or non-indexed paths.
- **Python logging behavior**: Widespread adoption of `Debug.log_suppressed` may change log volume and wording compared to bare `except` paths; confirm no user-facing regressions in diagnostics workflows.
- **API removal**: Call sites that depended on the old `RenderPassOutput` async readback façade must use the supported path or accept synchronous/explicit readback semantics—double-check no hidden callers remain outside the diff.
- **Scene rebuild contract**: Callers that previously relied on undocumented ordering may need to align with the newly stated contract in `Scene` / `SceneManager` headers.
