### PR TITLE
Infernux MCP Roadmap: Agent-Driven Game Creation and Balatro-Style Evaluation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,33 +75,25 @@ target_include_directories(_Infernux PRIVATE
 if(MSVC)
     target_compile_options(_Infernux PRIVATE
         /utf-8
-        $<$<CONFIG:Release>:/O2>
-        $<$<CONFIG:Release>:/Ob2>
-        $<$<CONFIG:Release>:/Oi>
-        $<$<CONFIG:Release>:/Ot>
-        $<$<CONFIG:Release>:/Oy>
-        $<$<CONFIG:Release>:/Gy>
-        $<$<CONFIG:Release>:/Gw>
-        $<$<CONFIG:Release>:/GL>
     )
 
     target_link_options(_Infernux PRIVATE
-        $<$<CONFIG:Release>:/LTCG>
-        $<$<CONFIG:Release>:/OPT:REF>
-        $<$<CONFIG:Release>:/OPT:ICF>
+        $<$<CONFIG:Release>:/OPT:NOREF>
+        $<$<CONFIG:Release>:/OPT:NOICF>
     )
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     target_compile_options(_Infernux PRIVATE
-        $<$<CONFIG:Release>:-O3>
+        $<$<CONFIG:Release>:-O0>
+        $<$<CONFIG:Release>:-fno-lto>
     )
 
     target_link_options(_Infernux PRIVATE
-        $<$<CONFIG:Release>:-flto>
+        $<$<CONFIG:Release>:-fno-lto>
     )
 endif()
 
-# Prefer whole-program optimization in Release when the toolchain supports it.
-set_property(TARGET _Infernux PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+# Disable target-level IPO/LTO in Release while investigating no-log crashes.
+set_property(TARGET _Infernux PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE FALSE)
 
 # ------------------------------------------------------------------------------
 # SPIRV-Cross (from Vulkan SDK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,10 @@ target_compile_definitions(_Infernux PRIVATE
     $<$<CONFIG:MinSizeRel>:INFERNUX_FILE_LOGGING=1>
     $<$<CONFIG:Release>:INFERNUX_DEFERRED_FILE_LOGGING=1>
     $<$<CONFIG:MinSizeRel>:INFERNUX_DEFERRED_FILE_LOGGING=1>
+    # Vulkan validation layers: on for Debug / RelWithDebInfo (preset "debug"),
+    # off for Release / MinSizeRel (preset "release"). See InxVkCoreModular::Init.
+    $<$<CONFIG:Debug>:INFERNUX_VULKAN_VALIDATION_LAYERS=1>
+    $<$<CONFIG:RelWithDebInfo>:INFERNUX_VULKAN_VALIDATION_LAYERS=1>
 )
 
 target_link_libraries(_Infernux PRIVATE

--- a/cpp/infernux/function/editor/ProjectPanel.cpp
+++ b/cpp/infernux/function/editor/ProjectPanel.cpp
@@ -156,7 +156,8 @@ constexpr float kModelExpandIconSrcPx = 32.0f;
 // Static extension sets
 // ════════════════════════════════════════════════════════════════════
 
-static const std::unordered_set<std::string> sImageExtensions = {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif"};
+static const std::unordered_set<std::string> sImageExtensions = {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif",
+                                                                 ".psd", ".hdr", ".pic",  ".pnm", ".pgm", ".ppm"};
 
 static const std::unordered_set<std::string> sMaterialExtensions = {".mat"};
 
@@ -232,6 +233,9 @@ const std::unordered_map<std::string, ProjectPanel::DragDropInfo> &ProjectPanel:
         {".psd", {"TEXTURE_FILE", "Texture"}},
         {".hdr", {"TEXTURE_FILE", "Texture"}},
         {".pic", {"TEXTURE_FILE", "Texture"}},
+        {".pnm", {"TEXTURE_FILE", "Texture"}},
+        {".pgm", {"TEXTURE_FILE", "Texture"}},
+        {".ppm", {"TEXTURE_FILE", "Texture"}},
         {".wav", {"AUDIO_FILE", "Audio"}},
         {".ttf", {"FONT_FILE", "Font"}},
         {".otf", {"FONT_FILE", "Font"}},

--- a/cpp/infernux/function/renderer/InxVkCoreModular.cpp
+++ b/cpp/infernux/function/renderer/InxVkCoreModular.cpp
@@ -185,6 +185,10 @@ void InxVkCoreModular::Init(InxAppMetadata appMetaData, InxAppMetadata rendererM
     m_deviceConfig.appName = appMetaData.appName ? appMetaData.appName : "Infernux App";
     m_deviceConfig.engineName = rendererMetaData.appName ? rendererMetaData.appName : "Infernux";
 
+#if defined(INFERNUX_VULKAN_VALIDATION_LAYERS)
+    m_deviceConfig.enableValidationLayers = true;
+#endif
+
     // Initialize instance only (device will be created in PrepareSurface after surface is available)
     if (!m_deviceContext.InitializeInstance(m_deviceConfig)) {
         INXLOG_ERROR("Failed to initialize Vulkan instance");

--- a/cpp/infernux/function/renderer/MaterialPipelineManager.cpp
+++ b/cpp/infernux/function/renderer/MaterialPipelineManager.cpp
@@ -1,5 +1,6 @@
 #include "MaterialPipelineManager.h"
 #include "InxRenderStruct.h"
+#include "VertexInputFilter.h"
 #include "vk/VkPipelineHelpers.h"
 #include "vk/VkRenderUtils.h"
 #include <algorithm>
@@ -460,16 +461,18 @@ VkPipeline MaterialPipelineManager::CreatePipelineWithProgram(ShaderProgram *pro
     // Dynamic state
     vkrender::DynamicViewportScissorState dynVpScissor;
 
-    // Vertex input - using standard Vertex structure
+    // Vertex input - expose only attributes consumed by this vertex shader.
+    // This keeps shaders that do not use skinning inputs from producing Vulkan
+    // validation warnings for locations 5/6.
     auto bindingDescription = Vertex::getBindingDescription();
-    auto attributeDescriptions = Vertex::getAttributeDescriptions();
+    auto attributeDescriptions = FilterVertexAttributesForReflection(program->GetVertexReflection());
 
     VkPipelineVertexInputStateCreateInfo vertexInputInfo{};
     vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    vertexInputInfo.vertexBindingDescriptionCount = 1;
-    vertexInputInfo.pVertexBindingDescriptions = &bindingDescription;
+    vertexInputInfo.vertexBindingDescriptionCount = attributeDescriptions.empty() ? 0u : 1u;
+    vertexInputInfo.pVertexBindingDescriptions = attributeDescriptions.empty() ? nullptr : &bindingDescription;
     vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(attributeDescriptions.size());
-    vertexInputInfo.pVertexAttributeDescriptions = attributeDescriptions.data();
+    vertexInputInfo.pVertexAttributeDescriptions = attributeDescriptions.empty() ? nullptr : attributeDescriptions.data();
 
     // Input assembly
     VkPipelineInputAssemblyStateCreateInfo inputAssembly{};

--- a/cpp/infernux/function/renderer/MaterialPipelineManager.cpp
+++ b/cpp/infernux/function/renderer/MaterialPipelineManager.cpp
@@ -472,7 +472,8 @@ VkPipeline MaterialPipelineManager::CreatePipelineWithProgram(ShaderProgram *pro
     vertexInputInfo.vertexBindingDescriptionCount = attributeDescriptions.empty() ? 0u : 1u;
     vertexInputInfo.pVertexBindingDescriptions = attributeDescriptions.empty() ? nullptr : &bindingDescription;
     vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(attributeDescriptions.size());
-    vertexInputInfo.pVertexAttributeDescriptions = attributeDescriptions.empty() ? nullptr : attributeDescriptions.data();
+    vertexInputInfo.pVertexAttributeDescriptions =
+        attributeDescriptions.empty() ? nullptr : attributeDescriptions.data();
 
     // Input assembly
     VkPipelineInputAssemblyStateCreateInfo inputAssembly{};

--- a/cpp/infernux/function/renderer/OutlineRenderer.cpp
+++ b/cpp/infernux/function/renderer/OutlineRenderer.cpp
@@ -14,6 +14,8 @@
 #include "vk/DescriptorBindTrace.h"
 #include "vk/VkPipelineHelpers.h"
 #include "vk/VkRenderUtils.h"
+#include "VertexInputFilter.h"
+#include "shader/ShaderReflection.h"
 #include <function/resources/InxMaterial/InxMaterial.h>
 
 #include <core/error/InxError.h>
@@ -24,6 +26,7 @@
 
 #include <array>
 #include <cstring>
+#include <vector>
 
 namespace infernux
 {
@@ -41,17 +44,32 @@ using DynamicViewportState = infernux::vkrender::DynamicViewportScissorState;
 
 struct MeshVertexInputState
 {
-    VkVertexInputBindingDescription bindingDesc = Vertex::getBindingDescription();
-    decltype(Vertex::getAttributeDescriptions()) attrDescs = Vertex::getAttributeDescriptions();
+    VkVertexInputBindingDescription bindingDesc{};
+    std::vector<VkVertexInputAttributeDescription> attrDescs;
     VkPipelineVertexInputStateCreateInfo createInfo{};
 
     MeshVertexInputState()
+        : bindingDesc(Vertex::getBindingDescription()),
+          attrDescs(FilterVertexAttributesForReflection(ShaderReflection{}))
     {
+        initCreateInfo();
+    }
+
+    explicit MeshVertexInputState(const ShaderReflection &vertexReflection)
+        : bindingDesc(Vertex::getBindingDescription()),
+          attrDescs(FilterVertexAttributesForReflection(vertexReflection))
+    {
+        initCreateInfo();
+    }
+
+    void initCreateInfo()
+    {
+        createInfo = {};
         createInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-        createInfo.vertexBindingDescriptionCount = 1;
-        createInfo.pVertexBindingDescriptions = &bindingDesc;
+        createInfo.vertexBindingDescriptionCount = attrDescs.empty() ? 0u : 1u;
+        createInfo.pVertexBindingDescriptions = attrDescs.empty() ? nullptr : &bindingDesc;
         createInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(attrDescs.size());
-        createInfo.pVertexAttributeDescriptions = attrDescs.data();
+        createInfo.pVertexAttributeDescriptions = attrDescs.empty() ? nullptr : attrDescs.data();
     }
 };
 
@@ -487,7 +505,13 @@ void OutlineRenderer::CreateOutlinePipelines()
             MakeShaderStageInfo(VK_SHADER_STAGE_FRAGMENT_BIT, m_core->GetShaderModule("outline_mask", "fragment")),
         };
 
-        m_outlineMaskPipeline = CreateMaskPipeline(stages.data(), m_outlineMaskPipelineLayout);
+        ShaderReflection outlineMaskVertRefl;
+        const auto *outlineMaskVertSpv = m_core->GetShaderCache().FindVertCode("outline_mask");
+        if (!outlineMaskVertSpv || !outlineMaskVertRefl.Reflect(*outlineMaskVertSpv, VK_SHADER_STAGE_VERTEX_BIT)) {
+            outlineMaskVertRefl.Clear();
+        }
+
+        m_outlineMaskPipeline = CreateMaskPipeline(stages.data(), m_outlineMaskPipelineLayout, outlineMaskVertRefl);
         if (m_outlineMaskPipeline == VK_NULL_HANDLE) {
             INXLOG_ERROR("OutlineRenderer: Failed to create outline mask pipeline");
         }
@@ -606,7 +630,8 @@ void OutlineRenderer::CreateOutlineMaterialResources()
         poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         poolSizes[0].descriptorCount = 64 + framesInFlight; // 32 materials × 2 bindings + globals UBOs
         poolSizes[1].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        poolSizes[1].descriptorCount = framesInFlight; // instance SSBOs
+        // Globals set at index 2 has three STORAGE_BUFFER bindings (instance + skin meta + palettes) per frame.
+        poolSizes[1].descriptorCount = framesInFlight * 3;
 
         VkDescriptorPoolCreateInfo poolInfo{};
         poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
@@ -676,9 +701,10 @@ void OutlineRenderer::CreateOutlineMaterialResources()
     }
 }
 
-VkPipeline OutlineRenderer::CreateMaskPipeline(const VkPipelineShaderStageCreateInfo stages[2], VkPipelineLayout layout)
+VkPipeline OutlineRenderer::CreateMaskPipeline(const VkPipelineShaderStageCreateInfo stages[2], VkPipelineLayout layout,
+                                                 const ShaderReflection &vertexReflection)
 {
-    MeshVertexInputState vertexInput;
+    MeshVertexInputState vertexInput(vertexReflection);
     VkPipelineInputAssemblyStateCreateInfo inputAssembly = MakeTriangleListInputAssembly();
     DynamicViewportState viewportState;
     VkPipelineRasterizationStateCreateInfo raster = MakeRasterizationState(VK_CULL_MODE_NONE);
@@ -734,7 +760,7 @@ VkPipeline OutlineRenderer::GetOrCreateMtlOutlinePipeline(InxMaterial *material)
         MakeShaderStageInfo(VK_SHADER_STAGE_FRAGMENT_BIT, fragModule),
     };
 
-    VkPipeline pipeline = CreateMaskPipeline(stages.data(), m_outlineMtlPipelineLayout);
+    VkPipeline pipeline = CreateMaskPipeline(stages.data(), m_outlineMtlPipelineLayout, program->GetVertexReflection());
     if (pipeline == VK_NULL_HANDLE) {
         INXLOG_WARN("OutlineRenderer: Failed to create per-material outline pipeline for '", material->GetName(), "'");
         return VK_NULL_HANDLE;

--- a/cpp/infernux/function/renderer/OutlineRenderer.cpp
+++ b/cpp/infernux/function/renderer/OutlineRenderer.cpp
@@ -10,12 +10,12 @@
 #include "MaterialDescriptor.h"
 #include "MaterialPipelineManager.h"
 #include "SceneRenderTarget.h"
+#include "VertexInputFilter.h"
 #include "shader/ShaderProgram.h"
+#include "shader/ShaderReflection.h"
 #include "vk/DescriptorBindTrace.h"
 #include "vk/VkPipelineHelpers.h"
 #include "vk/VkRenderUtils.h"
-#include "VertexInputFilter.h"
-#include "shader/ShaderReflection.h"
 #include <function/resources/InxMaterial/InxMaterial.h>
 
 #include <core/error/InxError.h>
@@ -56,8 +56,7 @@ struct MeshVertexInputState
     }
 
     explicit MeshVertexInputState(const ShaderReflection &vertexReflection)
-        : bindingDesc(Vertex::getBindingDescription()),
-          attrDescs(FilterVertexAttributesForReflection(vertexReflection))
+        : bindingDesc(Vertex::getBindingDescription()), attrDescs(FilterVertexAttributesForReflection(vertexReflection))
     {
         initCreateInfo();
     }
@@ -702,7 +701,7 @@ void OutlineRenderer::CreateOutlineMaterialResources()
 }
 
 VkPipeline OutlineRenderer::CreateMaskPipeline(const VkPipelineShaderStageCreateInfo stages[2], VkPipelineLayout layout,
-                                                 const ShaderReflection &vertexReflection)
+                                               const ShaderReflection &vertexReflection)
 {
     MeshVertexInputState vertexInput(vertexReflection);
     VkPipelineInputAssemblyStateCreateInfo inputAssembly = MakeTriangleListInputAssembly();

--- a/cpp/infernux/function/renderer/OutlineRenderer.h
+++ b/cpp/infernux/function/renderer/OutlineRenderer.h
@@ -37,6 +37,7 @@ class InxVkCoreModular;
 class SceneRenderTarget;
 class InxMaterial;
 class ShaderProgram;
+class ShaderReflection;
 
 /**
  * @brief Self-contained post-process selection outline renderer.
@@ -159,7 +160,8 @@ class OutlineRenderer
     // ========================================================================
 
     void CreateOutlineMaterialResources();
-    VkPipeline CreateMaskPipeline(const VkPipelineShaderStageCreateInfo stages[2], VkPipelineLayout layout);
+    VkPipeline CreateMaskPipeline(const VkPipelineShaderStageCreateInfo stages[2], VkPipelineLayout layout,
+                                  const ShaderReflection &vertexReflection);
     VkPipeline GetOrCreateMtlOutlinePipeline(InxMaterial *material);
     VkDescriptorSet GetOrCreateMtlOutlineDescSet(InxMaterial *material);
 

--- a/cpp/infernux/function/renderer/VertexInputFilter.h
+++ b/cpp/infernux/function/renderer/VertexInputFilter.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "shader/ShaderReflection.h"
+#include "InxRenderStruct.h"
+
+#include <unordered_set>
+#include <vector>
+
+#include <vulkan/vulkan.h>
+
+namespace infernux
+{
+
+/// Keep only vertex buffer attributes whose locations are actually read by the vertex shader.
+inline std::vector<VkVertexInputAttributeDescription>
+FilterVertexAttributesForReflection(const ShaderReflection &vertexReflection)
+{
+    const auto allAttributes = Vertex::getAttributeDescriptions();
+    const auto &shaderInputs = vertexReflection.GetInputs();
+
+    if (shaderInputs.empty()) {
+        return {allAttributes.begin(), allAttributes.end()};
+    }
+
+    std::unordered_set<uint32_t> consumedLocations;
+    consumedLocations.reserve(shaderInputs.size());
+    for (const auto &input : shaderInputs) {
+        consumedLocations.insert(input.location);
+    }
+
+    std::vector<VkVertexInputAttributeDescription> filtered;
+    filtered.reserve(allAttributes.size());
+    for (const auto &attribute : allAttributes) {
+        if (consumedLocations.find(attribute.location) != consumedLocations.end()) {
+            filtered.push_back(attribute);
+        }
+    }
+    return filtered;
+}
+
+} // namespace infernux

--- a/cpp/infernux/function/renderer/VertexInputFilter.h
+++ b/cpp/infernux/function/renderer/VertexInputFilter.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "shader/ShaderReflection.h"
 #include "InxRenderStruct.h"
+#include "shader/ShaderReflection.h"
 
 #include <unordered_set>
 #include <vector>

--- a/cpp/infernux/function/renderer/VkCoreMaterial.cpp
+++ b/cpp/infernux/function/renderer/VkCoreMaterial.cpp
@@ -15,8 +15,10 @@
 #include "gui/GPUMeshPreview.h"
 #include "vk/VkPipelineHelpers.h"
 #include "vk/VkRenderUtils.h"
+#include "VertexInputFilter.h"
 
 #include <function/renderer/shader/ShaderProgram.h>
+#include <function/renderer/shader/ShaderReflection.h>
 #include <function/resources/AssetDatabase/AssetDatabase.h>
 #include <function/resources/AssetRegistry/AssetRegistry.h>
 #include <function/resources/InxFileLoader/InxShaderLoader.hpp>
@@ -1202,16 +1204,29 @@ void InxVkCoreModular::CreateMaterialShadowPipeline(std::shared_ptr<InxMaterial>
     // Shader stages
     auto shaderStages = vkrender::MakeVertFragStages(vertModule, fragModule);
 
-    // Vertex input — same layout as the main scene rendering
+    // Vertex input — only attributes consumed by the shadow vertex shader (full mesh buffer still bound).
     auto bindingDesc = Vertex::getBindingDescription();
-    auto attrDescs = Vertex::getAttributeDescriptions();
+    ShaderReflection shadowVertRefl;
+    bool haveVertRefl = false;
+    if (const auto *spv = m_shaderCache.FindVertCode(shadowVertName)) {
+        haveVertRefl = shadowVertRefl.Reflect(*spv, VK_SHADER_STAGE_VERTEX_BIT);
+    }
+    if (!haveVertRefl) {
+        if (const auto *spv = m_shaderCache.FindVertCode(vertShaderName)) {
+            haveVertRefl = shadowVertRefl.Reflect(*spv, VK_SHADER_STAGE_VERTEX_BIT);
+        }
+    }
+    if (!haveVertRefl && forwardProgram != nullptr && vertModule == forwardProgram->GetVertexModule()) {
+        shadowVertRefl = forwardProgram->GetVertexReflection();
+    }
+    std::vector<VkVertexInputAttributeDescription> attrDescs = FilterVertexAttributesForReflection(shadowVertRefl);
 
     VkPipelineVertexInputStateCreateInfo vertexInput{};
     vertexInput.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    vertexInput.vertexBindingDescriptionCount = 1;
-    vertexInput.pVertexBindingDescriptions = &bindingDesc;
+    vertexInput.vertexBindingDescriptionCount = attrDescs.empty() ? 0u : 1u;
+    vertexInput.pVertexBindingDescriptions = attrDescs.empty() ? nullptr : &bindingDesc;
     vertexInput.vertexAttributeDescriptionCount = static_cast<uint32_t>(attrDescs.size());
-    vertexInput.pVertexAttributeDescriptions = attrDescs.data();
+    vertexInput.pVertexAttributeDescriptions = attrDescs.empty() ? nullptr : attrDescs.data();
 
     auto inputAssembly = vkrender::MakeTriangleListInputAssembly();
 

--- a/cpp/infernux/function/renderer/VkCoreMaterial.cpp
+++ b/cpp/infernux/function/renderer/VkCoreMaterial.cpp
@@ -11,11 +11,11 @@
 
 #include "InxError.h"
 #include "InxVkCoreModular.h"
+#include "VertexInputFilter.h"
 #include "gui/GPUMaterialPreview.h"
 #include "gui/GPUMeshPreview.h"
 #include "vk/VkPipelineHelpers.h"
 #include "vk/VkRenderUtils.h"
-#include "VertexInputFilter.h"
 
 #include <function/renderer/shader/ShaderProgram.h>
 #include <function/renderer/shader/ShaderReflection.h>

--- a/cpp/infernux/function/renderer/gui/InxResourcePreviewer.cpp
+++ b/cpp/infernux/function/renderer/gui/InxResourcePreviewer.cpp
@@ -236,7 +236,7 @@ ImagePreviewer::~ImagePreviewer()
 
 std::vector<std::string> ImagePreviewer::GetSupportedExtensions() const
 {
-    return {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".hdr", ".gif", ".psd", ".pic", ".pnm"};
+    return {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".hdr", ".gif", ".psd", ".pic", ".pnm", ".pgm", ".ppm"};
 }
 
 bool ImagePreviewer::Load(const std::string &filePath)

--- a/cpp/infernux/function/renderer/vk/VkResourceManager.cpp
+++ b/cpp/infernux/function/renderer/vk/VkResourceManager.cpp
@@ -8,6 +8,7 @@
 #include "VkDeviceContext.h"
 #include <SDL3/SDL.h>
 #include <core/error/InxError.h>
+#include <function/resources/InxFileLoader/InxTextureLoader.hpp>
 #include <platform/filesystem/InxPath.h>
 
 // STB_IMAGE_IMPLEMENTATION moved here after InxVkCore removal
@@ -352,17 +353,24 @@ std::unique_ptr<VkTexture> VkResourceManager::LoadTexture(const std::string &fil
     // LDR path: load as 8-bit RGBA
     stbi_uc *pixels = stbi_load_from_memory(fileBytes.data(), static_cast<int>(fileBytes.size()), &texWidth, &texHeight,
                                             &texChannels, STBI_rgb_alpha);
+    InxTextureData pnmFallback;
 
     if (!pixels) {
-        INXLOG_ERROR("Failed to load texture: ", filePath);
-        return nullptr;
+        pnmFallback = InxTextureLoader::LoadFromMemory(fileBytes.data(), fileBytes.size(), filePath);
+        if (!pnmFallback.IsValid()) {
+            INXLOG_ERROR("Failed to load texture: ", filePath);
+            return nullptr;
+        }
+        texWidth = pnmFallback.width;
+        texHeight = pnmFallback.height;
+        texChannels = pnmFallback.channels;
     }
 
     // Apply max_size clamping: downscale if either dimension exceeds maxSize
     uint32_t finalW = static_cast<uint32_t>(texWidth);
     uint32_t finalH = static_cast<uint32_t>(texHeight);
     std::vector<unsigned char> resizedBuf;
-    const unsigned char *basePixels = pixels;
+    const unsigned char *basePixels = pixels ? pixels : pnmFallback.pixels.data();
 
     if (normalMapMode) {
         INXLOG_INFO("LoadTexture: preserving authored tangent-space normal map '", filePath, "'");
@@ -386,7 +394,9 @@ std::unique_ptr<VkTexture> VkResourceManager::LoadTexture(const std::string &fil
     auto texture =
         CreateTextureFromPixels(srcPixels, finalW, finalH, format, generateMipmaps, filter, addressMode, aniso);
 
-    stbi_image_free(pixels);
+    if (pixels) {
+        stbi_image_free(pixels);
+    }
 
     return texture;
 }

--- a/cpp/infernux/function/renderer/vk/VkTypes.h
+++ b/cpp/infernux/function/renderer/vk/VkTypes.h
@@ -118,7 +118,7 @@ struct DeviceConfig
     uint32_t engineVersionMajor = 0;      ///< Engine major version
     uint32_t engineVersionMinor = 1;      ///< Engine minor version
     uint32_t engineVersionPatch = 0;      ///< Engine patch version
-    bool enableValidationLayers = true;   ///< Enable Vulkan validation layers
+    bool enableValidationLayers = false; ///< Set true at startup when built with INFERNUX_VULKAN_VALIDATION_LAYERS (Debug / RelWithDebInfo)
     QueueConfig queueConfig;              ///< Queue configuration
 };
 

--- a/cpp/infernux/function/renderer/vk/VkTypes.h
+++ b/cpp/infernux/function/renderer/vk/VkTypes.h
@@ -118,8 +118,9 @@ struct DeviceConfig
     uint32_t engineVersionMajor = 0;      ///< Engine major version
     uint32_t engineVersionMinor = 1;      ///< Engine minor version
     uint32_t engineVersionPatch = 0;      ///< Engine patch version
-    bool enableValidationLayers = false; ///< Set true at startup when built with INFERNUX_VULKAN_VALIDATION_LAYERS (Debug / RelWithDebInfo)
-    QueueConfig queueConfig;              ///< Queue configuration
+    bool enableValidationLayers =
+        false; ///< Set true at startup when built with INFERNUX_VULKAN_VALIDATION_LAYERS (Debug / RelWithDebInfo)
+    QueueConfig queueConfig; ///< Queue configuration
 };
 
 /**

--- a/cpp/infernux/function/resources/AssetDatabase/AssetDatabase.cpp
+++ b/cpp/infernux/function/resources/AssetDatabase/AssetDatabase.cpp
@@ -594,8 +594,8 @@ ResourceType AssetDatabase::GetResourcesType(const std::string &extensionName) c
     if (ext == ".py") {
         return ResourceType::Script;
     }
-    static const std::unordered_set<std::string> textureExtensions = {".png", ".jpg", ".jpeg", ".bmp", ".tga",
-                                                                      ".gif", ".psd", ".hdr",  ".pic"};
+    static const std::unordered_set<std::string> textureExtensions = {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif",
+                                                                      ".psd", ".hdr", ".pic",  ".pnm", ".pgm", ".ppm"};
     if (textureExtensions.find(ext) != textureExtensions.end()) {
         return ResourceType::Texture;
     }

--- a/cpp/infernux/function/resources/AssetImporter/ConcreteImporters.h
+++ b/cpp/infernux/function/resources/AssetImporter/ConcreteImporters.h
@@ -27,7 +27,7 @@ class TextureImporter final : public AssetImporter
 
     [[nodiscard]] std::vector<std::string> GetSupportedExtensions() const override
     {
-        return {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".pic"};
+        return {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".pic", ".pnm", ".pgm", ".ppm"};
     }
 
     bool Import(const ImportContext &ctx) override

--- a/cpp/infernux/function/resources/InxFileLoader/InxTextureLoader.cpp
+++ b/cpp/infernux/function/resources/InxFileLoader/InxTextureLoader.cpp
@@ -1,7 +1,9 @@
 #include "InxTextureLoader.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <core/log/InxLog.h>
+#include <cstdlib>
 #include <filesystem>
 #include <platform/filesystem/InxPath.h>
 #include <stb_image.h>
@@ -9,6 +11,156 @@
 
 namespace infernux
 {
+namespace
+{
+
+void SkipPnmWhitespaceAndComments(const unsigned char *data, size_t dataSize, size_t &pos)
+{
+    while (pos < dataSize) {
+        while (pos < dataSize && std::isspace(static_cast<unsigned char>(data[pos]))) {
+            ++pos;
+        }
+        if (pos < dataSize && data[pos] == '#') {
+            while (pos < dataSize && data[pos] != '\n' && data[pos] != '\r') {
+                ++pos;
+            }
+            continue;
+        }
+        break;
+    }
+}
+
+bool ReadPnmToken(const unsigned char *data, size_t dataSize, size_t &pos, std::string &out)
+{
+    SkipPnmWhitespaceAndComments(data, dataSize, pos);
+    if (pos >= dataSize) {
+        return false;
+    }
+    const size_t start = pos;
+    while (pos < dataSize && !std::isspace(static_cast<unsigned char>(data[pos])) && data[pos] != '#') {
+        ++pos;
+    }
+    out.assign(reinterpret_cast<const char *>(data + start), pos - start);
+    return !out.empty();
+}
+
+bool ReadPnmInt(const unsigned char *data, size_t dataSize, size_t &pos, int &out)
+{
+    std::string token;
+    if (!ReadPnmToken(data, dataSize, pos, token)) {
+        return false;
+    }
+    char *end = nullptr;
+    long value = std::strtol(token.c_str(), &end, 10);
+    if (end == token.c_str() || *end != '\0' || value < 0 || value > 65535) {
+        return false;
+    }
+    out = static_cast<int>(value);
+    return true;
+}
+
+unsigned char ScalePnmSample(int value, int maxValue)
+{
+    if (maxValue <= 0) {
+        return 0;
+    }
+    value = std::clamp(value, 0, maxValue);
+    return static_cast<unsigned char>((value * 255 + maxValue / 2) / maxValue);
+}
+
+bool DecodePnmToRgba(const unsigned char *data, size_t dataSize, InxTextureData &result)
+{
+    if (!data || dataSize < 3 || data[0] != 'P') {
+        return false;
+    }
+
+    const unsigned char magic = data[1];
+    const bool asciiRgb = magic == '3';
+    const bool asciiGray = magic == '2';
+    const bool binaryRgb = magic == '6';
+    const bool binaryGray = magic == '5';
+    if (!asciiRgb && !asciiGray && !binaryRgb && !binaryGray) {
+        return false;
+    }
+
+    size_t pos = 2;
+    int width = 0;
+    int height = 0;
+    int maxValue = 0;
+    if (!ReadPnmInt(data, dataSize, pos, width) || !ReadPnmInt(data, dataSize, pos, height) ||
+        !ReadPnmInt(data, dataSize, pos, maxValue)) {
+        return false;
+    }
+    if (width <= 0 || height <= 0 || maxValue <= 0 || maxValue > 65535) {
+        return false;
+    }
+
+    const size_t pixelCount = static_cast<size_t>(width) * static_cast<size_t>(height);
+    result.width = width;
+    result.height = height;
+    result.channels = 4;
+    result.pixels.clear();
+    result.pixels.resize(pixelCount * 4);
+
+    if (asciiRgb || asciiGray) {
+        for (size_t i = 0; i < pixelCount; ++i) {
+            int r = 0;
+            int g = 0;
+            int b = 0;
+            if (asciiRgb) {
+                if (!ReadPnmInt(data, dataSize, pos, r) || !ReadPnmInt(data, dataSize, pos, g) ||
+                    !ReadPnmInt(data, dataSize, pos, b)) {
+                    return false;
+                }
+            } else {
+                if (!ReadPnmInt(data, dataSize, pos, r)) {
+                    return false;
+                }
+                g = r;
+                b = r;
+            }
+            const size_t out = i * 4;
+            result.pixels[out + 0] = ScalePnmSample(r, maxValue);
+            result.pixels[out + 1] = ScalePnmSample(g, maxValue);
+            result.pixels[out + 2] = ScalePnmSample(b, maxValue);
+            result.pixels[out + 3] = 255;
+        }
+        return true;
+    }
+
+    // Binary P5/P6: one whitespace byte separates the header from pixel bytes.
+    SkipPnmWhitespaceAndComments(data, dataSize, pos);
+    const int srcChannels = binaryRgb ? 3 : 1;
+    const int bytesPerSample = maxValue > 255 ? 2 : 1;
+    const size_t required = pixelCount * static_cast<size_t>(srcChannels) * static_cast<size_t>(bytesPerSample);
+    if (pos + required > dataSize) {
+        return false;
+    }
+
+    for (size_t i = 0; i < pixelCount; ++i) {
+        int samples[3] = {0, 0, 0};
+        for (int c = 0; c < srcChannels; ++c) {
+            if (bytesPerSample == 1) {
+                samples[c] = data[pos++];
+            } else {
+                samples[c] = (static_cast<int>(data[pos]) << 8) | static_cast<int>(data[pos + 1]);
+                pos += 2;
+            }
+        }
+        if (srcChannels == 1) {
+            samples[1] = samples[0];
+            samples[2] = samples[0];
+        }
+        const size_t out = i * 4;
+        result.pixels[out + 0] = ScalePnmSample(samples[0], maxValue);
+        result.pixels[out + 1] = ScalePnmSample(samples[1], maxValue);
+        result.pixels[out + 2] = ScalePnmSample(samples[2], maxValue);
+        result.pixels[out + 3] = 255;
+    }
+    return true;
+}
+
+} // namespace
 
 InxTextureData InxTextureLoader::LoadFromFile(const std::string &filePath, const std::string &name)
 {
@@ -27,6 +179,10 @@ InxTextureData InxTextureLoader::LoadFromFile(const std::string &filePath, const
                                             &channels, STBI_rgb_alpha);
 
     if (!pixels) {
+        if (DecodePnmToRgba(fileBytes.data(), fileBytes.size(), result)) {
+            INXLOG_DEBUG("Loaded PNM texture: ", result.name, " [", result.width, "x", result.height, "]");
+            return result;
+        }
         INXLOG_ERROR("stbi_load failed for: ", filePath, " - ", stbi_failure_reason());
         return result;
     }
@@ -53,6 +209,10 @@ InxTextureData InxTextureLoader::LoadFromMemory(const unsigned char *data, size_
         stbi_load_from_memory(data, static_cast<int>(dataSize), &width, &height, &channels, STBI_rgb_alpha);
 
     if (!pixels) {
+        if (DecodePnmToRgba(data, dataSize, result)) {
+            INXLOG_DEBUG("Loaded PNM texture from memory: ", result.name, " [", result.width, "x", result.height, "]");
+            return result;
+        }
         INXLOG_ERROR("stbi_load_from_memory failed: ", stbi_failure_reason());
         return result;
     }

--- a/cpp/infernux/function/resources/InxTexture/TextureLoader.cpp
+++ b/cpp/infernux/function/resources/InxTexture/TextureLoader.cpp
@@ -1,6 +1,7 @@
 #include "TextureLoader.h"
 
 #include <core/log/InxLog.h>
+#include <function/resources/InxFileLoader/InxTextureLoader.hpp>
 #include <function/resources/InxTexture/InxTexture.h>
 
 #include <platform/filesystem/InxPath.h>
@@ -46,6 +47,13 @@ void TextureLoader::CreateMeta(const char *content, size_t contentSize, const st
         metaData.AddMetadata("width", width);
         metaData.AddMetadata("height", height);
         metaData.AddMetadata("channels", channels);
+    } else if (!fileBytes.empty()) {
+        InxTextureData pnmInfo = InxTextureLoader::LoadFromMemory(fileBytes.data(), fileBytes.size(), filePath);
+        if (pnmInfo.IsValid()) {
+            metaData.AddMetadata("width", pnmInfo.width);
+            metaData.AddMetadata("height", pnmInfo.height);
+            metaData.AddMetadata("channels", pnmInfo.channels);
+        }
     }
 
     metaData.AddMetadata("file_type", std::string("texture"));

--- a/packaging/runtime_requirements.py
+++ b/packaging/runtime_requirements.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-RUNTIME_PROFILE_VERSION = 2
+RUNTIME_PROFILE_VERSION = 3
 
 # Keep the managed runtime limited to the packages needed to launch Infernux
 # projects and build standalone players from a project's private Python copy.
@@ -17,6 +17,8 @@ _RUNTIME_PACKAGE_SPECS: tuple[tuple[str, str], ...] = (
     ("Pillow", "PIL"),
     ("imageio", "imageio"),
     ("av", "av"),
+    ("mcp", "mcp"),
+    ("fastmcp", "fastmcp"),
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "Pillow>=10.4.0",
     "imageio>=2.34.0",
     "av>=12.0.0",
+    "mcp>=1.24,<2",
+    "fastmcp",
 ]
 
 [project.urls]

--- a/python/Infernux/components/builtin/sprite_renderer.py
+++ b/python/Infernux/components/builtin/sprite_renderer.py
@@ -306,6 +306,9 @@ class SpriteRenderer(BuiltinComponent):
                 + _picker_assets(filt, "*.psd", assets_only=True)
                 + _picker_assets(filt, "*.hdr", assets_only=True)
                 + _picker_assets(filt, "*.pic", assets_only=True)
+                + _picker_assets(filt, "*.pnm", assets_only=True)
+                + _picker_assets(filt, "*.pgm", assets_only=True)
+                + _picker_assets(filt, "*.ppm", assets_only=True)
             )
 
         field_label(ctx, "Sprite", lw)

--- a/python/Infernux/core/asset_types.py
+++ b/python/Infernux/core/asset_types.py
@@ -485,7 +485,7 @@ def write_mesh_import_settings(asset_path: str, settings: MeshImportSettings) ->
 
 # Image extensions supported by InxTextureLoader / stb_image
 IMAGE_EXTENSIONS = frozenset({
-    ".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".pic",
+    ".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".psd", ".hdr", ".pic", ".pnm", ".pgm", ".ppm",
 })
 
 # Shader extensions supported by ShaderImporter

--- a/python/Infernux/engine/__init__.py
+++ b/python/Infernux/engine/__init__.py
@@ -184,6 +184,11 @@ def release_engine(project_path: str, engine_log_level=LogLevel.Info):
         bootstrap.engine.show()
         bootstrap.engine.run()
     finally:
+        try:
+            from Infernux.mcp import stop_server
+            stop_server()
+        except Exception as _exc:
+            Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
         _remove_project_lock(lock_path, lock_token)
 
     # Force-terminate: this is a standalone engine child process.

--- a/python/Infernux/engine/bootstrap.py
+++ b/python/Infernux/engine/bootstrap.py
@@ -144,6 +144,8 @@ class EditorBootstrap(BootstrapPanelsMixin, BootstrapSelectionMixin, BootstrapWi
         self._report_progress("Prewarming material previews\u2026")
         self._prewarm_material_previews()
 
+        self._start_mcp_http_server()
+
         if self.engine:
             try:
                 self.engine.set_game_camera_enabled(True)
@@ -155,6 +157,13 @@ class EditorBootstrap(BootstrapPanelsMixin, BootstrapSelectionMixin, BootstrapWi
                     ne.request_full_speed_frame()
             except Exception as _exc:
                 pass
+
+    def _start_mcp_http_server(self):
+        try:
+            from Infernux.mcp import start_server
+            start_server(self.project_path)
+        except Exception as exc:
+            Debug.log_warning(f"Failed to start Infernux MCP HTTP server: {exc}")
 
     def _report_progress(self, message: str):
         """Notify the launcher splash of the current bootstrap step."""

--- a/python/Infernux/engine/bootstrap_hierarchy/_creation.py
+++ b/python/Infernux/engine/bootstrap_hierarchy/_creation.py
@@ -1,189 +1,64 @@
 """Context-menu creation callbacks for the Hierarchy panel."""
+
 from __future__ import annotations
 
 from Infernux.debug import Debug
-from Infernux.engine.bootstrap_hierarchy._helpers import _get_py_components_safe
+from Infernux.engine.hierarchy_creation_service import (
+    HierarchyCreationService,
+    LIGHT_INDEX,
+    PRIMITIVE_INDEX,
+)
 
 
 def wire_creation_callbacks(ctx):
     """Wire all object-creation callbacks onto the hierarchy panel."""
     hp = ctx.hp
-    sel = ctx.sel
-    undo = ctx.undo
+    svc = HierarchyCreationService.instance()
+    svc.configure(selection_manager=ctx.sel, undo_tracker=ctx.undo, hierarchy_panel=hp)
 
-    def _finalize(new_obj, parent_id, description):
-        if parent_id and parent_id != 0:
-            from Infernux.lib import SceneManager
-            scene = SceneManager.instance().get_active_scene()
-            if scene:
-                parent = scene.find_by_id(parent_id)
-                if parent:
-                    new_obj.set_parent(parent)
-        sel.select(new_obj.id)
-        undo.record_create(new_obj.id, description)
-        if hp.on_selection_changed:
-            hp.on_selection_changed(new_obj.id)
+    def _create(kind: str, parent_id: int) -> None:
+        try:
+            svc.create(kind, parent_id=parent_id)
+        except Exception as exc:
+            Debug.log_error(f"Hierarchy create failed ({kind}): {exc}")
 
-    def _create_primitive(type_idx, parent_id):
-        from Infernux.lib import SceneManager, PrimitiveType
-        scene = SceneManager.instance().get_active_scene()
-        if not scene:
-            return
-        types = [PrimitiveType.Cube, PrimitiveType.Sphere, PrimitiveType.Capsule,
-                 PrimitiveType.Cylinder, PrimitiveType.Plane, PrimitiveType.Quad]
-        if type_idx < 0 or type_idx >= len(types):
-            return
-        new_obj = scene.create_primitive(types[type_idx])
-        if new_obj:
-            _finalize(new_obj, parent_id, "Create Primitive")
+    hp.create_primitive = lambda type_idx, parent_id: _create(
+        PRIMITIVE_INDEX.get(type_idx, ""), parent_id
+    )
+    hp.create_light = lambda type_idx, parent_id: _create(
+        LIGHT_INDEX.get(type_idx, ""), parent_id
+    )
+    hp.create_empty = lambda parent_id: _create("empty", parent_id)
 
-    def _create_light(type_idx, parent_id):
-        from Infernux.lib import SceneManager, LightType, LightShadows, Vector3
-        scene = SceneManager.instance().get_active_scene()
-        if not scene:
-            return
-        names = ["Directional Light", "Point Light", "Spot Light"]
-        light_types = [LightType.Directional, LightType.Point, LightType.Spot]
-        if type_idx < 0 or type_idx >= len(light_types):
-            return
-        new_obj = scene.create_game_object(names[type_idx])
-        if not new_obj:
-            return
-        light_comp = new_obj.add_component("Light")
-        if light_comp:
-            light_comp.light_type = light_types[type_idx]
-            light_comp.shadows = LightShadows.Hard
-            light_comp.shadow_bias = 0.0
-            if light_types[type_idx] == LightType.Directional:
-                trans = new_obj.transform
-                if trans:
-                    trans.euler_angles = Vector3(50.0, -30.0, 0.0)
-            elif light_types[type_idx] == LightType.Point:
-                light_comp.range = 10.0
-            elif light_types[type_idx] == LightType.Spot:
-                light_comp.range = 10.0
-                light_comp.outer_spot_angle = 45.0
-                light_comp.spot_angle = 30.0
-        _finalize(new_obj, parent_id, "Create Light")
-
-    def _create_camera(parent_id):
-        from Infernux.lib import SceneManager
-        scene = SceneManager.instance().get_active_scene()
-        if not scene:
-            return
-        new_obj = scene.create_game_object("Camera")
-        if new_obj:
-            new_obj.add_component("Camera")
-            _finalize(new_obj, parent_id, "Create Camera")
-
-    def _create_render_stack(parent_id):
-        from Infernux.lib import SceneManager
-        from Infernux.renderstack import RenderStack as RenderStackCls
-        scene = SceneManager.instance().get_active_scene()
-        if not scene:
-            return
-        new_obj = scene.create_game_object("RenderStack")
-        if not new_obj:
-            return
-        stack = new_obj.add_py_component(RenderStackCls())
-        if stack is None:
-            scene.destroy_game_object(new_obj)
-            return
-        _finalize(new_obj, parent_id, "Create RenderStack")
-
-    def _create_empty(parent_id):
-        from Infernux.lib import SceneManager
-        scene = SceneManager.instance().get_active_scene()
-        if scene:
-            new_obj = scene.create_game_object("GameObject")
-            if new_obj:
-                _finalize(new_obj, parent_id, "Create Empty")
-
-    def _create_sprite_renderer(parent_id):
-        from Infernux.lib import SceneManager
-        scene = SceneManager.instance().get_active_scene()
-        if not scene:
-            return
-        new_obj = scene.create_game_object("Sprite")
-        if not new_obj:
-            return
-        cpp_comp = new_obj.add_component("SpriteRenderer")
-        if cpp_comp is None:
-            scene.destroy_game_object(new_obj)
-            return
-        # Force Python wrapper creation so material is set up immediately
-        from Infernux.components.builtin.sprite_renderer import SpriteRenderer
-        SpriteRenderer._get_or_create_wrapper(cpp_comp, new_obj)
-        _finalize(new_obj, parent_id, "Create Sprite Renderer")
-
-    def _find_canvas_parent_id(scene, parent_id):
-        if parent_id == 0:
-            return 0
-        from Infernux.ui import UICanvas
-        obj = scene.find_by_id(parent_id)
-        if not obj:
-            return parent_id
-        cur = obj
-        while cur is not None:
-            for c in _get_py_components_safe(cur):
-                if isinstance(c, UICanvas):
-                    return cur.id
-            cur = cur.get_parent()
-        return parent_id
-
-    def _create_ui_canvas(parent_id):
-        from Infernux.lib import SceneManager
-        from Infernux.ui import UICanvas as UICanvasCls
-        from Infernux.ui.ui_canvas_utils import invalidate_canvas_cache
-        scene = SceneManager.instance().get_active_scene()
-        if not scene:
-            return
-        go = scene.create_game_object("Canvas")
-        if go:
-            go.add_py_component(UICanvasCls())
-            invalidate_canvas_cache()
-            _finalize(go, parent_id, "Create Canvas")
-
-    def _create_ui_text(parent_id):
-        from Infernux.lib import SceneManager
-        from Infernux.ui import UIText as UITextCls
-        from Infernux.ui.ui_canvas_utils import invalidate_canvas_cache
-        scene = SceneManager.instance().get_active_scene()
-        if not scene:
-            return
-        canvas_pid = _find_canvas_parent_id(scene, parent_id)
-        go = scene.create_game_object("Text")
-        if go:
-            go.add_py_component(UITextCls())
-            _finalize(go, canvas_pid, "Create Text")
-            invalidate_canvas_cache()
-
-    def _create_ui_button(parent_id):
-        from Infernux.lib import SceneManager
-        from Infernux.ui import UIButton as UIButtonCls
-        from Infernux.ui.ui_canvas_utils import invalidate_canvas_cache
-        scene = SceneManager.instance().get_active_scene()
-        if not scene:
-            return
-        canvas_pid = _find_canvas_parent_id(scene, parent_id)
-        go = scene.create_game_object("Button")
-        if go:
-            btn = UIButtonCls()
-            btn.width = 160.0
-            btn.height = 40.0
-            go.add_py_component(btn)
-            _finalize(go, canvas_pid, "Create Button")
-            invalidate_canvas_cache()
-
-    hp.create_primitive = _create_primitive
-    hp.create_light = _create_light
-    hp.create_empty = _create_empty
-
-    # Data-driven entries for Rendering and UI context menus
+    # Data-driven entries for Rendering and UI context menus.
     hp.clear_create_entries()
-    hp.add_create_entry("Rendering", "hierarchy.camera", _create_camera)
-    hp.add_create_entry("Rendering", "hierarchy.render_stack", _create_render_stack)
-    hp.add_create_entry("Rendering", "hierarchy.sprite_renderer", _create_sprite_renderer)
-    hp.add_create_entry("UI", "hierarchy.ui_canvas", _create_ui_canvas)
-    hp.add_create_entry("UI", "hierarchy.ui_text", _create_ui_text)
-    hp.add_create_entry("UI", "hierarchy.ui_button", _create_ui_button)
+    hp.add_create_entry(
+        "Rendering",
+        "hierarchy.camera",
+        lambda parent_id: _create("rendering.camera", parent_id),
+    )
+    hp.add_create_entry(
+        "Rendering",
+        "hierarchy.render_stack",
+        lambda parent_id: _create("rendering.render_stack", parent_id),
+    )
+    hp.add_create_entry(
+        "Rendering",
+        "hierarchy.sprite_renderer",
+        lambda parent_id: _create("rendering.sprite_renderer", parent_id),
+    )
+    hp.add_create_entry(
+        "UI",
+        "hierarchy.ui_canvas",
+        lambda parent_id: _create("ui.canvas", parent_id),
+    )
+    hp.add_create_entry(
+        "UI",
+        "hierarchy.ui_text",
+        lambda parent_id: _create("ui.text", parent_id),
+    )
+    hp.add_create_entry(
+        "UI",
+        "hierarchy.ui_button",
+        lambda parent_id: _create("ui.button", parent_id),
+    )

--- a/python/Infernux/engine/engine.py
+++ b/python/Infernux/engine/engine.py
@@ -175,6 +175,11 @@ class Engine():
             except Exception as exc:
                 Debug.log_suppressed("Engine.pre_gui_tick.DeferredTaskRunner", exc)
             try:
+                from Infernux.mcp.threading import MainThreadCommandQueue
+                MainThreadCommandQueue.instance().drain()
+            except Exception as exc:
+                Debug.log_suppressed("Engine.pre_gui_tick.MainThreadCommandQueue", exc)
+            try:
                 from Infernux.engine.ui.window_manager import WindowManager
                 manager = WindowManager.instance()
                 if manager is not None:

--- a/python/Infernux/engine/hierarchy_creation_service.py
+++ b/python/Infernux/engine/hierarchy_creation_service.py
@@ -6,7 +6,7 @@ UI creation and agent-driven creation stay behaviorally identical.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from Infernux.debug import Debug
 
@@ -29,11 +29,15 @@ LIGHT_INDEX = {
 
 class HierarchyCreationService:
     _instance: Optional["HierarchyCreationService"] = None
+    _kind_registry: dict[str, dict[str, Any]] = {}
+    _kind_factories: dict[str, Callable[[Any, int], Any]] = {}
+    _defaults_registered: bool = False
 
     def __init__(self) -> None:
         self._selection_manager = None
         self._undo_tracker = None
         self._hierarchy_panel = None
+        self._ensure_default_kinds()
 
     @classmethod
     def instance(cls) -> "HierarchyCreationService":
@@ -46,24 +50,70 @@ class HierarchyCreationService:
         self._undo_tracker = undo_tracker
         self._hierarchy_panel = hierarchy_panel
 
+    @classmethod
+    def register_create_kind(
+        cls,
+        kind: str,
+        label: str,
+        *,
+        category: str = "",
+        description: str = "",
+        factory: Callable[[Any, int], Any] | None = None,
+    ) -> None:
+        """Register a Hierarchy creation kind.
+
+        This is intentionally shared by UI and MCP. Future editor modules can
+        add objects (including UI widgets) without editing MCP code.
+        """
+        normalized = str(kind).strip()
+        if not normalized:
+            raise ValueError("Create kind cannot be empty.")
+        cls._kind_registry[normalized] = {
+            "kind": normalized,
+            "label": str(label or normalized),
+            "category": str(category or ""),
+            "description": str(description or ""),
+        }
+        if factory is not None:
+            cls._kind_factories[normalized] = factory
+
+    @classmethod
+    def unregister_create_kind(cls, kind: str) -> None:
+        normalized = str(kind).strip()
+        cls._kind_registry.pop(normalized, None)
+        cls._kind_factories.pop(normalized, None)
+
+    @classmethod
+    def _ensure_default_kinds(cls) -> None:
+        if cls._defaults_registered:
+            return
+        cls._defaults_registered = True
+        defaults = [
+            ("empty", "Empty", "General"),
+            ("primitive.cube", "Cube", "3D Object"),
+            ("primitive.sphere", "Sphere", "3D Object"),
+            ("primitive.capsule", "Capsule", "3D Object"),
+            ("primitive.cylinder", "Cylinder", "3D Object"),
+            ("primitive.plane", "Plane", "3D Object"),
+            ("primitive.quad", "Quad", "3D Object"),
+            ("light.directional", "Directional Light", "Light"),
+            ("light.point", "Point Light", "Light"),
+            ("light.spot", "Spot Light", "Light"),
+            ("rendering.camera", "Camera", "Rendering"),
+            ("rendering.render_stack", "RenderStack", "Rendering"),
+            ("rendering.sprite_renderer", "Sprite Renderer", "Rendering"),
+            ("ui.canvas", "Canvas", "UI"),
+            ("ui.text", "Text", "UI"),
+            ("ui.button", "Button", "UI"),
+        ]
+        for kind, label, category in defaults:
+            cls.register_create_kind(kind, label, category=category)
+
     def list_create_kinds(self) -> list[dict[str, str]]:
+        self._ensure_default_kinds()
         return [
-            {"kind": "empty", "label": "Empty"},
-            {"kind": "primitive.cube", "label": "Cube"},
-            {"kind": "primitive.sphere", "label": "Sphere"},
-            {"kind": "primitive.capsule", "label": "Capsule"},
-            {"kind": "primitive.cylinder", "label": "Cylinder"},
-            {"kind": "primitive.plane", "label": "Plane"},
-            {"kind": "primitive.quad", "label": "Quad"},
-            {"kind": "light.directional", "label": "Directional Light"},
-            {"kind": "light.point", "label": "Point Light"},
-            {"kind": "light.spot", "label": "Spot Light"},
-            {"kind": "rendering.camera", "label": "Camera"},
-            {"kind": "rendering.render_stack", "label": "RenderStack"},
-            {"kind": "rendering.sprite_renderer", "label": "Sprite Renderer"},
-            {"kind": "ui.canvas", "label": "Canvas"},
-            {"kind": "ui.text", "label": "Text"},
-            {"kind": "ui.button", "label": "Button"},
+            dict(value)
+            for _kind, value in sorted(self._kind_registry.items(), key=lambda item: (item[1].get("category", ""), item[1].get("label", "")))
         ]
 
     def create(
@@ -102,6 +152,10 @@ class HierarchyCreationService:
         return self._serialize_created(obj, kind, selected=select)
 
     def _create_raw(self, scene, kind: str, parent_id: int):
+        self._ensure_default_kinds()
+        factory = self._kind_factories.get(kind)
+        if factory is not None:
+            return factory(scene, parent_id)
         if kind == "empty":
             return scene.create_game_object("GameObject")
         if kind.startswith("primitive."):

--- a/python/Infernux/engine/hierarchy_creation_service.py
+++ b/python/Infernux/engine/hierarchy_creation_service.py
@@ -1,0 +1,309 @@
+"""Shared Hierarchy object creation service.
+
+Both the C++ HierarchyPanel callbacks and MCP tools use this service so editor
+UI creation and agent-driven creation stay behaviorally identical.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from Infernux.debug import Debug
+
+
+PRIMITIVE_INDEX = {
+    0: "primitive.cube",
+    1: "primitive.sphere",
+    2: "primitive.capsule",
+    3: "primitive.cylinder",
+    4: "primitive.plane",
+    5: "primitive.quad",
+}
+
+LIGHT_INDEX = {
+    0: "light.directional",
+    1: "light.point",
+    2: "light.spot",
+}
+
+
+class HierarchyCreationService:
+    _instance: Optional["HierarchyCreationService"] = None
+
+    def __init__(self) -> None:
+        self._selection_manager = None
+        self._undo_tracker = None
+        self._hierarchy_panel = None
+
+    @classmethod
+    def instance(cls) -> "HierarchyCreationService":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def configure(self, *, selection_manager=None, undo_tracker=None, hierarchy_panel=None) -> None:
+        self._selection_manager = selection_manager
+        self._undo_tracker = undo_tracker
+        self._hierarchy_panel = hierarchy_panel
+
+    def list_create_kinds(self) -> list[dict[str, str]]:
+        return [
+            {"kind": "empty", "label": "Empty"},
+            {"kind": "primitive.cube", "label": "Cube"},
+            {"kind": "primitive.sphere", "label": "Sphere"},
+            {"kind": "primitive.capsule", "label": "Capsule"},
+            {"kind": "primitive.cylinder", "label": "Cylinder"},
+            {"kind": "primitive.plane", "label": "Plane"},
+            {"kind": "primitive.quad", "label": "Quad"},
+            {"kind": "light.directional", "label": "Directional Light"},
+            {"kind": "light.point", "label": "Point Light"},
+            {"kind": "light.spot", "label": "Spot Light"},
+            {"kind": "rendering.camera", "label": "Camera"},
+            {"kind": "rendering.render_stack", "label": "RenderStack"},
+            {"kind": "rendering.sprite_renderer", "label": "Sprite Renderer"},
+            {"kind": "ui.canvas", "label": "Canvas"},
+            {"kind": "ui.text", "label": "Text"},
+            {"kind": "ui.button", "label": "Button"},
+        ]
+
+    def create(
+        self,
+        kind: str,
+        *,
+        parent_id: int = 0,
+        name: str | None = None,
+        select: bool = True,
+        record_undo: bool = True,
+    ) -> dict[str, Any]:
+        from Infernux.lib import SceneManager
+
+        scene = SceneManager.instance().get_active_scene()
+        if not scene:
+            raise RuntimeError("No active scene.")
+
+        parent_id = int(parent_id or 0)
+        effective_parent_id = parent_id
+        if kind in {"ui.text", "ui.button"}:
+            effective_parent_id = self._find_canvas_parent_id(scene, parent_id)
+
+        if effective_parent_id:
+            parent = scene.find_by_id(effective_parent_id)
+            if parent is None:
+                raise ValueError(f"Parent GameObject {effective_parent_id} was not found.")
+
+        obj = self._create_raw(scene, kind, parent_id)
+        if obj is None:
+            raise RuntimeError(f"Failed to create hierarchy object kind '{kind}'.")
+
+        if name:
+            obj.name = str(name)
+
+        self._finalize(obj, effective_parent_id, self._description_for(kind), select=select, record_undo=record_undo)
+        return self._serialize_created(obj, kind, selected=select)
+
+    def _create_raw(self, scene, kind: str, parent_id: int):
+        if kind == "empty":
+            return scene.create_game_object("GameObject")
+        if kind.startswith("primitive."):
+            return self._create_primitive(scene, kind)
+        if kind.startswith("light."):
+            return self._create_light(scene, kind)
+        if kind == "rendering.camera":
+            obj = scene.create_game_object("Camera")
+            if obj:
+                obj.add_component("Camera")
+            return obj
+        if kind == "rendering.render_stack":
+            from Infernux.renderstack import RenderStack as RenderStackCls
+            obj = scene.create_game_object("RenderStack")
+            if obj and obj.add_py_component(RenderStackCls()) is None:
+                scene.destroy_game_object(obj)
+                return None
+            return obj
+        if kind == "rendering.sprite_renderer":
+            obj = scene.create_game_object("Sprite")
+            if not obj:
+                return None
+            cpp_comp = obj.add_component("SpriteRenderer")
+            if cpp_comp is None:
+                scene.destroy_game_object(obj)
+                return None
+            from Infernux.components.builtin.sprite_renderer import SpriteRenderer
+            SpriteRenderer._get_or_create_wrapper(cpp_comp, obj)
+            return obj
+        if kind == "ui.canvas":
+            return self._create_ui_canvas(scene)
+        if kind == "ui.text":
+            return self._create_ui_text(scene, parent_id)
+        if kind == "ui.button":
+            return self._create_ui_button(scene, parent_id)
+        raise ValueError(f"Unknown hierarchy create kind: {kind}")
+
+    def _create_primitive(self, scene, kind: str):
+        from Infernux.lib import PrimitiveType
+        primitive_types = {
+            "primitive.cube": PrimitiveType.Cube,
+            "primitive.sphere": PrimitiveType.Sphere,
+            "primitive.capsule": PrimitiveType.Capsule,
+            "primitive.cylinder": PrimitiveType.Cylinder,
+            "primitive.plane": PrimitiveType.Plane,
+            "primitive.quad": PrimitiveType.Quad,
+        }
+        primitive_type = primitive_types.get(kind)
+        if primitive_type is None:
+            raise ValueError(f"Unknown primitive kind: {kind}")
+        return scene.create_primitive(primitive_type)
+
+    def _create_light(self, scene, kind: str):
+        from Infernux.lib import LightShadows, LightType, Vector3
+        light_types = {
+            "light.directional": ("Directional Light", LightType.Directional),
+            "light.point": ("Point Light", LightType.Point),
+            "light.spot": ("Spot Light", LightType.Spot),
+        }
+        entry = light_types.get(kind)
+        if entry is None:
+            raise ValueError(f"Unknown light kind: {kind}")
+        name, light_type = entry
+        obj = scene.create_game_object(name)
+        if not obj:
+            return None
+        light_comp = obj.add_component("Light")
+        if light_comp:
+            light_comp.light_type = light_type
+            light_comp.shadows = LightShadows.Hard
+            light_comp.shadow_bias = 0.0
+            if light_type == LightType.Directional and obj.transform:
+                obj.transform.euler_angles = Vector3(50.0, -30.0, 0.0)
+            elif light_type == LightType.Point:
+                light_comp.range = 10.0
+            elif light_type == LightType.Spot:
+                light_comp.range = 10.0
+                light_comp.outer_spot_angle = 45.0
+                light_comp.spot_angle = 30.0
+        return obj
+
+    def _create_ui_canvas(self, scene):
+        from Infernux.ui import UICanvas as UICanvasCls
+        from Infernux.ui.ui_canvas_utils import invalidate_canvas_cache
+        obj = scene.create_game_object("Canvas")
+        if obj:
+            obj.add_py_component(UICanvasCls())
+            invalidate_canvas_cache()
+        return obj
+
+    def _create_ui_text(self, scene, parent_id: int):
+        from Infernux.ui import UIText as UITextCls
+        from Infernux.ui.ui_canvas_utils import invalidate_canvas_cache
+        obj = scene.create_game_object("Text")
+        if obj:
+            obj.add_py_component(UITextCls())
+            invalidate_canvas_cache()
+        return obj
+
+    def _create_ui_button(self, scene, parent_id: int):
+        from Infernux.ui import UIButton as UIButtonCls
+        from Infernux.ui.ui_canvas_utils import invalidate_canvas_cache
+        obj = scene.create_game_object("Button")
+        if obj:
+            button = UIButtonCls()
+            button.width = 160.0
+            button.height = 40.0
+            obj.add_py_component(button)
+            invalidate_canvas_cache()
+        return obj
+
+    def _find_canvas_parent_id(self, scene, parent_id: int) -> int:
+        if parent_id == 0:
+            return 0
+        from Infernux.ui import UICanvas
+        obj = scene.find_by_id(parent_id)
+        if not obj:
+            return parent_id
+        current = obj
+        while current is not None:
+            for comp in _get_py_components_safe(current):
+                if isinstance(comp, UICanvas):
+                    return int(current.id)
+            current = current.get_parent()
+        return parent_id
+
+    def _finalize(self, obj, parent_id: int, description: str, *, select: bool, record_undo: bool) -> None:
+        if parent_id:
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            parent = scene.find_by_id(parent_id) if scene else None
+            if parent:
+                obj.set_parent(parent)
+
+        if select and self._selection_manager:
+            self._selection_manager.select(obj.id)
+
+        if record_undo and self._undo_tracker:
+            self._undo_tracker.record_create(obj.id, description)
+
+        hp = self._hierarchy_panel
+        callback = getattr(hp, "on_selection_changed", None) if hp is not None else None
+        if select and callback:
+            callback(obj.id)
+
+    def _description_for(self, kind: str) -> str:
+        if kind.startswith("primitive."):
+            return "Create Primitive"
+        if kind.startswith("light."):
+            return "Create Light"
+        if kind == "empty":
+            return "Create Empty"
+        if kind == "rendering.camera":
+            return "Create Camera"
+        if kind == "rendering.render_stack":
+            return "Create RenderStack"
+        if kind == "rendering.sprite_renderer":
+            return "Create Sprite Renderer"
+        if kind == "ui.canvas":
+            return "Create Canvas"
+        if kind == "ui.text":
+            return "Create Text"
+        if kind == "ui.button":
+            return "Create Button"
+        return "Create GameObject"
+
+    def _serialize_created(self, obj, kind: str, *, selected: bool) -> dict[str, Any]:
+        parent = None
+        try:
+            parent = obj.get_parent()
+        except Exception as exc:
+            Debug.log_suppressed("HierarchyCreationService.serialize.parent", exc)
+        return {
+            "id": int(obj.id),
+            "name": str(obj.name),
+            "kind": kind,
+            "parent_id": int(getattr(parent, "id", 0) or 0),
+            "selected": bool(selected),
+            "components": _component_names(obj),
+        }
+
+
+def _component_names(obj) -> list[str]:
+    names: list[str] = []
+    try:
+        for comp in obj.get_components() or []:
+            names.append(str(getattr(comp, "type_name", type(comp).__name__)))
+    except Exception as exc:
+        Debug.log_suppressed("HierarchyCreationService.components.native", exc)
+    try:
+        for comp in obj.get_py_components() or []:
+            names.append(str(getattr(comp, "type_name", type(comp).__name__)))
+    except Exception as exc:
+        Debug.log_suppressed("HierarchyCreationService.components.py", exc)
+    return names
+
+
+def _get_py_components_safe(obj) -> list[Any]:
+    if obj is None or not hasattr(obj, "get_py_components"):
+        return []
+    try:
+        return list(obj.get_py_components() or [])
+    except Exception as exc:
+        Debug.log_suppressed("HierarchyCreationService.get_py_components", exc)
+        return []

--- a/python/Infernux/engine/ui/_inspector_list_field.py
+++ b/python/Infernux/engine/ui/_inspector_list_field.py
@@ -147,7 +147,9 @@ def _make_list_picker_providers(element_type, metadata):
     if element_type == FieldType.MATERIAL:
         return (None, lambda filt: _picker_assets(filt, "*.mat"))
     if element_type == FieldType.TEXTURE:
-        return (None, lambda filt: _picker_assets(filt, "*.png", assets_only=True) + _picker_assets(filt, "*.jpg", assets_only=True))
+        patterns = ("*.png", "*.jpg", "*.jpeg", "*.bmp", "*.tga", "*.gif", "*.psd", "*.hdr", "*.pic", "*.pnm", "*.pgm", "*.ppm")
+        return (None, lambda filt, _patterns=patterns: sum(
+            (_picker_assets(filt, pattern, assets_only=True) for pattern in _patterns), []))
     if element_type == FieldType.SHADER:
         return (None, lambda filt: _picker_assets(filt, "*.vert") + _picker_assets(filt, "*.frag"))
     if element_type == FieldType.ASSET:

--- a/python/Infernux/engine/ui/_inspector_references.py
+++ b/python/Infernux/engine/ui/_inspector_references.py
@@ -300,7 +300,12 @@ def _get_asset_ref_config():
         from Infernux.components.serialized_field import FieldType
         _ASSET_REF_CONFIG = {
             FieldType.MATERIAL: ("Material",  "MATERIAL_FILE", ("*.mat",),            "mat"),
-            FieldType.TEXTURE:  ("Texture",   "TEXTURE_FILE",  ("*.png", "*.jpg"),     "tex"),
+            FieldType.TEXTURE:  (
+                "Texture",
+                "TEXTURE_FILE",
+                ("*.png", "*.jpg", "*.jpeg", "*.bmp", "*.tga", "*.gif", "*.psd", "*.hdr", "*.pic", "*.pnm", "*.pgm", "*.ppm"),
+                "tex",
+            ),
             FieldType.SHADER:   ("Shader",    "SHADER_FILE",   ("*.vert", "*.frag"),   "shd"),
             # ASSET is kept as a fallback; _resolve_asset_config overrides it.
             FieldType.ASSET:    ("AudioClip", "AUDIO_FILE",    ("*.wav", "*.mp3", "*.ogg"), "aud"),

--- a/python/Infernux/engine/ui/asset_resource_preview.py
+++ b/python/Infernux/engine/ui/asset_resource_preview.py
@@ -15,7 +15,7 @@ from Infernux.debug import Debug
 from Infernux.engine.texture_task_bridge import safe_mtime_ns
 
 
-_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".hdr", ".pic", ".psd"}
+_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".hdr", ".pic", ".psd", ".pnm", ".pgm", ".ppm"}
 _MATERIAL_EXTS = {".mat"}
 _MODEL_EXTS = {".fbx", ".obj", ".gltf", ".glb", ".dae", ".blend"}
 _PREFAB_EXTS = {".prefab"}

--- a/python/Infernux/engine/ui/inspector_ui_components.py
+++ b/python/Infernux/engine/ui/inspector_ui_components.py
@@ -78,7 +78,11 @@ def _render_texture_picker(ctx, comp, field_name: str, label: str, lw: float,
             _apply_if_changed(comp, field_name, tex_path, "")
 
     def _asset_items(filt):
-        return _picker_assets(filt, "*.png", assets_only=True) + _picker_assets(filt, "*.jpg", assets_only=True)
+        patterns = ("*.png", "*.jpg", "*.jpeg", "*.bmp", "*.tga", "*.gif", "*.psd", "*.hdr", "*.pic", "*.pnm", "*.pgm", "*.ppm")
+        items = []
+        for pattern in patterns:
+            items += _picker_assets(filt, pattern, assets_only=True)
+        return items
 
     field_label(ctx, label, lw)
     IGUI.object_field(

--- a/python/Infernux/engine/ui/project_utils.py
+++ b/python/Infernux/engine/ui/project_utils.py
@@ -874,7 +874,8 @@ def get_file_type(filename: str) -> str:
     ext = ext.lower()
     types = {
         '.png': '[IMG]', '.jpg': '[IMG]', '.jpeg': '[IMG]', '.bmp': '[IMG]',
-        '.tga': '[IMG]', '.gif': '[IMG]',
+        '.tga': '[IMG]', '.gif': '[IMG]', '.psd': '[IMG]', '.hdr': '[IMG]',
+        '.pic': '[IMG]', '.pnm': '[IMG]', '.pgm': '[IMG]', '.ppm': '[IMG]',
         '.py': '[PY]', '.lua': '[LUA]', '.cs': '[CS]', '.cpp': '[CPP]',
         '.h': '[H]', '.c': '[C]',
         '.vert': '[VERT]', '.frag': '[FRAG]', '.glsl': '[GLSL]', '.hlsl': '[HLSL]',

--- a/python/Infernux/mcp/__init__.py
+++ b/python/Infernux/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Embedded MCP integration for Infernux Editor."""
+
+from Infernux.mcp.server import endpoint_url, is_running, start_server, stop_server
+
+__all__ = ["endpoint_url", "is_running", "start_server", "stop_server"]

--- a/python/Infernux/mcp/project_tools/__init__.py
+++ b/python/Infernux/mcp/project_tools/__init__.py
@@ -1,0 +1,14 @@
+"""Project-defined MCP tool extension API."""
+
+from .decorators import AgentToolMetadata, InxAgentToolset, agent_action, agent_tool
+from .registry import ProjectToolRegistry, get_project_tool_registry
+
+__all__ = [
+    "AgentToolMetadata",
+    "InxAgentToolset",
+    "ProjectToolRegistry",
+    "agent_action",
+    "agent_tool",
+    "get_project_tool_registry",
+]
+

--- a/python/Infernux/mcp/project_tools/decorators.py
+++ b/python/Infernux/mcp/project_tools/decorators.py
@@ -1,0 +1,90 @@
+"""Decorators for project-defined MCP tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass
+class AgentToolMetadata:
+    name: str
+    summary: str = ""
+    tags: list[str] = field(default_factory=list)
+    generated: bool = False
+    source_trace: str = ""
+    source_traces: list[str] = field(default_factory=list)
+    validation: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def agent_tool(
+    *,
+    name: str,
+    summary: str = "",
+    tags: list[str] | tuple[str, ...] | None = None,
+    generated: bool = False,
+    source_trace: str = "",
+    source_traces: list[str] | tuple[str, ...] | None = None,
+    validation: str = "",
+    **extra: Any,
+) -> Callable:
+    """Mark a function as a project-defined MCP tool.
+
+    Project tools are ordinary project Python code. This decorator only adds
+    metadata so the MCP registry can discover and expose the function.
+    """
+    if not name or not str(name).strip():
+        raise ValueError("agent_tool requires a non-empty name.")
+
+    def _decorate(fn: Callable) -> Callable:
+        setattr(fn, "__inx_agent_tool__", AgentToolMetadata(
+            name=str(name).strip(),
+            summary=str(summary or ""),
+            tags=[str(tag) for tag in (tags or [])],
+            generated=bool(generated),
+            source_trace=str(source_trace or ""),
+            source_traces=[str(item) for item in (source_traces or [])],
+            validation=str(validation or ""),
+            extra=dict(extra),
+        ))
+        return fn
+
+    return _decorate
+
+
+def agent_action(
+    *,
+    name: str = "",
+    summary: str = "",
+    tags: list[str] | tuple[str, ...] | None = None,
+    generated: bool = False,
+    source_trace: str = "",
+    source_traces: list[str] | tuple[str, ...] | None = None,
+    validation: str = "",
+    **extra: Any,
+) -> Callable:
+    """Mark an ``InxAgentToolset`` method as a project MCP action."""
+
+    def _decorate(fn: Callable) -> Callable:
+        setattr(fn, "__inx_agent_action__", AgentToolMetadata(
+            name=str(name or "").strip(),
+            summary=str(summary or ""),
+            tags=[str(tag) for tag in (tags or [])],
+            generated=bool(generated),
+            source_trace=str(source_trace or ""),
+            source_traces=[str(item) for item in (source_traces or [])],
+            validation=str(validation or ""),
+            extra=dict(extra),
+        ))
+        return fn
+
+    return _decorate
+
+
+class InxAgentToolset:
+    """Base class for grouping project MCP tools under one namespace."""
+
+    namespace = "project"
+    tags: list[str] = []
+

--- a/python/Infernux/mcp/project_tools/loadability.py
+++ b/python/Infernux/mcp/project_tools/loadability.py
@@ -1,0 +1,203 @@
+"""Loadability checks for project-defined MCP tools."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import inspect
+import os
+import py_compile
+import sys
+import traceback
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Any, Callable
+
+from Infernux.engine.project_context import temporary_script_import_paths
+from Infernux.mcp.project_tools.decorators import AgentToolMetadata, InxAgentToolset
+
+
+@dataclass
+class ProjectToolDefinition:
+    name: str
+    summary: str
+    callable: Callable
+    path: str
+    rel_path: str
+    module_name: str
+    generated: bool = False
+    tags: list[str] = field(default_factory=list)
+    source_trace: str = ""
+    source_traces: list[str] = field(default_factory=list)
+    validation: str = ""
+    status: str = "loaded"
+
+
+def module_name_for_path(path: str) -> str:
+    normalized = os.path.normcase(os.path.normpath(os.path.abspath(path)))
+    digest = hashlib.md5(normalized.encode("utf-8")).hexdigest()[:12]
+    stem = os.path.splitext(os.path.basename(path))[0]
+    safe_stem = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in stem)
+    return f"infernux_project_tool_{safe_stem}_{digest}"
+
+
+def validate_file(project_path: str, path: str) -> dict[str, Any]:
+    file_path = _resolve_project_file(project_path, path)
+    rel_path = os.path.relpath(file_path, project_path).replace("\\", "/")
+    result: dict[str, Any] = {
+        "path": rel_path,
+        "ok": False,
+        "violations": [],
+        "tools": [],
+    }
+    if not os.path.isfile(file_path):
+        result["violations"].append({"code": "not_found", "message": f"File not found: {rel_path}"})
+        return result
+    if not file_path.endswith(".py"):
+        result["violations"].append({"code": "not_python", "message": "Project MCP tools must be Python files."})
+        return result
+
+    try:
+        py_compile.compile(file_path, doraise=True)
+    except py_compile.PyCompileError as exc:
+        result["violations"].append({"code": "syntax_error", "message": str(exc)})
+        return result
+
+    load = load_tool_module(project_path, file_path)
+    if not load["ok"]:
+        result["violations"].append({
+            "code": "import_error",
+            "message": load.get("error", ""),
+            "traceback": load.get("traceback", ""),
+        })
+        return result
+
+    definitions = collect_tool_definitions(load["module"], project_path, file_path)
+    for definition in definitions:
+        schema_issues = validate_callable_schema(definition.callable)
+        for issue in schema_issues:
+            result["violations"].append({"code": "schema_error", "tool": definition.name, "message": issue})
+        result["tools"].append(_definition_summary(definition))
+    result["ok"] = not result["violations"]
+    return result
+
+
+def load_tool_module(project_path: str, file_path: str) -> dict[str, Any]:
+    module_name = module_name_for_path(file_path)
+    sys.modules.pop(module_name, None)
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Failed to create module spec for {file_path}")
+        module = importlib.util.module_from_spec(spec)
+        with temporary_script_import_paths(file_path):
+            spec.loader.exec_module(module)
+        sys.modules[module_name] = module
+        return {"ok": True, "module": module, "module_name": module_name}
+    except Exception as exc:
+        return {
+            "ok": False,
+            "module_name": module_name,
+            "error": f"{type(exc).__name__}: {exc}",
+            "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        }
+
+
+def collect_tool_definitions(module: ModuleType, project_path: str, file_path: str) -> list[ProjectToolDefinition]:
+    rel_path = os.path.relpath(file_path, project_path).replace("\\", "/")
+    module_name = getattr(module, "__name__", module_name_for_path(file_path))
+    definitions: list[ProjectToolDefinition] = []
+    for _, obj in inspect.getmembers(module, inspect.isfunction):
+        meta = getattr(obj, "__inx_agent_tool__", None)
+        if isinstance(meta, AgentToolMetadata):
+            definitions.append(_definition_from_meta(meta, obj, file_path, rel_path, module_name))
+
+    for _, cls in inspect.getmembers(module, inspect.isclass):
+        if cls is InxAgentToolset or not issubclass(cls, InxAgentToolset):
+            continue
+        if getattr(cls, "__module__", "") != module_name:
+            continue
+        try:
+            instance = cls()
+        except Exception:
+            continue
+        namespace = str(getattr(cls, "namespace", "project") or "project").strip(".")
+        class_tags = [str(tag) for tag in getattr(cls, "tags", [])]
+        for method_name, method in inspect.getmembers(instance, inspect.ismethod):
+            meta = getattr(method.__func__, "__inx_agent_action__", None)
+            if not isinstance(meta, AgentToolMetadata):
+                continue
+            action_name = meta.name or method_name
+            full_name = action_name if "." in action_name else f"{namespace}.{action_name}"
+            merged = AgentToolMetadata(
+                name=full_name,
+                summary=meta.summary,
+                tags=class_tags + list(meta.tags),
+                generated=meta.generated,
+                source_trace=meta.source_trace,
+                source_traces=list(meta.source_traces),
+                validation=meta.validation,
+                extra=dict(meta.extra),
+            )
+            definitions.append(_definition_from_meta(merged, method, file_path, rel_path, module_name))
+    return definitions
+
+
+def validate_callable_schema(fn: Callable) -> list[str]:
+    issues: list[str] = []
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError) as exc:
+        return [f"Cannot inspect signature: {exc}"]
+    for name, param in signature.parameters.items():
+        if name == "self":
+            continue
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            issues.append(f"Parameter '{name}' uses *args/**kwargs, which cannot form a stable MCP schema.")
+        if param.annotation is inspect.Signature.empty:
+            issues.append(f"Parameter '{name}' has no type annotation.")
+    if signature.return_annotation is inspect.Signature.empty:
+        issues.append("Return type has no annotation; use -> dict for best MCP schema quality.")
+    return issues
+
+
+def _definition_from_meta(
+    meta: AgentToolMetadata,
+    fn: Callable,
+    file_path: str,
+    rel_path: str,
+    module_name: str,
+) -> ProjectToolDefinition:
+    return ProjectToolDefinition(
+        name=meta.name,
+        summary=meta.summary or (inspect.getdoc(fn) or ""),
+        callable=fn,
+        path=file_path,
+        rel_path=rel_path,
+        module_name=module_name,
+        generated=meta.generated,
+        tags=list(meta.tags),
+        source_trace=meta.source_trace,
+        source_traces=list(meta.source_traces),
+        validation=meta.validation,
+    )
+
+
+def _definition_summary(definition: ProjectToolDefinition) -> dict[str, Any]:
+    return {
+        "name": definition.name,
+        "summary": definition.summary,
+        "path": definition.rel_path,
+        "generated": definition.generated,
+        "tags": definition.tags,
+        "validation": definition.validation,
+    }
+
+
+def _resolve_project_file(project_path: str, path: str) -> str:
+    root = os.path.abspath(project_path)
+    raw = os.path.abspath(path if os.path.isabs(path) else os.path.join(root, path))
+    if os.path.commonpath([root, raw]) != root:
+        raise ValueError("Project tool path must stay inside the project.")
+    return raw
+

--- a/python/Infernux/mcp/project_tools/registry.py
+++ b/python/Infernux/mcp/project_tools/registry.py
@@ -1,0 +1,294 @@
+"""Runtime registry for project-defined MCP tools."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import time
+import traceback
+from functools import wraps
+from typing import Any, Callable
+
+from Infernux.mcp.project_tools.loadability import (
+    ProjectToolDefinition,
+    collect_tool_definitions,
+    load_tool_module,
+    validate_callable_schema,
+    validate_file,
+)
+from Infernux.mcp.project_tools.trace import record_tool_call
+from Infernux.mcp.threading import MainThreadCommandQueue
+
+
+_REGISTRY: "ProjectToolRegistry | None" = None
+
+
+def get_project_tool_registry(project_path: str | None = None) -> "ProjectToolRegistry":
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = ProjectToolRegistry(project_path or "")
+    elif project_path:
+        _REGISTRY.project_path = os.path.abspath(project_path)
+    return _REGISTRY
+
+
+class ProjectToolRegistry:
+    def __init__(self, project_path: str) -> None:
+        self.project_path = os.path.abspath(project_path) if project_path else ""
+        self.tools: dict[str, ProjectToolDefinition] = {}
+        self.disabled_tools: set[str] = set()
+        self.file_reports: dict[str, dict[str, Any]] = {}
+        self.audit_events: list[dict[str, Any]] = []
+        self._registered_names: set[str] = set()
+        self._mcp = None
+
+    def configure(self, project_path: str) -> None:
+        self.project_path = os.path.abspath(project_path)
+
+    def discover(self) -> dict[str, Any]:
+        self.tools.clear()
+        self.file_reports.clear()
+        config = self._config()
+        self.disabled_tools = set(str(item) for item in config.get("disabled_tools", []))
+        loaded = []
+        for file_path in self._iter_tool_files(config):
+            rel_path = self._rel(file_path)
+            report = self._load_file(file_path)
+            self.file_reports[rel_path] = report
+            if report.get("ok"):
+                loaded.append(rel_path)
+        self._audit("discover", True, f"Loaded {len(self.tools)} project tool(s).")
+        return {
+            "tool_count": len(self.tools),
+            "loaded_files": loaded,
+            "reports": list(self.file_reports.values()),
+            "disabled_tools": sorted(self.disabled_tools),
+        }
+
+    def register_with_mcp(self, mcp) -> dict[str, Any]:
+        from Infernux.mcp.tools.common import register_tool_metadata
+
+        self._mcp = mcp
+        registered = []
+        skipped = []
+        for name, definition in sorted(self.tools.items()):
+            register_tool_metadata(
+                name,
+                summary=definition.summary,
+                side_effects=["Runs project-defined Python code from Assets/AgentTools."],
+                recovery=["Use project_tools.audit and project_tools.validate to diagnose project tool failures."],
+                concepts={"Project MCP Tool": "A project-owned Python function exposed to agents as an MCP tool."},
+            )
+            if name in self._registered_names:
+                skipped.append(name)
+                continue
+            try:
+                mcp.tool(name=name)(self._make_mcp_callable(name))
+                self._registered_names.add(name)
+                registered.append(name)
+            except Exception as exc:
+                self._audit("register", False, f"Failed to register {name}: {exc}", tool=name)
+        return {"registered": registered, "already_registered": skipped}
+
+    def reload(self) -> dict[str, Any]:
+        result = self.discover()
+        if self._mcp is not None:
+            result["registration"] = self.register_with_mcp(self._mcp)
+        return result
+
+    def validate(self, path: str = "") -> dict[str, Any]:
+        if path:
+            return validate_file(self.project_path, path)
+        reports = []
+        for file_path in self._iter_tool_files(self._config()):
+            reports.append(validate_file(self.project_path, file_path))
+        return {"ok": all(report.get("ok") for report in reports), "reports": reports}
+
+    def list_tools(self) -> dict[str, Any]:
+        return {
+            "tools": [
+                {
+                    "name": definition.name,
+                    "summary": definition.summary,
+                    "path": definition.rel_path,
+                    "generated": definition.generated,
+                    "tags": definition.tags,
+                    "status": "disabled" if definition.name in self.disabled_tools else definition.status,
+                    "validation": definition.validation,
+                }
+                for definition in sorted(self.tools.values(), key=lambda item: item.name)
+            ],
+            "files": list(self.file_reports.values()),
+            "disabled_tools": sorted(self.disabled_tools),
+        }
+
+    def explain(self, name: str) -> dict[str, Any]:
+        definition = self.tools.get(name)
+        if definition is None:
+            raise FileNotFoundError(f"Project tool not found: {name}")
+        return {
+            "name": definition.name,
+            "summary": definition.summary,
+            "path": definition.rel_path,
+            "generated": definition.generated,
+            "tags": definition.tags,
+            "source_trace": definition.source_trace,
+            "source_traces": definition.source_traces,
+            "signature": str(inspect.signature(definition.callable)),
+            "doc": inspect.getdoc(definition.callable) or "",
+        }
+
+    def audit(self, limit: int = 100) -> dict[str, Any]:
+        return {"events": self.audit_events[-max(int(limit), 1):]}
+
+    def execute(self, name: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        from Infernux.mcp.tools.common import explain_for, fail, ok
+
+        started = time.monotonic()
+        definition = self.tools.get(name)
+        if definition is None:
+            result = fail("error.not_found", f"Project tool is not loaded: {name}")
+            record_tool_call(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), error="not loaded")
+            return result
+        if name in self.disabled_tools:
+            result = fail("error.disabled", f"Project tool is disabled: {name}")
+            record_tool_call(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), error="disabled")
+            return result
+
+        explain = explain_for(name, summary=definition.summary)
+        try:
+            value = MainThreadCommandQueue.instance().run_sync(
+                name,
+                lambda: definition.callable(*args, **kwargs),
+                timeout_ms=60000,
+            )
+            result = value if _is_envelope(value) else ok(value, explain=explain)
+            self._audit("call", True, f"Called {name}", tool=name)
+            record_tool_call(name, ok=True, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs))
+            return result
+        except Exception as exc:
+            message = f"{type(exc).__name__}: {exc}"
+            self._audit("call", False, message, tool=name, traceback_text="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
+            record_tool_call(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), error=message)
+            return fail("error.project_tool", message, hint="Use project_tools.audit and project_tools.validate to inspect this project-defined tool.", explain=explain)
+
+    def _make_mcp_callable(self, name: str) -> Callable:
+        definition = self.tools[name]
+
+        @wraps(definition.callable)
+        def _call(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return self.execute(name, *args, **kwargs)
+
+        try:
+            _call.__signature__ = inspect.signature(definition.callable)  # type: ignore[attr-defined]
+        except (TypeError, ValueError):
+            pass
+        _call.__doc__ = definition.summary or inspect.getdoc(definition.callable)
+        return _call
+
+    def _load_file(self, file_path: str) -> dict[str, Any]:
+        rel_path = self._rel(file_path)
+        load = load_tool_module(self.project_path, file_path)
+        if not load["ok"]:
+            self._audit("load", False, load.get("error", ""), path=rel_path, traceback_text=load.get("traceback", ""))
+            return {"path": rel_path, "ok": False, "error": load.get("error", ""), "tools": []}
+        definitions = collect_tool_definitions(load["module"], self.project_path, file_path)
+        tools = []
+        violations = []
+        for definition in definitions:
+            schema_issues = validate_callable_schema(definition.callable)
+            if schema_issues:
+                violations.append({"tool": definition.name, "issues": schema_issues})
+            if not definition.name.startswith("project."):
+                violations.append({"tool": definition.name, "issues": ["Project tool names should start with 'project.' for clarity."]})
+            if definition.name in self.tools:
+                violations.append({"tool": definition.name, "issues": [f"Duplicate project tool name: {definition.name}"]})
+                continue
+            self.tools[definition.name] = definition
+            tools.append(definition.name)
+        ok_flag = not violations
+        self._audit("load", ok_flag, f"Loaded {len(tools)} tool(s) from {rel_path}", path=rel_path)
+        return {"path": rel_path, "ok": ok_flag, "tools": tools, "violations": violations}
+
+    def _iter_tool_files(self, config: dict[str, Any]) -> list[str]:
+        roots = config.get("tool_roots") or ["Assets/AgentTools", "Assets/AgentTools/generated"]
+        scan_generated = bool(config.get("scan_generated_tools", True))
+        files = []
+        for root in roots:
+            root_path = self._resolve_project_path(str(root))
+            if not os.path.isdir(root_path):
+                continue
+            is_generated_root = self._rel(root_path).replace("\\", "/").startswith("Assets/AgentTools/generated")
+            if is_generated_root and not scan_generated:
+                continue
+            for base, dirs, names in os.walk(root_path):
+                dirs[:] = [d for d in dirs if d != "__pycache__"]
+                for name in sorted(names):
+                    if name.endswith(".py") and not name.startswith("_"):
+                        files.append(os.path.join(base, name))
+        return sorted(files)
+
+    def _config(self) -> dict[str, Any]:
+        default = {
+            "enabled": True,
+            "tool_roots": ["Assets/AgentTools", "Assets/AgentTools/generated"],
+            "scan_generated_tools": True,
+            "disabled_tools": [],
+        }
+        if not self.project_path:
+            return default
+        path = os.path.join(self.project_path, "ProjectSettings", "agent_tools.json")
+        if not os.path.isfile(path):
+            return default
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                merged = dict(default)
+                merged.update(data)
+                return merged
+        except Exception as exc:
+            self._audit("config", False, f"Failed to read ProjectSettings/agent_tools.json: {exc}")
+        return default
+
+    def _resolve_project_path(self, path: str) -> str:
+        root = os.path.abspath(self.project_path)
+        raw = os.path.abspath(path if os.path.isabs(path) else os.path.join(root, path))
+        if os.path.commonpath([root, raw]) != root:
+            raise ValueError("Project tool path must stay inside the project.")
+        return raw
+
+    def _rel(self, path: str) -> str:
+        return os.path.relpath(os.path.abspath(path), self.project_path).replace("\\", "/")
+
+    def _audit(self, action: str, success: bool, message: str, **extra: Any) -> None:
+        event = {
+            "time": time.time(),
+            "action": action,
+            "ok": bool(success),
+            "message": str(message),
+        }
+        event.update({key: value for key, value in extra.items() if value not in (None, "")})
+        self.audit_events.append(event)
+        if len(self.audit_events) > 500:
+            self.audit_events = self.audit_events[-500:]
+
+
+def _is_envelope(value: Any) -> bool:
+    return isinstance(value, dict) and "ok" in value and ("data" in value or "error" in value)
+
+
+def _elapsed_ms(started: float) -> float:
+    return (time.monotonic() - started) * 1000.0
+
+
+def _arguments(definition: ProjectToolDefinition | None, args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
+    if definition is None:
+        return dict(kwargs)
+    try:
+        bound = inspect.signature(definition.callable).bind_partial(*args, **kwargs)
+        return dict(bound.arguments)
+    except Exception:
+        return {"args": list(args), **kwargs}
+

--- a/python/Infernux/mcp/project_tools/trace.py
+++ b/python/Infernux/mcp/project_tools/trace.py
@@ -1,0 +1,120 @@
+"""Minimal trace recorder for MCP tool calls."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from typing import Any
+
+
+_active_trace: dict[str, Any] | None = None
+_last_trace: dict[str, Any] | None = None
+
+
+def start_trace(project_path: str, task: str = "") -> dict[str, Any]:
+    global _active_trace
+    _active_trace = {
+        "trace_id": f"{time.strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}",
+        "task": str(task or ""),
+        "started_at": time.time(),
+        "steps": [],
+    }
+    return current_trace()
+
+
+def stop_trace(project_path: str, save: bool = True) -> dict[str, Any]:
+    global _active_trace, _last_trace
+    if _active_trace is None:
+        return {"active": False, "trace": None, "saved_path": ""}
+    trace = dict(_active_trace)
+    trace["ended_at"] = time.time()
+    trace["elapsed_seconds"] = max(0.0, trace["ended_at"] - float(trace.get("started_at", trace["ended_at"])))
+    saved_path = ""
+    if save:
+        saved_path = _save_trace(project_path, trace)
+    _last_trace = trace
+    _active_trace = None
+    return {"active": False, "trace": trace, "saved_path": saved_path}
+
+
+def current_trace() -> dict[str, Any]:
+    return {"active": _active_trace is not None, "trace": _active_trace}
+
+
+def last_trace() -> dict[str, Any]:
+    return {"trace": _last_trace}
+
+
+def record_tool_call(
+    name: str,
+    *,
+    ok: bool,
+    elapsed_ms: float = 0.0,
+    arguments: dict[str, Any] | None = None,
+    error: str = "",
+) -> None:
+    if _active_trace is None:
+        return
+    step = {
+        "index": len(_active_trace["steps"]),
+        "tool": str(name),
+        "ok": bool(ok),
+        "elapsed_ms": round(float(elapsed_ms), 3),
+    }
+    if arguments:
+        step["arguments"] = _jsonable_summary(arguments)
+    if error:
+        step["error"] = str(error)
+    _active_trace["steps"].append(step)
+
+
+def list_traces(project_path: str, limit: int = 50) -> list[dict[str, Any]]:
+    trace_dir = _trace_dir(project_path)
+    if not os.path.isdir(trace_dir):
+        return []
+    entries = []
+    for name in sorted(os.listdir(trace_dir), reverse=True):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(trace_dir, name)
+        entries.append({
+            "file": os.path.relpath(path, project_path).replace("\\", "/"),
+            "name": name,
+            "size": os.path.getsize(path),
+        })
+        if len(entries) >= max(int(limit), 1):
+            break
+    return entries
+
+
+def _save_trace(project_path: str, trace: dict[str, Any]) -> str:
+    trace_dir = _trace_dir(project_path)
+    os.makedirs(trace_dir, exist_ok=True)
+    file_path = os.path.join(trace_dir, f"{trace['trace_id']}.json")
+    with open(file_path, "w", encoding="utf-8", newline="\n") as f:
+        json.dump(trace, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    return os.path.relpath(file_path, project_path).replace("\\", "/")
+
+
+def _trace_dir(project_path: str) -> str:
+    return os.path.join(os.path.abspath(project_path), ".infernux", "mcp_traces")
+
+
+def _jsonable_summary(value: Any, *, max_string: int = 240) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return value if len(value) <= max_string else value[:max_string] + "...<truncated>"
+    if isinstance(value, dict):
+        return {str(k): _jsonable_summary(v, max_string=max_string) for k, v in list(value.items())[:40]}
+    if isinstance(value, (list, tuple)):
+        items = list(value)
+        summarized = [_jsonable_summary(v, max_string=max_string) for v in items[:40]]
+        if len(items) > 40:
+            summarized.append(f"...<{len(items) - 40} more>")
+        return summarized
+    return str(value)
+

--- a/python/Infernux/mcp/server.py
+++ b/python/Infernux/mcp/server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 import threading
 from typing import Optional
 
@@ -9,6 +11,8 @@ from Infernux.debug import Debug
 
 HOST = "127.0.0.1"
 PORT = 9713
+PATH = "/mcp"
+SERVER_NAME = "Infernux Editor"
 
 _server_thread: Optional[threading.Thread] = None
 _server = None
@@ -32,9 +36,10 @@ def start_server(project_path: str, *, host: str = HOST, port: int = PORT) -> bo
         return False
 
     _project_path = project_path
-    _server = FastMCP("Infernux Editor")
+    _server = FastMCP(SERVER_NAME)
     from Infernux.mcp.tools import register_all_tools
     register_all_tools(_server, project_path)
+    _write_discovery_files(project_path, host=host, port=int(port))
 
     def _run() -> None:
         last_error = None
@@ -52,7 +57,7 @@ def start_server(project_path: str, *, host: str = HOST, port: int = PORT) -> bo
 
     _server_thread = threading.Thread(target=_run, name="InfernuxMCPHTTP", daemon=True)
     _server_thread.start()
-    Debug.log_internal(f"Infernux MCP HTTP server starting at http://{host}:{port}/mcp")
+    Debug.log_internal(f"Infernux MCP HTTP server starting at {endpoint_url(host=host, port=int(port))}")
     return True
 
 
@@ -75,8 +80,220 @@ def is_running() -> bool:
     return _server_thread is not None and _server_thread.is_alive()
 
 
-def endpoint_url() -> str:
-    return f"http://{HOST}:{PORT}/mcp"
+def endpoint_url(*, host: str = HOST, port: int = PORT) -> str:
+    return f"http://{host}:{int(port)}{PATH}"
+
+
+def connection_info(*, host: str = HOST, port: int = PORT) -> dict:
+    url = endpoint_url(host=host, port=int(port))
+    return {
+        "name": SERVER_NAME,
+        "transport": "streamable-http",
+        "host": host,
+        "port": int(port),
+        "path": PATH,
+        "url": url,
+        "clients": _client_connection_configs(url),
+    }
+
+
+def _client_connection_configs(url: str) -> dict:
+    return {
+        "generic": {
+            "file": "mcp.json",
+            "format": "mcpServers",
+            "config": {
+                "mcpServers": {
+                    "infernux-editor": {
+                        "url": url,
+                        "transport": "streamable-http",
+                    }
+                }
+            },
+        },
+        "cursor": {
+            "file": ".cursor/mcp.json",
+            "format": "mcpServers",
+            "config": {
+                "mcpServers": {
+                    "infernux-editor": {
+                        "url": url,
+                        "transport": "streamable-http",
+                    }
+                }
+            },
+        },
+        "claude_code": {
+            "file": ".mcp.json",
+            "format": "mcpServers",
+            "config": {
+                "mcpServers": {
+                    "infernux-editor": {
+                        "type": "http",
+                        "url": url,
+                    }
+                }
+            },
+        },
+        "vscode_copilot": {
+            "file": ".vscode/mcp.json",
+            "format": "servers",
+            "config": {
+                "servers": {
+                    "infernux-editor": {
+                        "type": "http",
+                        "url": url,
+                    }
+                }
+            },
+        },
+        "trae": {
+            "file": ".trae/mcp.json",
+            "format": "mcpServers",
+            "config": {
+                "mcpServers": {
+                    "infernux-editor": {
+                        "type": "http",
+                        "url": url,
+                    }
+                }
+            },
+        },
+        "gemini": {
+            "file": ".gemini/settings.json",
+            "format": "mcpServers",
+            "config": {
+                "mcpServers": {
+                    "infernux-editor": {
+                        "httpUrl": url,
+                        "timeout": 600000,
+                        "trust": False,
+                    }
+                }
+            },
+        },
+        "codex": {
+            "file": ".codex/config.toml",
+            "format": "toml:mcp_servers",
+            "toml": (
+                "[mcp_servers.\"infernux-editor\"]\n"
+                f"url = \"{url}\"\n"
+                "enabled = true\n"
+                "startup_timeout_sec = 10\n"
+                "tool_timeout_sec = 120\n"
+            ),
+        },
+    }
+
+
+def _write_discovery_files(project_path: str, *, host: str, port: int) -> None:
+    """Write small project-local MCP discovery files for external agents.
+
+    These files are intentionally data-only and safe to regenerate. They make
+    the embedded editor MCP endpoint discoverable without hard-coding the port
+    in an agent prompt.
+    """
+    root = os.path.abspath(project_path or "")
+    if not root:
+        return
+    info = connection_info(host=host, port=port)
+    try:
+        os.makedirs(root, exist_ok=True)
+        _write_generic_manifest(root, info)
+        for client_name, client in info["clients"].items():
+            if client_name == "generic":
+                continue
+            target = os.path.join(root, client["file"])
+            if client.get("format") == "toml:mcp_servers":
+                _upsert_toml_block(target, "infernux-editor", client["toml"])
+            else:
+                _merge_client_json_config(target, client["config"])
+    except Exception as exc:
+        Debug.log_suppressed("Infernux.mcp.write_discovery_files", exc)
+
+
+def _write_generic_manifest(root: str, info: dict) -> None:
+    generic = info["clients"]["generic"]["config"]
+    _write_json_if_changed(os.path.join(root, "mcp.json"), {
+        "infernux": {
+            "name": info["name"],
+            "transport": info["transport"],
+            "host": info["host"],
+            "port": info["port"],
+            "path": info["path"],
+            "url": info["url"],
+        },
+        "clients": {
+            name: {"file": client["file"], "format": client["format"]}
+            for name, client in info["clients"].items()
+        },
+        **generic,
+    })
+
+
+def _merge_client_json_config(path: str, config: dict) -> None:
+    data = _read_json_object(path)
+    for root_key, root_value in config.items():
+        if isinstance(root_value, dict):
+            bucket = data.setdefault(root_key, {})
+            if isinstance(bucket, dict):
+                bucket.update(root_value)
+            else:
+                data[root_key] = root_value
+        else:
+            data[root_key] = root_value
+    _write_json_if_changed(path, data)
+
+
+def _upsert_toml_block(path: str, server_name: str, block: str) -> None:
+    start = f"# BEGIN INFERNUX MCP {server_name}"
+    end = f"# END INFERNUX MCP {server_name}"
+    marked = f"{start}\n{block.rstrip()}\n{end}\n"
+    text = ""
+    if os.path.isfile(path):
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+    if start in text and end in text:
+        before, rest = text.split(start, 1)
+        _old, after = rest.split(end, 1)
+        new_text = before.rstrip() + "\n\n" + marked + after.lstrip()
+    else:
+        duplicate_headers = (
+            f'[mcp_servers."{server_name}"]',
+            f"[mcp_servers.{server_name}]",
+        )
+        if any(header in text for header in duplicate_headers):
+            return
+        new_text = text.rstrip() + ("\n\n" if text.strip() else "") + marked
+    _write_text_if_changed(path, new_text)
+
+
+def _read_json_object(path: str) -> dict:
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            value = json.load(f)
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_json_if_changed(path: str, value: dict) -> None:
+    text = json.dumps(value, indent=2, ensure_ascii=False) + "\n"
+    _write_text_if_changed(path, text)
+
+
+def _write_text_if_changed(path: str, text: str) -> None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            if f.read() == text:
+                return
+    except FileNotFoundError:
+        pass
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(text)
 
 
 def _import_fastmcp():

--- a/python/Infernux/mcp/server.py
+++ b/python/Infernux/mcp/server.py
@@ -1,0 +1,94 @@
+"""Embedded HTTP MCP server for Infernux Editor."""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from Infernux.debug import Debug
+
+HOST = "127.0.0.1"
+PORT = 9713
+
+_server_thread: Optional[threading.Thread] = None
+_server = None
+_project_path = ""
+
+
+def start_server(project_path: str, *, host: str = HOST, port: int = PORT) -> bool:
+    """Start the embedded HTTP MCP server if it is not already running."""
+    global _server_thread, _server, _project_path
+
+    if _server_thread is not None and _server_thread.is_alive():
+        return True
+
+    try:
+        FastMCP = _import_fastmcp()
+    except Exception as exc:
+        Debug.log_warning(
+            "Infernux MCP disabled: install PyPI packages 'mcp' and 'fastmcp' to enable "
+            f"the embedded HTTP server ({exc})."
+        )
+        return False
+
+    _project_path = project_path
+    _server = FastMCP("Infernux Editor")
+    from Infernux.mcp.tools import register_all_tools
+    register_all_tools(_server, project_path)
+
+    def _run() -> None:
+        last_error = None
+        try:
+            for transport in ("http", "streamable-http"):
+                try:
+                    _server.run(transport=transport, host=host, port=int(port))
+                    return
+                except Exception as exc:
+                    last_error = exc
+                    if transport == "streamable-http":
+                        raise
+        except Exception as exc:
+            Debug.log_error(f"Infernux MCP HTTP server stopped: {exc or last_error}")
+
+    _server_thread = threading.Thread(target=_run, name="InfernuxMCPHTTP", daemon=True)
+    _server_thread.start()
+    Debug.log_internal(f"Infernux MCP HTTP server starting at http://{host}:{port}/mcp")
+    return True
+
+
+def stop_server() -> None:
+    """Best-effort stop hook for editor shutdown."""
+    global _server
+    server = _server
+    _server = None
+    for method_name in ("stop", "shutdown", "close"):
+        method = getattr(server, method_name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception as exc:
+                Debug.log_suppressed(f"Infernux.mcp.stop_server.{method_name}", exc)
+            break
+
+
+def is_running() -> bool:
+    return _server_thread is not None and _server_thread.is_alive()
+
+
+def endpoint_url() -> str:
+    return f"http://{HOST}:{PORT}/mcp"
+
+
+def _import_fastmcp():
+    try:
+        from fastmcp import FastMCP
+        return FastMCP
+    except Exception as first:
+        try:
+            from mcp.server.fastmcp import FastMCP
+            return FastMCP
+        except Exception as second:
+            raise ImportError(
+                "Need PyPI packages 'mcp' and 'fastmcp' (see ProjectSettings/requirements.txt). "
+                f"Primary import failed: {first!r}; fallback failed: {second!r}"
+            ) from second

--- a/python/Infernux/mcp/threading.py
+++ b/python/Infernux/mcp/threading.py
@@ -1,0 +1,84 @@
+"""Main-thread command queue for the embedded MCP server."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from typing import Any, Callable, Optional
+
+
+class CommandFuture:
+    def __init__(self, name: str):
+        self.name = name
+        self._event = threading.Event()
+        self._result: Any = None
+        self._error: Optional[BaseException] = None
+
+    def set_result(self, value: Any) -> None:
+        self._result = value
+        self._event.set()
+
+    def set_error(self, error: BaseException) -> None:
+        self._error = error
+        self._event.set()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        if not self._event.wait(timeout):
+            raise TimeoutError(f"MCP command timed out: {self.name}")
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+class MainThreadCommandQueue:
+    _instance: Optional["MainThreadCommandQueue"] = None
+
+    def __init__(self) -> None:
+        self._queue: "queue.Queue[tuple[str, Callable[[], Any], CommandFuture]]" = queue.Queue()
+        self._main_thread_id: Optional[int] = None
+
+    @classmethod
+    def instance(cls) -> "MainThreadCommandQueue":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def submit(self, name: str, fn: Callable[[], Any], *, timeout_ms: int = 30000) -> CommandFuture:
+        future = CommandFuture(name)
+        if self._main_thread_id == threading.get_ident():
+            try:
+                future.set_result(fn())
+            except BaseException as exc:
+                future.set_error(exc)
+            return future
+        self._queue.put((name, fn, future))
+        return future
+
+    def run_sync(self, name: str, fn: Callable[[], Any], *, timeout_ms: int = 30000) -> Any:
+        future = self.submit(name, fn, timeout_ms=timeout_ms)
+        return future.result(timeout=max(timeout_ms, 1) / 1000.0)
+
+    def drain(self, max_commands: int = 16) -> int:
+        self._main_thread_id = threading.get_ident()
+        processed = 0
+        for _ in range(max_commands):
+            try:
+                _name, fn, future = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            try:
+                future.set_result(fn())
+            except BaseException as exc:
+                future.set_error(exc)
+            finally:
+                processed += 1
+        return processed
+
+    def wait_until_ready(self, timeout: float = 5.0) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self._main_thread_id is not None:
+                return True
+            time.sleep(0.01)
+        return self._main_thread_id is not None

--- a/python/Infernux/mcp/tools/__init__.py
+++ b/python/Infernux/mcp/tools/__init__.py
@@ -1,0 +1,19 @@
+"""MCP tool registration for the embedded Infernux server."""
+
+from __future__ import annotations
+
+from Infernux.mcp.tools.assets import register_asset_tools
+from Infernux.mcp.tools.console import register_console_tools
+from Infernux.mcp.tools.editor import register_editor_tools
+from Infernux.mcp.tools.hierarchy import register_hierarchy_tools
+from Infernux.mcp.tools.project import register_project_tools
+from Infernux.mcp.tools.scene import register_scene_tools
+
+
+def register_all_tools(mcp, project_path: str) -> None:
+    register_project_tools(mcp, project_path)
+    register_editor_tools(mcp)
+    register_scene_tools(mcp)
+    register_hierarchy_tools(mcp)
+    register_asset_tools(mcp, project_path)
+    register_console_tools(mcp)

--- a/python/Infernux/mcp/tools/__init__.py
+++ b/python/Infernux/mcp/tools/__init__.py
@@ -3,17 +3,27 @@
 from __future__ import annotations
 
 from Infernux.mcp.tools.assets import register_asset_tools
+from Infernux.mcp.tools.camera import register_camera_tools
 from Infernux.mcp.tools.console import register_console_tools
+from Infernux.mcp.tools.docs import register_docs_tools
 from Infernux.mcp.tools.editor import register_editor_tools
 from Infernux.mcp.tools.hierarchy import register_hierarchy_tools
+from Infernux.mcp.tools.material import register_material_tools
 from Infernux.mcp.tools.project import register_project_tools
+from Infernux.mcp.tools.runtime import register_runtime_tools
 from Infernux.mcp.tools.scene import register_scene_tools
+from Infernux.mcp.tools.ui import register_ui_tools
 
 
 def register_all_tools(mcp, project_path: str) -> None:
+    register_docs_tools(mcp, project_path)
     register_project_tools(mcp, project_path)
     register_editor_tools(mcp)
     register_scene_tools(mcp)
     register_hierarchy_tools(mcp)
     register_asset_tools(mcp, project_path)
+    register_material_tools(mcp, project_path)
     register_console_tools(mcp)
+    register_camera_tools(mcp)
+    register_runtime_tools(mcp)
+    register_ui_tools(mcp)

--- a/python/Infernux/mcp/tools/__init__.py
+++ b/python/Infernux/mcp/tools/__init__.py
@@ -10,6 +10,7 @@ from Infernux.mcp.tools.editor import register_editor_tools
 from Infernux.mcp.tools.hierarchy import register_hierarchy_tools
 from Infernux.mcp.tools.material import register_material_tools
 from Infernux.mcp.tools.project import register_project_tools
+from Infernux.mcp.tools.project_tools import register_project_defined_tools, register_project_tool_management
 from Infernux.mcp.tools.runtime import register_runtime_tools
 from Infernux.mcp.tools.scene import register_scene_tools
 from Infernux.mcp.tools.ui import register_ui_tools
@@ -27,3 +28,5 @@ def register_all_tools(mcp, project_path: str) -> None:
     register_camera_tools(mcp)
     register_runtime_tools(mcp)
     register_ui_tools(mcp)
+    register_project_tool_management(mcp, project_path)
+    register_project_defined_tools(mcp, project_path)

--- a/python/Infernux/mcp/tools/assets.py
+++ b/python/Infernux/mcp/tools/assets.py
@@ -1,0 +1,296 @@
+"""Asset/resource creation MCP tools."""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+from Infernux.mcp.tools.common import (
+    get_asset_database,
+    main_thread,
+    notify_asset_changed,
+    resolve_project_dir,
+    resolve_project_path,
+)
+
+
+def register_asset_tools(mcp, project_path: str) -> None:
+    @mcp.tool(name="asset.create_builtin_resource")
+    def asset_create_builtin_resource(
+        kind: str,
+        name: str,
+        directory: str = "Assets",
+        shader_type: str = "frag",
+    ) -> dict:
+        """Create a built-in resource type: folder, script, material, shader, or scene."""
+
+        def _create():
+            return _create_builtin(project_path, kind, name, directory, shader_type)
+
+        return main_thread("asset.create_builtin_resource", _create)
+
+    @mcp.tool(name="asset.create_script")
+    def asset_create_script(name: str, directory: str = "Assets") -> dict:
+        """Create a Python component script resource from the editor template."""
+        return main_thread(
+            "asset.create_script",
+            lambda: _create_builtin(project_path, "script", name, directory, "frag"),
+        )
+
+    @mcp.tool(name="asset.create_material")
+    def asset_create_material(name: str, directory: str = "Assets") -> dict:
+        """Create a material resource from the editor template."""
+        return main_thread(
+            "asset.create_material",
+            lambda: _create_builtin(project_path, "material", name, directory, "frag"),
+        )
+
+    @mcp.tool(name="asset.list")
+    def asset_list(
+        directory: str = "Assets",
+        recursive: bool = True,
+        include_meta: bool = False,
+        limit: int = 500,
+    ) -> dict:
+        """List files and directories under the project."""
+
+        def _list():
+            root = resolve_project_path(project_path, directory or "Assets")
+            entries = []
+            max_count = max(int(limit), 1)
+            adb = get_asset_database()
+
+            def _entry(path: str) -> dict:
+                rel = os.path.relpath(path, project_path).replace("\\", "/")
+                data = {
+                    "path": rel,
+                    "name": os.path.basename(path),
+                    "directory": os.path.isdir(path),
+                }
+                if include_meta and adb and os.path.isfile(path):
+                    try:
+                        data["guid"] = adb.get_guid_from_path(path) or ""
+                    except Exception:
+                        data["guid"] = ""
+                return data
+
+            if recursive:
+                for base, dirs, files in os.walk(root):
+                    dirs[:] = [d for d in dirs if d not in {".git", "__pycache__"}]
+                    for name in sorted(dirs + files):
+                        entries.append(_entry(os.path.join(base, name)))
+                        if len(entries) >= max_count:
+                            return {"root": os.path.relpath(root, project_path).replace("\\", "/"), "entries": entries}
+            else:
+                for name in sorted(os.listdir(root)):
+                    entries.append(_entry(os.path.join(root, name)))
+                    if len(entries) >= max_count:
+                        break
+            return {"root": os.path.relpath(root, project_path).replace("\\", "/"), "entries": entries}
+
+        return main_thread("asset.list", _list)
+
+    @mcp.tool(name="asset.search")
+    def asset_search(query: str, directory: str = "Assets", extensions: list[str] | None = None, limit: int = 100) -> dict:
+        """Search asset paths by filename substring and optional extensions."""
+
+        def _search():
+            root = resolve_project_path(project_path, directory or "Assets")
+            needle = (query or "").lower()
+            exts = {e.lower() if e.startswith(".") else "." + e.lower() for e in (extensions or [])}
+            matches = []
+            for base, dirs, files in os.walk(root):
+                dirs[:] = [d for d in dirs if d not in {".git", "__pycache__"}]
+                for name in files:
+                    if needle and needle not in name.lower():
+                        continue
+                    if exts and os.path.splitext(name)[1].lower() not in exts:
+                        continue
+                    path = os.path.join(base, name)
+                    matches.append(os.path.relpath(path, project_path).replace("\\", "/"))
+                    if len(matches) >= max(int(limit), 1):
+                        return {"matches": matches}
+            return {"matches": matches}
+
+        return main_thread("asset.search", _search)
+
+    @mcp.tool(name="asset.read_text")
+    def asset_read_text(path: str, max_bytes: int = 262144) -> dict:
+        """Read a UTF-8 text file inside the project."""
+
+        def _read():
+            file_path = resolve_project_path(project_path, path)
+            if not os.path.isfile(file_path):
+                raise FileNotFoundError(f"File not found: {path}")
+            size = os.path.getsize(file_path)
+            if size > max(int(max_bytes), 1):
+                raise ValueError(f"File is too large ({size} bytes).")
+            with open(file_path, "r", encoding="utf-8") as f:
+                text = f.read()
+            return {
+                "path": os.path.relpath(file_path, project_path).replace("\\", "/"),
+                "size": size,
+                "text": text,
+            }
+
+        return main_thread("asset.read_text", _read)
+
+    @mcp.tool(name="asset.write_text")
+    def asset_write_text(path: str, text: str, overwrite: bool = True) -> dict:
+        """Write a UTF-8 text file inside the project and notify AssetDatabase."""
+
+        def _write():
+            file_path = resolve_project_path(project_path, path)
+            existed = os.path.exists(file_path)
+            if existed and not overwrite:
+                raise FileExistsError(f"File already exists: {path}")
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            with open(file_path, "w", encoding="utf-8", newline="\n") as f:
+                f.write(text or "")
+            notify_asset_changed(file_path, "modified" if existed else "created")
+            return {
+                "path": os.path.relpath(file_path, project_path).replace("\\", "/"),
+                "bytes": os.path.getsize(file_path),
+                "created": not existed,
+            }
+
+        return main_thread("asset.write_text", _write)
+
+    @mcp.tool(name="asset.edit_text")
+    def asset_edit_text(path: str, old_text: str, new_text: str, count: int = 1) -> dict:
+        """Replace text in a UTF-8 file inside the project."""
+
+        def _edit():
+            file_path = resolve_project_path(project_path, path)
+            if not os.path.isfile(file_path):
+                raise FileNotFoundError(f"File not found: {path}")
+            with open(file_path, "r", encoding="utf-8") as f:
+                original = f.read()
+            occurrences = original.count(old_text)
+            if occurrences == 0:
+                raise ValueError("old_text was not found.")
+            replace_count = -1 if int(count) <= 0 else int(count)
+            updated = original.replace(old_text, new_text, replace_count)
+            with open(file_path, "w", encoding="utf-8", newline="\n") as f:
+                f.write(updated)
+            notify_asset_changed(file_path, "modified")
+            return {
+                "path": os.path.relpath(file_path, project_path).replace("\\", "/"),
+                "occurrences": occurrences,
+                "replaced": occurrences if replace_count < 0 else min(occurrences, replace_count),
+                "bytes": os.path.getsize(file_path),
+            }
+
+        return main_thread("asset.edit_text", _edit)
+
+    @mcp.tool(name="asset.delete")
+    def asset_delete(path: str) -> dict:
+        """Delete a file or directory inside the project."""
+
+        def _delete():
+            target = resolve_project_path(project_path, path)
+            if os.path.abspath(target) == os.path.abspath(project_path):
+                raise ValueError("Refusing to delete the project root.")
+            if not os.path.exists(target):
+                raise FileNotFoundError(f"Path not found: {path}")
+            is_dir = os.path.isdir(target)
+            try:
+                from Infernux.engine.ui.project_file_ops import delete_item
+                delete_item(target, get_asset_database())
+            except Exception:
+                if is_dir:
+                    shutil.rmtree(target)
+                else:
+                    os.remove(target)
+                notify_asset_changed(target, "deleted")
+            return {"deleted": True, "path": os.path.relpath(target, project_path).replace("\\", "/"), "directory": is_dir}
+
+        return main_thread("asset.delete", _delete)
+
+    @mcp.tool(name="asset.refresh")
+    def asset_refresh() -> dict:
+        """Refresh the AssetDatabase."""
+
+        def _refresh():
+            adb = get_asset_database()
+            if adb is None:
+                raise RuntimeError("AssetDatabase is not available.")
+            adb.refresh()
+            return {"refreshed": True}
+
+        return main_thread("asset.refresh", _refresh)
+
+    @mcp.tool(name="asset.resolve")
+    def asset_resolve(path: str = "", guid: str = "") -> dict:
+        """Resolve between asset path and GUID."""
+
+        def _resolve():
+            adb = get_asset_database()
+            if adb is None:
+                raise RuntimeError("AssetDatabase is not available.")
+            resolved_path = ""
+            resolved_guid = ""
+            if guid:
+                resolved_path = adb.get_path_from_guid(guid) or ""
+                resolved_guid = guid
+            elif path:
+                file_path = resolve_project_path(project_path, path)
+                resolved_guid = adb.get_guid_from_path(file_path) or ""
+                resolved_path = file_path
+            else:
+                raise ValueError("Provide path or guid.")
+            return {
+                "path": os.path.relpath(resolved_path, project_path).replace("\\", "/") if resolved_path else "",
+                "guid": resolved_guid,
+            }
+
+        return main_thread("asset.resolve", _resolve)
+
+
+
+def _create_builtin(project_path: str, kind: str, name: str, directory: str, shader_type: str) -> dict:
+    from Infernux.engine.ui import project_file_ops as ops
+
+    target_dir = resolve_project_dir(project_path, directory)
+    adb = get_asset_database()
+    normalized = kind.strip().lower()
+    if normalized == "folder":
+        success, message = ops.create_folder(target_dir, name)
+        path = os.path.join(target_dir, name.strip())
+    elif normalized == "script":
+        success, message = ops.create_script(target_dir, name, adb)
+        file_name = name if name.endswith(".py") else name + ".py"
+        path = os.path.join(target_dir, file_name)
+    elif normalized == "material":
+        success, message = ops.create_material(target_dir, name, adb)
+        base = name[:-4] if name.endswith(".mat") else name
+        path = os.path.join(target_dir, base + ".mat")
+    elif normalized == "shader":
+        success, message = ops.create_shader(target_dir, name, shader_type, adb)
+        base = name
+        for ext in (".vert", ".frag", ".glsl"):
+            if base.endswith(ext):
+                base = base[: -len(ext)]
+                break
+        path = os.path.join(target_dir, base + "." + shader_type)
+    elif normalized == "scene":
+        success, message = ops.create_scene(target_dir, name, adb)
+        path = message if success else ""
+    else:
+        raise ValueError("kind must be one of: folder, script, material, shader, scene")
+
+    if not success:
+        raise RuntimeError(message or f"Failed to create {kind}.")
+
+    guid = ""
+    if adb and path and os.path.isfile(path):
+        try:
+            guid = adb.get_guid_from_path(path) or ""
+        except Exception:
+            guid = ""
+    return {
+        "kind": normalized,
+        "name": name,
+        "path": path,
+        "guid": guid,
+    }

--- a/python/Infernux/mcp/tools/assets.py
+++ b/python/Infernux/mcp/tools/assets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import json
 import shutil
 
 from Infernux.mcp.tools.common import (
@@ -245,6 +246,220 @@ def register_asset_tools(mcp, project_path: str) -> None:
             }
 
         return main_thread("asset.resolve", _resolve)
+
+    @mcp.tool(name="asset.import")
+    def asset_import(path: str) -> dict:
+        """Import or re-import one asset path."""
+
+        def _import():
+            file_path = resolve_project_path(project_path, path)
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"Path not found: {path}")
+            notify_asset_changed(file_path, "modified")
+            return {"path": os.path.relpath(file_path, project_path).replace("\\", "/"), "imported": True}
+
+        return main_thread("asset.import", _import)
+
+    @mcp.tool(name="asset.move")
+    def asset_move(path: str, new_path: str, overwrite: bool = False) -> dict:
+        """Move a file or directory inside the project."""
+
+        def _move():
+            src = resolve_project_path(project_path, path)
+            dst = resolve_project_path(project_path, new_path)
+            if not os.path.exists(src):
+                raise FileNotFoundError(f"Path not found: {path}")
+            if os.path.exists(dst):
+                if not overwrite:
+                    raise FileExistsError(f"Destination already exists: {new_path}")
+                if os.path.isdir(dst):
+                    shutil.rmtree(dst)
+                else:
+                    os.remove(dst)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            adb = get_asset_database()
+            try:
+                from Infernux.engine.ui.project_file_ops import move_path
+                moved = move_path(src, dst, adb)
+                if moved:
+                    dst = moved
+                else:
+                    shutil.move(src, dst)
+            except Exception:
+                shutil.move(src, dst)
+            if adb:
+                try:
+                    adb.on_asset_moved(src, dst)
+                except Exception:
+                    pass
+            return {
+                "old_path": os.path.relpath(src, project_path).replace("\\", "/"),
+                "path": os.path.relpath(dst, project_path).replace("\\", "/"),
+            }
+
+        return main_thread("asset.move", _move)
+
+    @mcp.tool(name="asset.rename")
+    def asset_rename(path: str, new_name: str) -> dict:
+        """Rename a file or directory in place."""
+
+        def _rename():
+            src = resolve_project_path(project_path, path)
+            if not os.path.exists(src):
+                raise FileNotFoundError(f"Path not found: {path}")
+            try:
+                from Infernux.engine.ui.project_file_ops import do_rename
+                dst = do_rename(src, new_name, get_asset_database())
+            except Exception:
+                dst = None
+            if not dst:
+                dst = os.path.join(os.path.dirname(src), new_name)
+                if os.path.exists(dst):
+                    raise FileExistsError(f"Destination already exists: {new_name}")
+                os.rename(src, dst)
+            notify_asset_changed(dst, "modified")
+            return {"path": os.path.relpath(dst, project_path).replace("\\", "/")}
+
+        return main_thread("asset.rename", _rename)
+
+    @mcp.tool(name="asset.copy")
+    def asset_copy(path: str, new_path: str, overwrite: bool = False) -> dict:
+        """Copy a file or directory inside the project."""
+
+        def _copy():
+            src = resolve_project_path(project_path, path)
+            dst = resolve_project_path(project_path, new_path)
+            if not os.path.exists(src):
+                raise FileNotFoundError(f"Path not found: {path}")
+            if os.path.exists(dst):
+                if not overwrite:
+                    raise FileExistsError(f"Destination already exists: {new_path}")
+                if os.path.isdir(dst):
+                    shutil.rmtree(dst)
+                else:
+                    os.remove(dst)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if os.path.isdir(src):
+                shutil.copytree(src, dst)
+            else:
+                shutil.copy2(src, dst)
+            notify_asset_changed(dst, "created")
+            return {
+                "source": os.path.relpath(src, project_path).replace("\\", "/"),
+                "path": os.path.relpath(dst, project_path).replace("\\", "/"),
+            }
+
+        return main_thread("asset.copy", _copy)
+
+    @mcp.tool(name="asset.get_meta")
+    def asset_get_meta(path: str = "", guid: str = "") -> dict:
+        """Return AssetDatabase metadata when available."""
+
+        def _meta():
+            adb = get_asset_database()
+            if adb is None:
+                raise RuntimeError("AssetDatabase is not available.")
+            meta = None
+            if guid:
+                meta = adb.get_meta_by_guid(guid)
+            elif path:
+                meta = adb.get_meta_by_path(resolve_project_path(project_path, path))
+            else:
+                raise ValueError("Provide path or guid.")
+            if meta is None:
+                raise FileNotFoundError("Asset metadata not found.")
+            return {
+                "guid": str(getattr(meta, "guid", guid or "")),
+                "path": str(getattr(meta, "path", path or "")),
+                "type": str(getattr(getattr(meta, "type", None), "name", getattr(meta, "type", ""))),
+            }
+
+        return main_thread("asset.get_meta", _meta)
+
+    @mcp.tool(name="asset.list_by_type")
+    def asset_list_by_type(asset_type: str, limit: int = 500) -> dict:
+        """List AssetDatabase resources by resource type name."""
+
+        def _list_by_type():
+            adb = get_asset_database()
+            if adb is None:
+                raise RuntimeError("AssetDatabase is not available.")
+            matches = []
+            for guid in adb.get_all_resource_guids():
+                path = adb.get_path_from_guid(guid)
+                type_name = ""
+                try:
+                    type_name = getattr(adb.get_resource_type(path), "name", str(adb.get_resource_type(path)))
+                except Exception:
+                    pass
+                if asset_type and str(type_name).lower() != str(asset_type).lower():
+                    continue
+                matches.append({"guid": guid, "path": os.path.relpath(path, project_path).replace("\\", "/"), "type": type_name})
+                if len(matches) >= max(int(limit), 1):
+                    break
+            return {"assets": matches}
+
+        return main_thread("asset.list_by_type", _list_by_type)
+
+    @mcp.tool(name="asset.read_json")
+    def asset_read_json(path: str, max_bytes: int = 262144) -> dict:
+        """Read and parse a JSON text asset."""
+
+        def _read_json():
+            file_path = resolve_project_path(project_path, path)
+            if not os.path.isfile(file_path):
+                raise FileNotFoundError(f"File not found: {path}")
+            if os.path.getsize(file_path) > max(int(max_bytes), 1):
+                raise ValueError("JSON file is too large.")
+            with open(file_path, "r", encoding="utf-8") as f:
+                return {"path": os.path.relpath(file_path, project_path).replace("\\", "/"), "json": json.load(f)}
+
+        return main_thread("asset.read_json", _read_json)
+
+    @mcp.tool(name="asset.write_json")
+    def asset_write_json(path: str, value: dict | list, overwrite: bool = True, indent: int = 2) -> dict:
+        """Write a JSON text asset."""
+
+        def _write_json():
+            file_path = resolve_project_path(project_path, path)
+            existed = os.path.exists(file_path)
+            if existed and not overwrite:
+                raise FileExistsError(f"File already exists: {path}")
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            with open(file_path, "w", encoding="utf-8", newline="\n") as f:
+                json.dump(value, f, ensure_ascii=False, indent=int(indent))
+                f.write("\n")
+            notify_asset_changed(file_path, "modified" if existed else "created")
+            return {"path": os.path.relpath(file_path, project_path).replace("\\", "/"), "bytes": os.path.getsize(file_path), "created": not existed}
+
+        return main_thread("asset.write_json", _write_json)
+
+    @mcp.tool(name="asset.patch_text")
+    def asset_patch_text(path: str, replacements: list[dict[str, str]]) -> dict:
+        """Apply a sequence of exact text replacements to a file."""
+
+        def _patch_text():
+            file_path = resolve_project_path(project_path, path)
+            if not os.path.isfile(file_path):
+                raise FileNotFoundError(f"File not found: {path}")
+            with open(file_path, "r", encoding="utf-8") as f:
+                text = f.read()
+            trace = []
+            for item in replacements or []:
+                old = item.get("old", "")
+                new = item.get("new", "")
+                count = int(item.get("count", 1) or 1)
+                hits = text.count(old)
+                if hits <= 0:
+                    raise ValueError(f"Patch text was not found: {old[:80]!r}")
+                text = text.replace(old, new, -1 if count <= 0 else count)
+                trace.append({"old": old[:80], "hits": hits, "replaced": hits if count <= 0 else min(hits, count)})
+            with open(file_path, "w", encoding="utf-8", newline="\n") as f:
+                f.write(text)
+            notify_asset_changed(file_path, "modified")
+            return {"path": os.path.relpath(file_path, project_path).replace("\\", "/"), "replacements": trace}
+
+        return main_thread("asset.patch_text", _patch_text)
 
 
 

--- a/python/Infernux/mcp/tools/camera.py
+++ b/python/Infernux/mcp/tools/camera.py
@@ -1,0 +1,287 @@
+"""Camera, lighting, and render-view semantic MCP tools."""
+
+from __future__ import annotations
+
+from Infernux.mcp.tools.common import coerce_vector3, main_thread, register_tool_metadata
+
+
+def register_camera_tools(mcp) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="camera.find_main")
+    def camera_find_main() -> dict:
+        """Find likely main cameras in the active scene."""
+
+        def _find():
+            cameras = _find_cameras()
+            preferred = _pick_main_camera(cameras)
+            return {"main": preferred, "cameras": cameras}
+
+        return main_thread("camera.find_main", _find)
+
+    @mcp.tool(name="camera.ensure_main")
+    def camera_ensure_main(name: str = "Main Camera", create_if_missing: bool = True) -> dict:
+        """Return an existing main camera or create one if needed."""
+
+        def _ensure():
+            cameras = _find_cameras()
+            chosen = _pick_main_camera(cameras)
+            if chosen is None and create_if_missing:
+                from Infernux.engine.hierarchy_creation_service import HierarchyCreationService
+                created = HierarchyCreationService.instance().create("rendering.camera", name=name, select=False)
+                chosen = {
+                    "id": int(created["id"]),
+                    "name": str(created["name"]),
+                    "component_id": 0,
+                    "reason": "created",
+                }
+            if chosen is None:
+                raise FileNotFoundError("No camera found and create_if_missing is false.")
+            _try_set_scene_main_camera(int(chosen["id"]))
+            return {"camera": chosen, "created": chosen.get("reason") == "created"}
+
+        return main_thread("camera.ensure_main", _ensure)
+
+    @mcp.tool(name="camera.set_main")
+    def camera_set_main(object_id: int) -> dict:
+        """Set Scene.main_camera when supported by the binding."""
+
+        def _set():
+            obj = _find_game_object(object_id)
+            if _find_component(obj, "Camera") is None:
+                raise ValueError(f"GameObject {object_id} does not have a Camera component.")
+            applied = _try_set_scene_main_camera(int(object_id))
+            return {"object_id": int(object_id), "applied": applied}
+
+        return main_thread("camera.set_main", _set)
+
+    @mcp.tool(name="camera.attach_to_target")
+    def camera_attach_to_target(
+        camera_id: int,
+        target_id: int,
+        local_position: dict | list | tuple = None,
+        local_euler_angles: dict | list | tuple = None,
+        world_position_stays: bool = False,
+    ) -> dict:
+        """Parent a camera to a target with optional local offset."""
+
+        def _attach():
+            cam = _find_game_object(camera_id)
+            target = _find_game_object(target_id)
+            if _find_component(cam, "Camera") is None:
+                raise ValueError(f"GameObject {camera_id} does not have a Camera component.")
+            cam.set_parent(target, bool(world_position_stays))
+            if local_position is not None:
+                cam.transform.local_position = coerce_vector3(local_position)
+            if local_euler_angles is not None:
+                cam.transform.local_euler_angles = coerce_vector3(local_euler_angles)
+            _mark_scene_dirty()
+            return {
+                "camera_id": int(cam.id),
+                "target_id": int(target.id),
+                "local_position": _vec(cam.transform.local_position),
+                "local_euler_angles": _vec(cam.transform.local_euler_angles),
+            }
+
+        return main_thread("camera.attach_to_target", _attach)
+
+    @mcp.tool(name="camera.setup_third_person")
+    def camera_setup_third_person(
+        target_id: int,
+        camera_id: int = 0,
+        local_position: dict | list | tuple = None,
+        local_euler_angles: dict | list | tuple = None,
+        field_of_view: float = 65.0,
+    ) -> dict:
+        """Configure a main camera as a third-person child of target_id."""
+
+        def _setup():
+            if camera_id:
+                cam = _find_game_object(camera_id)
+            else:
+                ensured = _ensure_camera_object()
+                cam = _find_game_object(int(ensured["id"]))
+            target = _find_game_object(target_id)
+            cam.set_parent(target, False)
+            cam.transform.local_position = coerce_vector3(local_position or {"x": 0.0, "y": 3.0, "z": -7.0})
+            cam.transform.local_euler_angles = coerce_vector3(local_euler_angles or {"x": 18.0, "y": 0.0, "z": 0.0})
+            comp = _find_component(cam, "Camera")
+            if comp is not None:
+                try:
+                    comp.field_of_view = float(field_of_view)
+                except Exception:
+                    pass
+            _try_set_scene_main_camera(int(cam.id))
+            _mark_scene_dirty()
+            return {
+                "camera_id": int(cam.id),
+                "target_id": int(target.id),
+                "local_position": _vec(cam.transform.local_position),
+                "local_euler_angles": _vec(cam.transform.local_euler_angles),
+                "field_of_view": float(field_of_view),
+            }
+
+        return main_thread("camera.setup_third_person", _setup)
+
+    @mcp.tool(name="camera.setup_2d_card_game")
+    def camera_setup_2d_card_game(
+        camera_id: int = 0,
+        position: dict | list | tuple = None,
+        euler_angles: dict | list | tuple = None,
+        orthographic_size: float = 8.0,
+    ) -> dict:
+        """Configure a stable orthographic camera for card/UI-heavy games."""
+
+        def _setup():
+            if camera_id:
+                cam = _find_game_object(camera_id)
+            else:
+                ensured = _ensure_camera_object()
+                cam = _find_game_object(int(ensured["id"]))
+            cam.transform.position = coerce_vector3(position or {"x": 0.0, "y": 0.0, "z": 10.0})
+            cam.transform.euler_angles = coerce_vector3(euler_angles or {"x": 0.0, "y": 180.0, "z": 0.0})
+            comp = _find_component(cam, "Camera")
+            if comp is not None:
+                for field, value in (("projection_mode", 1), ("orthographic_size", float(orthographic_size)), ("near_clip", 0.01), ("far_clip", 1000.0)):
+                    try:
+                        setattr(comp, field, value)
+                    except Exception:
+                        pass
+            _try_set_scene_main_camera(int(cam.id))
+            _mark_scene_dirty()
+            return {
+                "camera_id": int(cam.id),
+                "position": _vec(cam.transform.position),
+                "euler_angles": _vec(cam.transform.euler_angles),
+                "orthographic_size": float(orthographic_size),
+            }
+
+        return main_thread("camera.setup_2d_card_game", _setup)
+
+    @mcp.tool(name="lighting.ensure_default")
+    def lighting_ensure_default() -> dict:
+        """Ensure the scene has a usable directional light."""
+
+        def _ensure():
+            from Infernux.engine.hierarchy_creation_service import HierarchyCreationService
+            from Infernux.lib import SceneManager, Vector3
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            for obj in scene.get_all_objects() or []:
+                if _find_component(obj, "Light") is not None:
+                    return {"light_id": int(obj.id), "created": False}
+            created = HierarchyCreationService.instance().create("light.directional", name="Directional Light", select=False)
+            obj = scene.find_by_id(int(created["id"]))
+            if obj and obj.transform:
+                obj.transform.euler_angles = Vector3(50.0, -30.0, 0.0)
+            return {"light_id": int(created["id"]), "created": True}
+
+        return main_thread("lighting.ensure_default", _ensure)
+
+
+def _find_cameras() -> list[dict]:
+    from Infernux.lib import SceneManager
+    scene = SceneManager.instance().get_active_scene()
+    if not scene:
+        raise RuntimeError("No active scene.")
+    cameras = []
+    main_camera = getattr(scene, "main_camera", None)
+    main_owner_id = int(getattr(getattr(main_camera, "game_object", None), "id", 0) or 0)
+    for obj in list(scene.get_all_objects() or []):
+        comp = _find_component(obj, "Camera")
+        if comp is None:
+            continue
+        cameras.append({
+            "id": int(obj.id),
+            "name": str(obj.name),
+            "component_id": int(getattr(comp, "component_id", 0) or 0),
+            "is_scene_main": main_owner_id == int(obj.id),
+        })
+    return cameras
+
+
+def _pick_main_camera(cameras: list[dict]) -> dict | None:
+    if not cameras:
+        return None
+    for cam in cameras:
+        if cam.get("is_scene_main"):
+            return {**cam, "reason": "scene.main_camera"}
+    for cam in cameras:
+        if str(cam.get("name", "")).lower() == "main camera":
+            return {**cam, "reason": "name"}
+    return {**cameras[0], "reason": "first_camera"}
+
+
+def _ensure_camera_object() -> dict:
+    chosen = _pick_main_camera(_find_cameras())
+    if chosen is not None:
+        return chosen
+    from Infernux.engine.hierarchy_creation_service import HierarchyCreationService
+    return HierarchyCreationService.instance().create("rendering.camera", name="Main Camera", select=False)
+
+
+def _try_set_scene_main_camera(object_id: int) -> bool:
+    from Infernux.lib import SceneManager
+    scene = SceneManager.instance().get_active_scene()
+    if not scene:
+        return False
+    obj = scene.find_by_id(int(object_id))
+    if obj is None:
+        return False
+    comp = _find_component(obj, "Camera")
+    if comp is None:
+        return False
+    try:
+        scene.main_camera = comp
+        return True
+    except Exception:
+        return False
+
+
+def _find_game_object(object_id: int):
+    from Infernux.mcp.tools.common import find_game_object
+    return find_game_object(object_id)
+
+
+def _find_component(obj, component_type: str):
+    try:
+        comp = obj.get_component(component_type)
+        if comp is not None:
+            return comp
+    except Exception:
+        pass
+    try:
+        for comp in obj.get_components() or []:
+            if getattr(comp, "type_name", type(comp).__name__) == component_type:
+                return comp
+    except Exception:
+        pass
+    return None
+
+
+def _mark_scene_dirty() -> None:
+    try:
+        from Infernux.engine.scene_manager import SceneFileManager
+        sfm = SceneFileManager.instance()
+        if sfm:
+            sfm.mark_dirty()
+    except Exception:
+        pass
+
+
+def _vec(value) -> list[float]:
+    return [float(value.x), float(value.y), float(value.z)]
+
+
+def _register_metadata() -> None:
+    for name, summary in {
+        "camera.find_main": "Find cameras and pick the best main camera candidate.",
+        "camera.ensure_main": "Reuse an existing main camera or create one if missing.",
+        "camera.set_main": "Set Scene.main_camera when the engine binding supports it.",
+        "camera.attach_to_target": "Parent a camera to a target with local offset.",
+        "camera.setup_third_person": "Configure a third-person camera rig.",
+        "camera.setup_2d_card_game": "Configure an orthographic camera for card/UI games.",
+        "lighting.ensure_default": "Ensure a directional light exists.",
+    }.items():
+        register_tool_metadata(name, summary=summary, next_suggested_tools=["scene.inspect", "runtime.read_errors"])

--- a/python/Infernux/mcp/tools/common.py
+++ b/python/Infernux/mcp/tools/common.py
@@ -3,35 +3,136 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Callable
 
 from Infernux.mcp.threading import MainThreadCommandQueue
 
+MCP_PROTOCOL_VERSION = "2025-03-26"
+MCP_SERVER_VERSION = "0.2.0"
 
-def ok(data: Any = None) -> dict[str, Any]:
-    return {"ok": True, "data": data if data is not None else {}}
+_TOOL_METADATA: dict[str, dict[str, Any]] = {}
 
 
-def fail(code: str, message: str, *, hint: str = "") -> dict[str, Any]:
+def register_tool_metadata(
+    name: str,
+    *,
+    summary: str = "",
+    parameters: dict[str, Any] | None = None,
+    side_effects: list[str] | None = None,
+    next_suggested_tools: list[str] | None = None,
+    recovery: list[str] | None = None,
+    examples: list[dict[str, Any]] | None = None,
+    concepts: dict[str, str] | None = None,
+) -> None:
+    """Register human/agent-facing metadata for a tool."""
+    _TOOL_METADATA[name] = {
+        "name": name,
+        "summary": summary,
+        "parameters": parameters or {},
+        "side_effects": side_effects or [],
+        "next_suggested_tools": next_suggested_tools or [],
+        "recovery": recovery or [],
+        "examples": examples or [],
+        "concepts": concepts or {},
+    }
+
+
+def get_tool_metadata(name: str) -> dict[str, Any]:
+    meta = dict(_TOOL_METADATA.get(name, {}))
+    if not meta:
+        meta = {
+            "name": name,
+            "summary": "No detailed metadata registered yet.",
+            "parameters": {},
+            "side_effects": [],
+            "next_suggested_tools": [],
+            "recovery": ["Use mcp.capabilities or mcp.list_tools_verbose to inspect available tools."],
+            "examples": [],
+            "concepts": {},
+        }
+    return meta
+
+
+def list_tool_metadata() -> list[dict[str, Any]]:
+    return [get_tool_metadata(name) for name in sorted(_TOOL_METADATA)]
+
+
+def explain_for(
+    tool: str,
+    *,
+    summary: str = "",
+    warnings: list[str] | None = None,
+    side_effects: list[str] | None = None,
+    next_suggested_tools: list[str] | None = None,
+    recovery: list[str] | None = None,
+    concepts: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    meta = get_tool_metadata(tool)
+    return {
+        "tool": tool,
+        "summary": summary or meta.get("summary", ""),
+        "concepts": concepts or meta.get("concepts", {}),
+        "side_effects": side_effects if side_effects is not None else meta.get("side_effects", []),
+        "warnings": warnings or [],
+        "next_suggested_tools": (
+            next_suggested_tools
+            if next_suggested_tools is not None
+            else meta.get("next_suggested_tools", [])
+        ),
+        "recovery": recovery if recovery is not None else meta.get("recovery", []),
+    }
+
+
+def ok(data: Any = None, *, explain: dict[str, Any] | None = None, trace: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"ok": True, "data": data if data is not None else {}}
+    if explain is not None:
+        payload["explain"] = explain
+    if trace is not None:
+        payload["trace"] = trace
+    return payload
+
+
+def fail(
+    code: str,
+    message: str,
+    *,
+    hint: str = "",
+    explain: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     error = {"code": code, "message": message}
     if hint:
         error["hint"] = hint
-    return {"ok": False, "error": error}
+    payload: dict[str, Any] = {"ok": False, "error": error}
+    if explain is not None:
+        payload["explain"] = explain
+    return payload
 
 
-def main_thread(name: str, fn, *, timeout_ms: int = 30000) -> dict[str, Any]:
+def main_thread(name: str, fn, *, timeout_ms: int = 30000, explain: dict[str, Any] | None = None) -> dict[str, Any]:
+    response_explain = explain or explain_for(name)
     try:
-        return ok(MainThreadCommandQueue.instance().run_sync(name, fn, timeout_ms=timeout_ms))
+        return ok(MainThreadCommandQueue.instance().run_sync(name, fn, timeout_ms=timeout_ms), explain=response_explain)
     except TimeoutError as exc:
-        return fail("error.timeout", str(exc))
+        return fail(
+            "error.timeout",
+            str(exc),
+            hint="The editor main thread did not process this command in time. Ensure the editor is not blocked by a modal operation.",
+            explain=response_explain,
+        )
     except ValueError as exc:
-        return fail("error.invalid_argument", str(exc))
+        return fail("error.invalid_argument", str(exc), hint="Check parameter schema with mcp.help or component.describe_type.", explain=response_explain)
     except FileExistsError as exc:
-        return fail("error.exists", str(exc))
+        return fail("error.exists", str(exc), hint="Use overwrite=true or choose a different path/name.", explain=response_explain)
     except FileNotFoundError as exc:
-        return fail("error.not_found", str(exc))
+        return fail("error.not_found", str(exc), hint="Use scene.inspect, gameobject.find, or asset.search to locate valid targets.", explain=response_explain)
     except Exception as exc:
-        return fail("error.internal", str(exc))
+        return fail("error.internal", str(exc), hint="Read console.read and retry with a smaller operation.", explain=response_explain)
+
+
+def register_and_tool(mcp, name: str, **metadata: Any) -> Callable:
+    """Register metadata and return mcp.tool for future tools."""
+    register_tool_metadata(name, **metadata)
+    return mcp.tool(name=name)
 
 
 def get_asset_database():

--- a/python/Infernux/mcp/tools/common.py
+++ b/python/Infernux/mcp/tools/common.py
@@ -1,0 +1,176 @@
+"""Shared helpers for Infernux MCP tools."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from Infernux.mcp.threading import MainThreadCommandQueue
+
+
+def ok(data: Any = None) -> dict[str, Any]:
+    return {"ok": True, "data": data if data is not None else {}}
+
+
+def fail(code: str, message: str, *, hint: str = "") -> dict[str, Any]:
+    error = {"code": code, "message": message}
+    if hint:
+        error["hint"] = hint
+    return {"ok": False, "error": error}
+
+
+def main_thread(name: str, fn, *, timeout_ms: int = 30000) -> dict[str, Any]:
+    try:
+        return ok(MainThreadCommandQueue.instance().run_sync(name, fn, timeout_ms=timeout_ms))
+    except TimeoutError as exc:
+        return fail("error.timeout", str(exc))
+    except ValueError as exc:
+        return fail("error.invalid_argument", str(exc))
+    except FileExistsError as exc:
+        return fail("error.exists", str(exc))
+    except FileNotFoundError as exc:
+        return fail("error.not_found", str(exc))
+    except Exception as exc:
+        return fail("error.internal", str(exc))
+
+
+def get_asset_database():
+    try:
+        from Infernux.lib import AssetRegistry
+        registry = AssetRegistry.instance()
+        if registry:
+            return registry.get_asset_database()
+    except Exception:
+        return None
+    return None
+
+
+def project_assets_dir(project_path: str) -> str:
+    assets = os.path.join(os.path.abspath(project_path), "Assets")
+    os.makedirs(assets, exist_ok=True)
+    return assets
+
+
+def resolve_project_dir(project_path: str, directory: str | None) -> str:
+    root = os.path.abspath(project_path)
+    if not directory:
+        return project_assets_dir(root)
+    raw = os.path.abspath(directory if os.path.isabs(directory) else os.path.join(root, directory))
+    if os.path.commonpath([root, raw]) != root:
+        raise ValueError("Target directory must stay inside the project.")
+    os.makedirs(raw, exist_ok=True)
+    return raw
+
+
+def resolve_project_path(project_path: str, path: str | None, *, default: str = "") -> str:
+    """Resolve a project-relative or absolute path and keep it inside the project."""
+    root = os.path.abspath(project_path)
+    candidate = path or default
+    if not candidate:
+        candidate = root
+    raw = os.path.abspath(candidate if os.path.isabs(candidate) else os.path.join(root, candidate))
+    if os.path.commonpath([root, raw]) != root:
+        raise ValueError("Path must stay inside the project.")
+    return raw
+
+
+def resolve_asset_path(project_path: str, path: str | None, *, default_name: str = "") -> str:
+    """Resolve a path under the project Assets directory."""
+    root = os.path.abspath(project_path)
+    assets = project_assets_dir(root)
+    candidate = path or default_name
+    if not candidate:
+        return assets
+    raw = os.path.abspath(candidate if os.path.isabs(candidate) else os.path.join(root, candidate))
+    if os.path.commonpath([assets, raw]) != assets:
+        raise ValueError("Asset path must stay inside Assets/.")
+    return raw
+
+
+def notify_asset_changed(path: str, action: str = "modified") -> None:
+    """Best-effort AssetDatabase notification for external MCP file writes."""
+    adb = get_asset_database()
+    if not adb:
+        return
+    method_names = {
+        "created": ("on_asset_created", "import_asset"),
+        "modified": ("on_asset_modified", "import_asset"),
+        "deleted": ("on_asset_deleted",),
+    }.get(action, ("on_asset_modified",))
+    for method_name in method_names:
+        method = getattr(adb, method_name, None)
+        if callable(method):
+            try:
+                method(path)
+                return
+            except Exception:
+                pass
+
+
+def serialize_vector(value) -> Any:
+    if value is None:
+        return None
+    if all(hasattr(value, attr) for attr in ("x", "y", "z")):
+        return [float(value.x), float(value.y), float(value.z)]
+    if all(hasattr(value, attr) for attr in ("x", "y")):
+        return [float(value.x), float(value.y)]
+    return value
+
+
+def coerce_vector3(value):
+    from Infernux.lib import Vector3
+    if isinstance(value, dict):
+        return Vector3(float(value.get("x", 0.0)), float(value.get("y", 0.0)), float(value.get("z", 0.0)))
+    if isinstance(value, (list, tuple)) and len(value) >= 3:
+        return Vector3(float(value[0]), float(value[1]), float(value[2]))
+    raise ValueError("Expected Vector3 as [x, y, z] or {x, y, z}.")
+
+
+def serialize_value(value: Any) -> Any:
+    """Convert editor/Python/C++ values to JSON-friendly data."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    vector = serialize_vector(value)
+    if vector is not value:
+        return vector
+    if hasattr(value, "name") and hasattr(value, "value") and type(value).__name__ != "GameObject":
+        try:
+            return {"name": str(value.name), "value": int(value.value)}
+        except Exception:
+            return str(value)
+    if hasattr(value, "id") and hasattr(value, "name"):
+        try:
+            return {"id": int(value.id), "name": str(value.name), "type": type(value).__name__}
+        except Exception:
+            pass
+    if isinstance(value, dict):
+        return {str(k): serialize_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [serialize_value(v) for v in value]
+    return str(value)
+
+
+def serialize_component(comp) -> dict[str, Any]:
+    type_name = str(getattr(comp, "type_name", type(comp).__name__))
+    data: dict[str, Any] = {
+        "type": type_name,
+        "python": bool(hasattr(comp, "_script_guid")),
+    }
+    component_id = getattr(comp, "component_id", None)
+    if component_id:
+        data["component_id"] = int(component_id)
+    script_guid = getattr(comp, "_script_guid", "")
+    if script_guid:
+        data["script_guid"] = script_guid
+    return data
+
+
+def find_game_object(object_id: int):
+    from Infernux.lib import SceneManager
+    scene = SceneManager.instance().get_active_scene()
+    if not scene:
+        raise RuntimeError("No active scene.")
+    obj = scene.find_by_id(int(object_id))
+    if obj is None:
+        raise FileNotFoundError(f"GameObject {object_id} was not found.")
+    return obj

--- a/python/Infernux/mcp/tools/common.py
+++ b/python/Infernux/mcp/tools/common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Any, Callable
 
 from Infernux.mcp.threading import MainThreadCommandQueue
@@ -110,9 +111,13 @@ def fail(
 
 def main_thread(name: str, fn, *, timeout_ms: int = 30000, explain: dict[str, Any] | None = None) -> dict[str, Any]:
     response_explain = explain or explain_for(name)
+    started = time.monotonic()
     try:
-        return ok(MainThreadCommandQueue.instance().run_sync(name, fn, timeout_ms=timeout_ms), explain=response_explain)
+        result = ok(MainThreadCommandQueue.instance().run_sync(name, fn, timeout_ms=timeout_ms), explain=response_explain)
+        _record_trace(name, True, started)
+        return result
     except TimeoutError as exc:
+        _record_trace(name, False, started, str(exc))
         return fail(
             "error.timeout",
             str(exc),
@@ -120,13 +125,25 @@ def main_thread(name: str, fn, *, timeout_ms: int = 30000, explain: dict[str, An
             explain=response_explain,
         )
     except ValueError as exc:
+        _record_trace(name, False, started, str(exc))
         return fail("error.invalid_argument", str(exc), hint="Check parameter schema with mcp.help or component.describe_type.", explain=response_explain)
     except FileExistsError as exc:
+        _record_trace(name, False, started, str(exc))
         return fail("error.exists", str(exc), hint="Use overwrite=true or choose a different path/name.", explain=response_explain)
     except FileNotFoundError as exc:
+        _record_trace(name, False, started, str(exc))
         return fail("error.not_found", str(exc), hint="Use scene.inspect, gameobject.find, or asset.search to locate valid targets.", explain=response_explain)
     except Exception as exc:
+        _record_trace(name, False, started, str(exc))
         return fail("error.internal", str(exc), hint="Read console.read and retry with a smaller operation.", explain=response_explain)
+
+
+def _record_trace(name: str, ok_flag: bool, started: float, error: str = "") -> None:
+    try:
+        from Infernux.mcp.project_tools.trace import record_tool_call
+        record_tool_call(name, ok=ok_flag, elapsed_ms=(time.monotonic() - started) * 1000.0, error=error)
+    except Exception:
+        pass
 
 
 def register_and_tool(mcp, name: str, **metadata: Any) -> Callable:

--- a/python/Infernux/mcp/tools/console.py
+++ b/python/Infernux/mcp/tools/console.py
@@ -1,0 +1,30 @@
+"""Console MCP tools."""
+
+from __future__ import annotations
+
+from Infernux.mcp.tools.common import main_thread
+
+
+def register_console_tools(mcp) -> None:
+    @mcp.tool(name="console.read")
+    def console_read(limit: int = 100, levels: list[str] | None = None) -> dict:
+        """Read recent DebugConsole entries."""
+
+        def _read():
+            from Infernux.debug import DebugConsole
+            allowed = {str(level).upper() for level in (levels or [])}
+            entries = []
+            for entry in DebugConsole.instance().get_entries()[-max(int(limit), 1):]:
+                level = getattr(entry.log_type, "name", str(entry.log_type)).upper()
+                if allowed and level not in allowed:
+                    continue
+                entries.append({
+                    "time": entry.get_formatted_time(),
+                    "level": level,
+                    "message": entry.message,
+                    "source_file": entry.source_file,
+                    "source_line": entry.source_line,
+                })
+            return {"entries": entries}
+
+        return main_thread("console.read", _read)

--- a/python/Infernux/mcp/tools/docs.py
+++ b/python/Infernux/mcp/tools/docs.py
@@ -183,12 +183,29 @@ def register_docs_tools(mcp, project_path: str) -> None:
             "endpoint": server.endpoint_url(),
         })
 
+    @mcp.tool(name="mcp.discovery")
+    def mcp_discovery() -> dict:
+        """Return connection info and project-local discovery file locations."""
+        info = server.connection_info()
+        return ok({
+            **info,
+            "project_root": project_path,
+            "files": {
+                name: client["file"]
+                for name, client in info.get("clients", {}).items()
+            },
+            "config_snippets": {
+                name: client.get("config") or client.get("toml")
+                for name, client in info.get("clients", {}).items()
+            },
+        })
+
     @mcp.tool(name="mcp.capabilities")
     def mcp_capabilities() -> dict:
         """Return high-level capability groups and known tool names."""
         return ok({
             "groups": {
-                "foundation": ["mcp.ping", "mcp.version", "mcp.health", "mcp.help"],
+                "foundation": ["mcp.ping", "mcp.version", "mcp.discovery", "mcp.health", "mcp.help"],
                 "self_description": ["engine.concepts", "engine.concept.get", "workflow.list", "workflow.help"],
                 "scene": ["scene.inspect", "scene.get_hierarchy", "scene.save", "scene.open", "scene.new"],
                 "gameobject": ["hierarchy.create_object", "gameobject.find", "gameobject.get", "gameobject.set_parent"],
@@ -342,7 +359,7 @@ def _register_metadata() -> None:
     }.items():
         register_tool_metadata(name, summary=summary)
     for name in [
-        "mcp.ping", "mcp.version", "mcp.capabilities", "mcp.health", "mcp.help", "mcp.batch",
+        "mcp.ping", "mcp.version", "mcp.discovery", "mcp.capabilities", "mcp.health", "mcp.help", "mcp.batch",
         "engine.concepts", "engine.concept.get", "workflow.list", "workflow.help",
         "workflow.examples",
     ]:

--- a/python/Infernux/mcp/tools/docs.py
+++ b/python/Infernux/mcp/tools/docs.py
@@ -1,0 +1,430 @@
+"""Self-description and workflow documentation MCP tools."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Any
+
+from Infernux.mcp import server
+from Infernux.mcp.threading import MainThreadCommandQueue
+from Infernux.mcp.tools.common import (
+    MCP_PROTOCOL_VERSION,
+    MCP_SERVER_VERSION,
+    get_asset_database,
+    get_tool_metadata,
+    list_tool_metadata,
+    main_thread,
+    ok,
+    register_tool_metadata,
+)
+
+
+CONCEPTS: dict[str, dict[str, Any]] = {
+    "Scene": {
+        "summary": "A loaded world containing root GameObjects and their children.",
+        "notes": [
+            "Scene object IDs are editor-session IDs; reacquire them after reload.",
+            "Use scene.inspect for a compact map and scene.get_hierarchy for nested structure.",
+        ],
+        "tools": ["scene.inspect", "scene.get_hierarchy", "scene.save", "scene.open", "scene.new"],
+    },
+    "GameObject": {
+        "summary": "A scene entity with a Transform and zero or more Components.",
+        "notes": [
+            "Every GameObject has a Transform.",
+            "Use stable names and hierarchy paths for generated content so agents can find it later.",
+        ],
+        "tools": ["hierarchy.create_object", "gameobject.find", "gameobject.get", "gameobject.set_parent"],
+    },
+    "Transform": {
+        "summary": "Position, rotation, scale, and hierarchy relationship for a GameObject.",
+        "notes": [
+            "World fields: position/euler_angles.",
+            "Local fields: local_position/local_euler_angles/local_scale.",
+        ],
+        "tools": ["transform.set", "gameobject.set_parent", "camera.attach_to_target"],
+    },
+    "Component": {
+        "summary": "Behavior or data attached to a GameObject.",
+        "notes": [
+            "Built-in components are backed by C++ wrappers.",
+            "Python components inherit InxComponent and can expose serialized_field metadata.",
+        ],
+        "tools": ["component.list_types", "component.describe_type", "gameobject.add_component"],
+    },
+    "Python Component": {
+        "summary": "User-authored gameplay script inheriting from Infernux.components.InxComponent.",
+        "notes": [
+            "Lifecycle methods include awake, start, update, late_update, on_enable, on_disable, on_destroy.",
+            "Use asset.write_text to create scripts, asset.refresh to import them, and gameobject.add_component with script_path to attach.",
+        ],
+        "tools": ["asset.write_text", "asset.refresh", "gameobject.add_component", "runtime.read_errors"],
+    },
+    "Builtin Component": {
+        "summary": "A C++ engine component exposed through Python wrapper metadata.",
+        "notes": [
+            "Examples: Camera, Light, MeshRenderer, Rigidbody, BoxCollider.",
+            "Use component.describe_type before setting fields.",
+        ],
+        "tools": ["component.list_types", "component.describe_type", "component.set_field"],
+    },
+    "AssetDatabase": {
+        "summary": "Tracks Assets/ files and maps project paths to GUIDs.",
+        "notes": [
+            "Generated files should stay under Assets/Generated/<GameName>/ when possible.",
+            "Call asset.refresh after external writes if the editor does not auto-import immediately.",
+        ],
+        "tools": ["asset.list", "asset.search", "asset.resolve", "asset.refresh"],
+    },
+    "PlayMode": {
+        "summary": "Runtime simulation mode with editor-scene isolation.",
+        "notes": [
+            "Use editor.play, runtime.wait, runtime.read_errors, then editor.stop for validation.",
+            "Script load errors can block entering Play Mode.",
+        ],
+        "tools": ["editor.play", "runtime.wait", "runtime.run_for", "runtime.read_errors", "editor.stop"],
+    },
+    "Camera": {
+        "summary": "Rendering view for Game View. Agents should reuse Main Camera when present.",
+        "notes": [
+            "Use camera.ensure_main instead of blindly creating another camera.",
+            "Card games usually want an orthographic camera; third-person games usually attach camera to a target.",
+        ],
+        "tools": ["camera.find_main", "camera.ensure_main", "camera.setup_2d_card_game", "camera.setup_third_person"],
+    },
+    "UI Canvas": {
+        "summary": "Root object for UI elements such as text and buttons.",
+        "notes": [
+            "UI tools are planned as semantic wrappers; low-level creation can use hierarchy.create_object with ui.* kinds.",
+        ],
+        "tools": ["hierarchy.create_object", "workflow.help"],
+    },
+    "Input": {
+        "summary": "Runtime input facade used by Python components.",
+        "notes": [
+            "Use Infernux.input.Input.get_axis('Horizontal') and get_axis('Vertical') for WASD movement.",
+            "Input is Game View focus-gated.",
+        ],
+        "tools": ["asset.write_text", "runtime.run_for"],
+    },
+    "Undo": {
+        "summary": "Editor undo/dirty tracking layer for hierarchy and inspector changes.",
+        "notes": [
+            "MCP mutation tools should mark scenes/assets dirty or call editor undo helpers when available.",
+        ],
+        "tools": ["gameobject.set", "component.set_field", "scene.save"],
+    },
+}
+
+
+WORKFLOWS: dict[str, dict[str, Any]] = {
+    "physics_test_scene": {
+        "summary": "Create a ground plane, dynamic cube, collider, rigidbody, light, and camera.",
+        "steps": [
+            "Call camera.ensure_main or camera.setup_third_person rather than creating duplicate cameras.",
+            "Create primitive.plane and add BoxCollider.",
+            "Create primitive.cube, add BoxCollider and Rigidbody.",
+            "Run editor.play, runtime.wait, runtime.read_errors.",
+        ],
+        "tools": ["hierarchy.create_object", "gameobject.add_component", "transform.set", "editor.play"],
+    },
+    "third_person_controller": {
+        "summary": "Create a controllable character with a following camera.",
+        "steps": [
+            "Write an InxComponent script with Input.get_axis and Rigidbody.velocity.",
+            "Create or reuse a player GameObject.",
+            "Use camera.ensure_main, then camera.attach_to_target or camera.setup_third_person.",
+            "Enter Play Mode and validate with runtime.get_object_state.",
+        ],
+        "tools": ["asset.write_text", "gameobject.add_component", "camera.setup_third_person", "runtime.read_errors"],
+    },
+    "card_game_shell": {
+        "summary": "Create folders, scripts, JSON data, orthographic camera, and UI roots for a Balatro-style prototype.",
+        "steps": [
+            "Create Assets/Generated/<GameName>/Scripts, Data, Materials, Scenes.",
+            "Write data model and controller scripts.",
+            "Use camera.setup_2d_card_game.",
+            "Create UI Canvas hierarchy for menu, run screen, hand, shop, and game over.",
+            "Run Play Mode and validate console/runtime state.",
+        ],
+        "tools": ["asset.write_text", "asset.write_json", "camera.setup_2d_card_game", "runtime.read_errors"],
+    },
+    "script_attach_play_validate": {
+        "summary": "Write a gameplay script, attach it, play, read errors, stop.",
+        "steps": [
+            "asset.write_text(path='Assets/.../MyComponent.py')",
+            "asset.refresh",
+            "gameobject.add_component(component_type='MyComponent', script_path='Assets/.../MyComponent.py')",
+            "editor.play",
+            "runtime.wait(play_state='playing')",
+            "runtime.read_errors",
+        ],
+        "tools": ["asset.write_text", "asset.refresh", "gameobject.add_component", "editor.play", "runtime.read_errors"],
+    },
+}
+
+
+def register_docs_tools(mcp, project_path: str) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="mcp.ping")
+    def mcp_ping() -> dict:
+        """Return a lightweight MCP liveness response."""
+        return ok({"pong": True, "endpoint": server.endpoint_url()})
+
+    @mcp.tool(name="mcp.version")
+    def mcp_version() -> dict:
+        """Return MCP server version and protocol information."""
+        return ok({
+            "server": "Infernux Editor",
+            "mcp_server_version": MCP_SERVER_VERSION,
+            "protocol_version": MCP_PROTOCOL_VERSION,
+            "endpoint": server.endpoint_url(),
+        })
+
+    @mcp.tool(name="mcp.capabilities")
+    def mcp_capabilities() -> dict:
+        """Return high-level capability groups and known tool names."""
+        return ok({
+            "groups": {
+                "foundation": ["mcp.ping", "mcp.version", "mcp.health", "mcp.help"],
+                "self_description": ["engine.concepts", "engine.concept.get", "workflow.list", "workflow.help"],
+                "scene": ["scene.inspect", "scene.get_hierarchy", "scene.save", "scene.open", "scene.new"],
+                "gameobject": ["hierarchy.create_object", "gameobject.find", "gameobject.get", "gameobject.set_parent"],
+                "component": ["component.list_types", "component.describe_type", "component.set_field"],
+                "asset": ["asset.list", "asset.search", "asset.read_text", "asset.write_text", "asset.refresh"],
+                "camera": ["camera.find_main", "camera.ensure_main", "camera.setup_2d_card_game"],
+                "runtime": ["editor.play", "runtime.wait", "runtime.run_for", "runtime.read_errors"],
+            },
+            "tools": [meta["name"] for meta in list_tool_metadata()],
+        })
+
+    @mcp.tool(name="mcp.health")
+    def mcp_health() -> dict:
+        """Report editor, scene, asset database, and queue readiness."""
+
+        def _health():
+            from Infernux.engine.deferred_task import DeferredTaskRunner
+            from Infernux.engine.play_mode import PlayModeManager
+            from Infernux.engine.scene_manager import SceneFileManager
+            from Infernux.lib import SceneManager
+
+            scene = SceneManager.instance().get_active_scene()
+            sfm = SceneFileManager.instance()
+            pmm = PlayModeManager.instance()
+            runner = DeferredTaskRunner.instance()
+            adb = get_asset_database()
+            return {
+                "server_running": server.is_running(),
+                "endpoint": server.endpoint_url(),
+                "main_thread_queue_ready": MainThreadCommandQueue.instance().wait_until_ready(0.01),
+                "active_scene": {
+                    "available": scene is not None,
+                    "name": getattr(scene, "name", ""),
+                    "path": getattr(sfm, "current_scene_path", "") if sfm else "",
+                    "dirty": bool(getattr(sfm, "is_dirty", False)) if sfm else False,
+                    "loading": bool(getattr(sfm, "is_loading", False)) if sfm else False,
+                },
+                "play_state": getattr(getattr(pmm, "state", None), "name", "edit").lower() if pmm else "edit",
+                "deferred_task_busy": bool(getattr(runner, "is_busy", False)),
+                "asset_database_ready": adb is not None,
+                "project_root": project_path,
+            }
+
+        return main_thread("mcp.health", _health)
+
+    @mcp.tool(name="mcp.list_tools_verbose")
+    def mcp_list_tools_verbose() -> dict:
+        """Return registered tool metadata."""
+        return ok({"tools": list_tool_metadata()})
+
+    @mcp.tool(name="mcp.help")
+    def mcp_help(tool_name: str = "") -> dict:
+        """Return detailed help for one tool or all tool groups."""
+        if tool_name:
+            return ok({"tool": get_tool_metadata(tool_name)})
+        return ok({"tools": list_tool_metadata(), "workflows": list(WORKFLOWS), "concepts": list(CONCEPTS)})
+
+    @mcp.tool(name="mcp.batch")
+    def mcp_batch(steps: list[dict[str, Any]], continue_on_error: bool = False) -> dict:
+        """Execute a list of MCP tool calls and return an operation trace.
+
+        Each step is {"tool": "...", "arguments": {...}, "label": "..."}.
+        This intentionally goes through the MCP transport so the batch path
+        observes the same envelope and main-thread behavior as external agents.
+        """
+        trace = []
+        client = _NestedMCPClient(server.endpoint_url())
+        for index, step in enumerate(steps or []):
+            tool_name = str(step.get("tool", ""))
+            arguments = step.get("arguments", {}) or {}
+            label = str(step.get("label", "")) or tool_name
+            try:
+                result = client.call(tool_name, arguments)
+                ok_flag = bool(result.get("ok", True)) if isinstance(result, dict) else True
+                trace.append({
+                    "index": index,
+                    "label": label,
+                    "tool": tool_name,
+                    "ok": ok_flag,
+                    "result": result,
+                })
+                if not ok_flag and not continue_on_error:
+                    break
+            except Exception as exc:
+                trace.append({
+                    "index": index,
+                    "label": label,
+                    "tool": tool_name,
+                    "ok": False,
+                    "error": {"code": "error.batch_step", "message": str(exc)},
+                })
+                if not continue_on_error:
+                    break
+        return ok({"ok": all(item.get("ok") for item in trace), "trace": trace}, trace=trace)
+
+    @mcp.tool(name="engine.concepts")
+    def engine_concepts() -> dict:
+        """List Infernux concepts exposed to agents."""
+        return ok({"concepts": [{"name": key, "summary": value["summary"]} for key, value in sorted(CONCEPTS.items())]})
+
+    @mcp.tool(name="engine.concept.get")
+    def engine_concept_get(name: str) -> dict:
+        """Return a single concept page."""
+        key = _lookup_key(CONCEPTS, name)
+        if not key:
+            return ok({"found": False, "available": sorted(CONCEPTS)})
+        return ok({"name": key, **CONCEPTS[key]})
+
+    @mcp.tool(name="workflow.list")
+    def workflow_list() -> dict:
+        """List documented workflows."""
+        return ok({"workflows": [{"name": key, "summary": value["summary"]} for key, value in sorted(WORKFLOWS.items())]})
+
+    @mcp.tool(name="workflow.help")
+    def workflow_help(name: str) -> dict:
+        """Return detailed workflow guidance."""
+        key = _lookup_key(WORKFLOWS, name)
+        if not key:
+            return ok({"found": False, "available": sorted(WORKFLOWS)})
+        return ok({"name": key, **WORKFLOWS[key]})
+
+    @mcp.tool(name="workflow.examples")
+    def workflow_examples(name: str = "") -> dict:
+        """Return compact workflow examples."""
+        if name:
+            key = _lookup_key(WORKFLOWS, name)
+            if not key:
+                return ok({"found": False, "available": sorted(WORKFLOWS)})
+            return ok({"examples": [{key: WORKFLOWS[key]}]})
+        return ok({"examples": WORKFLOWS})
+
+def _lookup_key(mapping: dict[str, Any], name: str) -> str:
+    lowered = str(name).strip().lower()
+    for key in mapping:
+        if key.lower() == lowered:
+            return key
+    return ""
+
+
+def _register_metadata() -> None:
+    for name, summary in {
+        "project.info": "Return current project, active scene, play state, and selection.",
+        "editor.get_state": "Return lightweight editor state.",
+        "scene.inspect": "Return compact active scene summary.",
+        "scene.get_hierarchy": "Return active scene hierarchy.",
+        "hierarchy.create_object": "Create a GameObject using registered HierarchyCreationService kinds.",
+        "gameobject.add_component": "Attach a built-in or Python script component to a GameObject.",
+        "component.describe_type": "Describe fields and metadata for a component type.",
+        "asset.write_text": "Write a UTF-8 project file and notify AssetDatabase.",
+        "console.read": "Read recent editor console entries.",
+    }.items():
+        register_tool_metadata(name, summary=summary)
+    for name in [
+        "mcp.ping", "mcp.version", "mcp.capabilities", "mcp.health", "mcp.help", "mcp.batch",
+        "engine.concepts", "engine.concept.get", "workflow.list", "workflow.help",
+        "workflow.examples",
+    ]:
+        register_tool_metadata(name, summary=f"Self-description tool: {name}.")
+
+
+class _NestedMCPClient:
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+        self.request_id = 1
+        self.session_id = ""
+        self._initialize()
+
+    def call(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+        data = self._post({
+            "jsonrpc": "2.0",
+            "id": self._next_id(),
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        })
+        if "error" in data:
+            raise RuntimeError(data["error"])
+        result = data.get("result", {})
+        if isinstance(result, dict):
+            structured = result.get("structuredContent")
+            if structured is not None:
+                return structured
+            content = result.get("content") or []
+            if content and isinstance(content[0].get("text"), str):
+                try:
+                    return json.loads(content[0]["text"])
+                except Exception:
+                    return {"text": content[0]["text"]}
+        return result
+
+    def _initialize(self) -> None:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._next_id(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "infernux-nested-batch", "version": MCP_SERVER_VERSION},
+            },
+        }
+        data, headers = self._post_raw(payload, include_headers=True)
+        self.session_id = headers.get("mcp-session-id") or headers.get("Mcp-Session-Id") or ""
+        if not self.session_id:
+            raise RuntimeError(f"Nested MCP initialize did not return a session id: {data}")
+        self._post({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    def _post(self, payload: dict[str, Any]) -> dict[str, Any]:
+        data, _headers = self._post_raw(payload, include_headers=True)
+        return data
+
+    def _post_raw(self, payload: dict[str, Any], *, include_headers: bool = False):
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self.session_id:
+            headers["mcp-session-id"] = self.session_id
+        req = urllib.request.Request(
+            self.endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=60) as response:
+            body = response.read().decode("utf-8")
+            parsed = self._parse_body(body)
+            if include_headers:
+                return parsed, dict(response.headers)
+            return parsed
+
+    def _parse_body(self, body: str) -> dict[str, Any]:
+        for line in body.splitlines():
+            if line.startswith("data:"):
+                return json.loads(line[5:].strip())
+        return json.loads(body) if body.strip() else {}
+
+    def _next_id(self) -> int:
+        self.request_id += 1
+        return self.request_id

--- a/python/Infernux/mcp/tools/docs.py
+++ b/python/Infernux/mcp/tools/docs.py
@@ -213,6 +213,8 @@ def register_docs_tools(mcp, project_path: str) -> None:
                 "asset": ["asset.list", "asset.search", "asset.read_text", "asset.write_text", "asset.refresh"],
                 "camera": ["camera.find_main", "camera.ensure_main", "camera.setup_2d_card_game"],
                 "runtime": ["editor.play", "runtime.wait", "runtime.run_for", "runtime.read_errors"],
+                "project_tools": ["project_tools.list", "project_tools.reload", "project_tools.validate", "project_tools.audit"],
+                "trace": ["mcp.trace.start", "mcp.trace.stop", "mcp.trace.current", "mcp.trace.list"],
             },
             "tools": [meta["name"] for meta in list_tool_metadata()],
         })

--- a/python/Infernux/mcp/tools/editor.py
+++ b/python/Infernux/mcp/tools/editor.py
@@ -1,0 +1,115 @@
+"""Editor-state MCP tools."""
+
+from __future__ import annotations
+
+from Infernux.mcp.tools.common import main_thread
+
+
+def register_editor_tools(mcp) -> None:
+    @mcp.tool(name="editor.get_state")
+    def editor_get_state() -> dict:
+        """Return lightweight editor state."""
+
+        def _read():
+            from Infernux.engine.deferred_task import DeferredTaskRunner
+            from Infernux.engine.play_mode import PlayModeManager
+            from Infernux.engine.scene_manager import SceneFileManager
+            from Infernux.engine.ui.selection_manager import SelectionManager
+
+            pmm = PlayModeManager.instance()
+            sfm = SceneFileManager.instance()
+            sel = SelectionManager.instance()
+            runner = DeferredTaskRunner.instance()
+            return {
+                "play_state": getattr(getattr(pmm, "state", None), "name", "edit").lower() if pmm else "edit",
+                "deferred_task_busy": bool(getattr(runner, "is_busy", False)),
+                "selected_ids": sel.get_ids() if sel else [],
+                "scene_dirty": bool(sfm.is_dirty) if sfm else False,
+                "is_prefab_mode": bool(getattr(sfm, "is_prefab_mode", False)) if sfm else False,
+            }
+
+        return main_thread("editor.get_state", _read)
+
+    @mcp.tool(name="editor.play")
+    def editor_play() -> dict:
+        """Enter Play Mode."""
+
+        def _play():
+            from Infernux.engine.play_mode import PlayModeManager
+            pmm = PlayModeManager.instance()
+            if pmm is None:
+                raise RuntimeError("PlayModeManager is not available.")
+            return {"accepted": bool(pmm.enter_play_mode()), "state": pmm.state.name.lower()}
+
+        return main_thread("editor.play", _play)
+
+    @mcp.tool(name="editor.stop")
+    def editor_stop() -> dict:
+        """Exit Play Mode."""
+
+        def _stop():
+            from Infernux.engine.play_mode import PlayModeManager
+            pmm = PlayModeManager.instance()
+            if pmm is None:
+                raise RuntimeError("PlayModeManager is not available.")
+            return {"accepted": bool(pmm.exit_play_mode()), "state": pmm.state.name.lower()}
+
+        return main_thread("editor.stop", _stop)
+
+    @mcp.tool(name="editor.pause")
+    def editor_pause() -> dict:
+        """Pause Play Mode."""
+
+        def _pause():
+            from Infernux.engine.play_mode import PlayModeManager
+            pmm = PlayModeManager.instance()
+            if pmm is None:
+                raise RuntimeError("PlayModeManager is not available.")
+            return {"accepted": bool(pmm.pause()), "state": pmm.state.name.lower()}
+
+        return main_thread("editor.pause", _pause)
+
+    @mcp.tool(name="editor.resume")
+    def editor_resume() -> dict:
+        """Resume from paused Play Mode."""
+
+        def _resume():
+            from Infernux.engine.play_mode import PlayModeManager
+            pmm = PlayModeManager.instance()
+            if pmm is None:
+                raise RuntimeError("PlayModeManager is not available.")
+            return {"accepted": bool(pmm.resume()), "state": pmm.state.name.lower()}
+
+        return main_thread("editor.resume", _resume)
+
+    @mcp.tool(name="editor.step")
+    def editor_step() -> dict:
+        """Step one frame while Play Mode is paused."""
+
+        def _step():
+            from Infernux.engine.play_mode import PlayModeManager
+            pmm = PlayModeManager.instance()
+            if pmm is None:
+                raise RuntimeError("PlayModeManager is not available.")
+            pmm.step_frame()
+            return {"state": pmm.state.name.lower()}
+
+        return main_thread("editor.step", _step)
+
+    @mcp.tool(name="editor.select")
+    def editor_select(object_ids: list[int] | None = None, primary_id: int = 0) -> dict:
+        """Set the current editor selection."""
+
+        def _select():
+            from Infernux.engine.ui.selection_manager import SelectionManager
+            sel = SelectionManager.instance()
+            ids = [int(i) for i in (object_ids or []) if int(i) > 0]
+            if primary_id:
+                sel.select(int(primary_id))
+            elif ids:
+                sel.box_select(ids)
+            else:
+                sel.clear()
+            return {"selected_ids": sel.get_ids()}
+
+        return main_thread("editor.select", _select)

--- a/python/Infernux/mcp/tools/hierarchy.py
+++ b/python/Infernux/mcp/tools/hierarchy.py
@@ -1,0 +1,37 @@
+"""Hierarchy creation MCP tools."""
+
+from __future__ import annotations
+
+from Infernux.mcp.tools.common import main_thread
+
+
+def register_hierarchy_tools(mcp) -> None:
+    @mcp.tool(name="hierarchy.list_create_kinds")
+    def hierarchy_list_create_kinds() -> dict:
+        """List object kinds supported by hierarchy.create_object."""
+
+        def _list():
+            from Infernux.engine.hierarchy_creation_service import HierarchyCreationService
+            return {"kinds": HierarchyCreationService.instance().list_create_kinds()}
+
+        return main_thread("hierarchy.list_create_kinds", _list)
+
+    @mcp.tool(name="hierarchy.create_object")
+    def hierarchy_create_object(
+        kind: str,
+        parent_id: int = 0,
+        name: str = "",
+        select: bool = True,
+    ) -> dict:
+        """Create an object using the same behavior as the Hierarchy panel."""
+
+        def _create():
+            from Infernux.engine.hierarchy_creation_service import HierarchyCreationService
+            return HierarchyCreationService.instance().create(
+                kind,
+                parent_id=int(parent_id or 0),
+                name=name or None,
+                select=bool(select),
+            )
+
+        return main_thread("hierarchy.create_object", _create)

--- a/python/Infernux/mcp/tools/material.py
+++ b/python/Infernux/mcp/tools/material.py
@@ -1,0 +1,105 @@
+"""Material MCP tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from Infernux.mcp.tools.common import main_thread, notify_asset_changed, register_tool_metadata, resolve_project_path, serialize_value
+
+
+def register_material_tools(mcp, project_path: str) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="material.create")
+    def material_create(path: str, template: str = "lit", overwrite: bool = False, properties: dict[str, Any] | None = None) -> dict:
+        """Create a material asset and optionally set properties."""
+
+        def _create():
+            import os
+            from Infernux.core.material import Material
+            file_path = resolve_project_path(project_path, path)
+            if os.path.exists(file_path) and not overwrite:
+                raise FileExistsError(f"Material already exists: {path}")
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            mat = Material.create_default_unlit() if str(template).lower() == "unlit" else Material.create_default_lit()
+            mat.name = os.path.splitext(os.path.basename(file_path))[0]
+            _set_properties(mat, properties or {})
+            mat.save(file_path)
+            notify_asset_changed(file_path, "created")
+            return {"path": os.path.relpath(file_path, project_path).replace("\\", "/"), "properties": _properties(mat)}
+
+        return main_thread("material.create", _create)
+
+    @mcp.tool(name="material.get_properties")
+    def material_get_properties(path: str) -> dict:
+        """Read material properties."""
+
+        def _get():
+            import os
+            mat = _load_material(project_path, path)
+            return {"path": os.path.relpath(resolve_project_path(project_path, path), project_path).replace("\\", "/"), "properties": _properties(mat)}
+
+        return main_thread("material.get_properties", _get)
+
+    @mcp.tool(name="material.set_property")
+    def material_set_property(path: str, name: str, value: Any, value_type: str = "auto") -> dict:
+        """Set one material property."""
+
+        def _set():
+            file_path = resolve_project_path(project_path, path)
+            mat = _load_material(project_path, path)
+            _set_one(mat, name, value, value_type)
+            mat.flush()
+            mat.save(file_path)
+            notify_asset_changed(file_path, "modified")
+            return {"path": path, "name": name, "value": serialize_value(mat.get_property(name))}
+
+        return main_thread("material.set_property", _set)
+
+
+def _load_material(project_path: str, path: str):
+    from Infernux.core.material import Material
+    file_path = resolve_project_path(project_path, path)
+    mat = Material.load(file_path)
+    if mat is None:
+        raise FileNotFoundError(f"Material not found or failed to load: {path}")
+    return mat
+
+
+def _set_properties(mat, properties: dict[str, Any]) -> None:
+    for name, value in properties.items():
+        _set_one(mat, name, value, "auto")
+
+
+def _set_one(mat, name: str, value: Any, value_type: str) -> None:
+    kind = str(value_type or "auto").lower()
+    if kind == "float" or (kind == "auto" and isinstance(value, float)):
+        mat.set_float(name, float(value))
+    elif kind == "int" or (kind == "auto" and isinstance(value, int) and not isinstance(value, bool)):
+        mat.set_int(name, int(value))
+    elif kind == "color" or (kind == "auto" and isinstance(value, (list, tuple)) and len(value) == 4):
+        mat.set_color(name, float(value[0]), float(value[1]), float(value[2]), float(value[3]))
+    elif kind == "vector2" or (kind == "auto" and isinstance(value, (list, tuple)) and len(value) == 2):
+        mat.set_vector2(name, float(value[0]), float(value[1]))
+    elif kind == "vector3" or (kind == "auto" and isinstance(value, (list, tuple)) and len(value) == 3):
+        mat.set_vector3(name, float(value[0]), float(value[1]), float(value[2]))
+    elif kind == "texture":
+        mat.set_texture(name, value)
+    else:
+        mat.set_param(name, value)
+
+
+def _properties(mat) -> dict[str, Any]:
+    try:
+        return serialize_value(mat.get_all_properties())
+    except Exception:
+        return {}
+
+
+def _register_metadata() -> None:
+    for name, summary in {
+        "material.create": "Create a material asset.",
+        "material.get_properties": "Read material properties.",
+        "material.set_property": "Set a material shader property.",
+    }.items():
+        register_tool_metadata(name, summary=summary)

--- a/python/Infernux/mcp/tools/material.py
+++ b/python/Infernux/mcp/tools/material.py
@@ -21,8 +21,8 @@ def register_material_tools(mcp, project_path: str) -> None:
             if os.path.exists(file_path) and not overwrite:
                 raise FileExistsError(f"Material already exists: {path}")
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            mat = Material.create_default_unlit() if str(template).lower() == "unlit" else Material.create_default_lit()
-            mat.name = os.path.splitext(os.path.basename(file_path))[0]
+            name = os.path.splitext(os.path.basename(file_path))[0]
+            mat = Material.create_unlit(name) if str(template).lower() == "unlit" else Material.create_lit(name)
             _set_properties(mat, properties or {})
             mat.save(file_path)
             notify_asset_changed(file_path, "created")

--- a/python/Infernux/mcp/tools/project.py
+++ b/python/Infernux/mcp/tools/project.py
@@ -1,0 +1,35 @@
+"""Project-level MCP tools."""
+
+from __future__ import annotations
+
+from Infernux.mcp.tools.common import main_thread
+
+
+def register_project_tools(mcp, project_path: str) -> None:
+    @mcp.tool(name="project.info")
+    def project_info() -> dict:
+        """Return the currently opened project and scene state."""
+
+        def _read():
+            from Infernux.engine.play_mode import PlayModeManager
+            from Infernux.engine.scene_manager import SceneFileManager
+            from Infernux.engine.ui.selection_manager import SelectionManager
+            from Infernux.lib import SceneManager
+
+            sfm = SceneFileManager.instance()
+            pmm = PlayModeManager.instance()
+            sel = SelectionManager.instance()
+            scene = SceneManager.instance().get_active_scene()
+            return {
+                "engine_version": "0.1.5",
+                "project_root": project_path,
+                "active_scene": {
+                    "name": getattr(scene, "name", ""),
+                    "path": getattr(sfm, "current_scene_path", "") if sfm else "",
+                    "dirty": bool(getattr(sfm, "is_dirty", False)) if sfm else False,
+                },
+                "play_state": getattr(getattr(pmm, "state", None), "name", "edit").lower() if pmm else "edit",
+                "selected_ids": sel.get_ids() if sel else [],
+            }
+
+        return main_thread("project.info", _read)

--- a/python/Infernux/mcp/tools/project_tools.py
+++ b/python/Infernux/mcp/tools/project_tools.py
@@ -1,0 +1,87 @@
+"""MCP management tools for project-defined agent tools."""
+
+from __future__ import annotations
+
+from Infernux.mcp.project_tools.registry import get_project_tool_registry
+from Infernux.mcp.project_tools.trace import current_trace, last_trace, list_traces, start_trace, stop_trace
+from Infernux.mcp.tools.common import main_thread, ok, register_tool_metadata
+
+
+def register_project_tool_management(mcp, project_path: str) -> None:
+    _register_metadata()
+    registry = get_project_tool_registry(project_path)
+    registry.configure(project_path)
+
+    @mcp.tool(name="project_tools.list")
+    def project_tools_list() -> dict:
+        """List project-defined MCP tools and load reports."""
+        return ok(registry.list_tools())
+
+    @mcp.tool(name="project_tools.reload")
+    def project_tools_reload() -> dict:
+        """Rediscover project-defined MCP tools from Assets/AgentTools."""
+        return main_thread("project_tools.reload", registry.reload)
+
+    @mcp.tool(name="project_tools.validate")
+    def project_tools_validate(path: str = "") -> dict:
+        """Validate one project tool file or every discovered tool file."""
+        return main_thread("project_tools.validate", lambda: registry.validate(path))
+
+    @mcp.tool(name="project_tools.explain")
+    def project_tools_explain(name: str) -> dict:
+        """Explain one project-defined MCP tool."""
+        return main_thread("project_tools.explain", lambda: registry.explain(name))
+
+    @mcp.tool(name="project_tools.audit")
+    def project_tools_audit(limit: int = 100) -> dict:
+        """Return recent project tool load/call audit events."""
+        return ok(registry.audit(limit))
+
+    @mcp.tool(name="mcp.trace.start")
+    def mcp_trace_start(task: str = "") -> dict:
+        """Start recording MCP tool call trace metadata."""
+        return ok(start_trace(project_path, task))
+
+    @mcp.tool(name="mcp.trace.stop")
+    def mcp_trace_stop(save: bool = True) -> dict:
+        """Stop the active MCP trace and optionally save it to .infernux/mcp_traces."""
+        return ok(stop_trace(project_path, save=save))
+
+    @mcp.tool(name="mcp.trace.current")
+    def mcp_trace_current() -> dict:
+        """Return the currently active MCP trace."""
+        return ok(current_trace())
+
+    @mcp.tool(name="mcp.trace.last")
+    def mcp_trace_last() -> dict:
+        """Return the last stopped MCP trace."""
+        return ok(last_trace())
+
+    @mcp.tool(name="mcp.trace.list")
+    def mcp_trace_list(limit: int = 50) -> dict:
+        """List saved MCP traces."""
+        return ok({"traces": list_traces(project_path, limit=limit)})
+
+
+def register_project_defined_tools(mcp, project_path: str) -> dict:
+    registry = get_project_tool_registry(project_path)
+    registry.configure(project_path)
+    registry.discover()
+    return registry.register_with_mcp(mcp)
+
+
+def _register_metadata() -> None:
+    for name, summary in {
+        "project_tools.list": "List project-defined MCP tools.",
+        "project_tools.reload": "Rediscover and register project-defined MCP tools.",
+        "project_tools.validate": "Validate project tool loadability and schema quality.",
+        "project_tools.explain": "Explain one project-defined MCP tool.",
+        "project_tools.audit": "Return project tool load/call audit events.",
+        "mcp.trace.start": "Start an MCP tool-call trace.",
+        "mcp.trace.stop": "Stop and optionally save the active MCP trace.",
+        "mcp.trace.current": "Return the active MCP trace.",
+        "mcp.trace.last": "Return the last stopped MCP trace.",
+        "mcp.trace.list": "List saved MCP trace files.",
+    }.items():
+        register_tool_metadata(name, summary=summary)
+

--- a/python/Infernux/mcp/tools/runtime.py
+++ b/python/Infernux/mcp/tools/runtime.py
@@ -1,0 +1,262 @@
+"""Runtime observation and validation MCP tools."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from Infernux.mcp.threading import MainThreadCommandQueue
+from Infernux.mcp.tools.common import (
+    fail,
+    find_game_object,
+    ok,
+    register_tool_metadata,
+    serialize_component,
+    serialize_value,
+)
+
+
+def register_runtime_tools(mcp) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="runtime.wait")
+    def runtime_wait(
+        play_state: str = "",
+        deferred_idle: bool = True,
+        timeout_seconds: float = 10.0,
+        poll_interval: float = 0.1,
+    ) -> dict:
+        """Wait until editor runtime conditions are met."""
+        deadline = time.time() + max(float(timeout_seconds), 0.01)
+        desired_state = str(play_state or "").lower()
+        last_state: dict[str, Any] = {}
+        while time.time() < deadline:
+            last_state = _run_on_main("runtime.wait.state", _editor_state)
+            state_ok = not desired_state or last_state.get("play_state") == desired_state
+            idle_ok = not deferred_idle or not last_state.get("deferred_task_busy")
+            if state_ok and idle_ok:
+                return ok({"ready": True, "state": last_state, "elapsed_seconds": max(0.0, timeout_seconds - (deadline - time.time()))})
+            time.sleep(max(float(poll_interval), 0.01))
+        return fail(
+            "error.timeout",
+            "Timed out waiting for runtime condition.",
+            hint="Use editor.get_state, console.read, or runtime.read_errors to diagnose why the condition did not become true.",
+            explain={"tool": "runtime.wait", "summary": "Wait for Play Mode/deferred task conditions."},
+        ) | {"data": {"ready": False, "state": last_state}}
+
+    @mcp.tool(name="runtime.run_for")
+    def runtime_run_for(seconds: float = 1.0, stop_on_error: bool = True, poll_interval: float = 0.25) -> dict:
+        """Let Play Mode run for a duration while polling for errors."""
+        duration = max(float(seconds), 0.0)
+        deadline = time.time() + duration
+        samples = []
+        errors: list[dict[str, Any]] = []
+        while time.time() < deadline:
+            time.sleep(max(float(poll_interval), 0.01))
+            state = _run_on_main("runtime.run_for.state", _editor_state)
+            samples.append(state)
+            errors = _run_on_main("runtime.run_for.errors", _read_errors)["errors"]
+            if stop_on_error and errors:
+                break
+        return ok({
+            "elapsed_seconds": duration,
+            "stopped_on_error": bool(stop_on_error and errors),
+            "samples": samples[-10:],
+            "errors": errors,
+        })
+
+    @mcp.tool(name="runtime.get_object_state")
+    def runtime_get_object_state(object_id: int) -> dict:
+        """Read runtime GameObject transform and component summary."""
+
+        def _read():
+            obj = find_game_object(object_id)
+            trans = obj.transform
+            return {
+                "id": int(obj.id),
+                "name": str(obj.name),
+                "active": bool(getattr(obj, "active", True)),
+                "transform": {
+                    "position": _vec(trans.position),
+                    "euler_angles": _vec(trans.euler_angles),
+                    "local_position": _vec(trans.local_position),
+                    "local_euler_angles": _vec(trans.local_euler_angles),
+                    "local_scale": _vec(trans.local_scale),
+                },
+                "components": _components(obj),
+                "parent_id": int(getattr(obj.get_parent(), "id", 0) or 0),
+                "child_count": int(obj.get_child_count()),
+            }
+
+        return ok(_run_on_main("runtime.get_object_state", _read))
+
+    @mcp.tool(name="runtime.get_component_state")
+    def runtime_get_component_state(object_id: int, component_type: str, ordinal: int = 0) -> dict:
+        """Read a component snapshot at runtime."""
+
+        def _read():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, int(ordinal))
+            if comp is None:
+                raise FileNotFoundError(f"Component '{component_type}' was not found on GameObject {object_id}.")
+            data = serialize_component(comp)
+            fields = {}
+            try:
+                from Infernux.components.serialized_field import get_serialized_fields
+                for name in get_serialized_fields(type(comp)):
+                    try:
+                        fields[name] = serialize_value(getattr(comp, name))
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+            return {"object_id": int(obj.id), "component": data, "fields": fields}
+
+        try:
+            return ok(_run_on_main("runtime.get_component_state", _read))
+        except FileNotFoundError as exc:
+            return fail("error.not_found", str(exc), hint="Use component.list_on_object or gameobject.get first.")
+
+    @mcp.tool(name="runtime.read_errors")
+    def runtime_read_errors(include_warnings: bool = False, limit: int = 100) -> dict:
+        """Read console errors and script loader errors."""
+        return ok(_run_on_main("runtime.read_errors", lambda: _read_errors(include_warnings=include_warnings, limit=limit)))
+
+    @mcp.tool(name="runtime.assert")
+    def runtime_assert(assertions: list[dict[str, Any]]) -> dict:
+        """Evaluate simple runtime assertions."""
+
+        def _assert():
+            results = []
+            for item in assertions or []:
+                kind = str(item.get("kind", ""))
+                passed = False
+                message = ""
+                if kind == "play_state":
+                    state = _editor_state().get("play_state")
+                    expected = str(item.get("equals", "")).lower()
+                    passed = state == expected
+                    message = f"play_state is {state!r}, expected {expected!r}"
+                elif kind == "object_exists":
+                    obj = _try_find_object(int(item.get("object_id", 0)))
+                    passed = obj is not None
+                    message = f"object_id {item.get('object_id')} exists={passed}"
+                elif kind == "component_exists":
+                    obj = _try_find_object(int(item.get("object_id", 0)))
+                    comp = _find_component(obj, str(item.get("component_type", "")), 0) if obj else None
+                    passed = comp is not None
+                    message = f"component {item.get('component_type')} exists={passed}"
+                elif kind == "no_errors":
+                    errors = _read_errors(include_warnings=False).get("errors", [])
+                    passed = len(errors) == 0
+                    message = f"{len(errors)} error(s)"
+                else:
+                    message = f"Unknown assertion kind: {kind}"
+                results.append({"assertion": item, "passed": passed, "message": message})
+            return {"passed": all(r["passed"] for r in results), "results": results}
+
+        return ok(_run_on_main("runtime.assert", _assert))
+
+
+def _run_on_main(name: str, fn):
+    return MainThreadCommandQueue.instance().run_sync(name, fn, timeout_ms=30000)
+
+
+def _editor_state() -> dict[str, Any]:
+    from Infernux.engine.deferred_task import DeferredTaskRunner
+    from Infernux.engine.play_mode import PlayModeManager
+    from Infernux.engine.scene_manager import SceneFileManager
+    from Infernux.engine.ui.selection_manager import SelectionManager
+
+    pmm = PlayModeManager.instance()
+    sfm = SceneFileManager.instance()
+    sel = SelectionManager.instance()
+    runner = DeferredTaskRunner.instance()
+    return {
+        "play_state": getattr(getattr(pmm, "state", None), "name", "edit").lower() if pmm else "edit",
+        "deferred_task_busy": bool(getattr(runner, "is_busy", False)),
+        "selected_ids": sel.get_ids() if sel else [],
+        "scene_dirty": bool(sfm.is_dirty) if sfm else False,
+        "is_prefab_mode": bool(getattr(sfm, "is_prefab_mode", False)) if sfm else False,
+    }
+
+
+def _read_errors(include_warnings: bool = False, limit: int = 100) -> dict[str, Any]:
+    from Infernux.debug import DebugConsole
+    from Infernux.components.script_loader import get_script_errors
+
+    allowed = {"ERROR", "FATAL"}
+    if include_warnings:
+        allowed.add("WARN")
+        allowed.add("WARNING")
+    entries = []
+    for entry in DebugConsole.instance().get_entries()[-max(int(limit), 1):]:
+        level = getattr(entry.log_type, "name", str(entry.log_type)).upper()
+        if level not in allowed:
+            continue
+        entries.append({
+            "time": entry.get_formatted_time(),
+            "level": level,
+            "message": entry.message,
+            "source_file": entry.source_file,
+            "source_line": entry.source_line,
+        })
+    script_errors = [
+        {"path": path, "traceback": tb}
+        for path, tb in get_script_errors().items()
+    ]
+    return {"errors": entries, "script_errors": script_errors}
+
+
+def _components(obj) -> list[dict[str, Any]]:
+    items = []
+    seen = set()
+    for getter in ("get_components", "get_py_components"):
+        try:
+            for comp in getattr(obj, getter)() or []:
+                data = serialize_component(comp)
+                key = (data.get("type"), data.get("component_id"))
+                if key in seen:
+                    continue
+                seen.add(key)
+                items.append(data)
+        except Exception:
+            pass
+    return items
+
+
+def _find_component(obj, component_type: str, ordinal: int = 0):
+    if obj is None:
+        return None
+    matches = []
+    for getter in ("get_components", "get_py_components"):
+        try:
+            for comp in getattr(obj, getter)() or []:
+                if getattr(comp, "type_name", type(comp).__name__) == component_type or type(comp).__name__ == component_type:
+                    matches.append(comp)
+        except Exception:
+            pass
+    return matches[ordinal] if 0 <= ordinal < len(matches) else None
+
+
+def _try_find_object(object_id: int):
+    try:
+        return find_game_object(object_id)
+    except Exception:
+        return None
+
+
+def _vec(value) -> list[float]:
+    return [float(value.x), float(value.y), float(value.z)]
+
+
+def _register_metadata() -> None:
+    for name, summary in {
+        "runtime.wait": "Wait for Play Mode/deferred task state.",
+        "runtime.run_for": "Let runtime advance while polling errors.",
+        "runtime.get_object_state": "Read object transform and component state at runtime.",
+        "runtime.get_component_state": "Read one component state at runtime.",
+        "runtime.read_errors": "Read console and script loader errors.",
+        "runtime.assert": "Evaluate simple runtime assertions.",
+    }.items():
+        register_tool_metadata(name, summary=summary, next_suggested_tools=["runtime.read_errors", "console.read"])

--- a/python/Infernux/mcp/tools/scene.py
+++ b/python/Infernux/mcp/tools/scene.py
@@ -1,0 +1,689 @@
+"""Scene inspection and mutation MCP tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from Infernux.mcp.tools.common import (
+    coerce_vector3,
+    find_game_object,
+    main_thread,
+    resolve_asset_path,
+    serialize_component,
+    serialize_value,
+    serialize_vector,
+)
+
+
+def register_scene_tools(mcp) -> None:
+    @mcp.tool(name="scene.get_hierarchy")
+    def scene_get_hierarchy(
+        depth: int = 6,
+        include_components: bool = True,
+        include_inactive: bool = True,
+    ) -> dict:
+        """Return the active scene hierarchy."""
+
+        def _read():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            roots = list(scene.get_root_objects() or [])
+            return {
+                "scene": getattr(scene, "name", ""),
+                "roots": [
+                    _serialize_object(
+                        root,
+                        depth=max(int(depth), 0),
+                        include_components=bool(include_components),
+                        include_inactive=bool(include_inactive),
+                    )
+                    for root in roots
+                    if include_inactive or bool(getattr(root, "active", True))
+                ],
+            }
+
+        return main_thread("scene.get_hierarchy", _read)
+
+    @mcp.tool(name="scene.save")
+    def scene_save(path: str = "") -> dict:
+        """Save the active scene. If path is provided, it must be under Assets/."""
+
+        def _save():
+            from Infernux.engine.scene_manager import SceneFileManager
+            sfm = SceneFileManager.instance()
+            if sfm is None:
+                raise RuntimeError("SceneFileManager is not available.")
+            if path:
+                from Infernux.engine.project_context import get_project_root
+                save_path = resolve_asset_path(get_project_root(), path)
+                ok = bool(sfm._do_save(save_path))
+            else:
+                ok = bool(sfm.save_current_scene())
+                save_path = getattr(sfm, "current_scene_path", "") or ""
+            return {"saved": ok, "path": save_path, "dirty": bool(getattr(sfm, "is_dirty", False))}
+
+        return main_thread("scene.save", _save)
+
+    @mcp.tool(name="scene.open")
+    def scene_open(path: str) -> dict:
+        """Open a .scene file under Assets/."""
+
+        def _open():
+            from Infernux.engine.project_context import get_project_root
+            from Infernux.engine.scene_manager import SceneFileManager
+            scene_path = resolve_asset_path(get_project_root(), path)
+            sfm = SceneFileManager.instance()
+            if sfm is None:
+                raise RuntimeError("SceneFileManager is not available.")
+            accepted = bool(sfm.open_scene(scene_path))
+            return {"accepted": accepted, "path": scene_path, "loading": bool(getattr(sfm, "is_loading", False))}
+
+        return main_thread("scene.open", _open)
+
+    @mcp.tool(name="scene.new")
+    def scene_new() -> dict:
+        """Create a new empty scene through SceneFileManager."""
+
+        def _new():
+            from Infernux.engine.scene_manager import SceneFileManager
+            sfm = SceneFileManager.instance()
+            if sfm is None:
+                raise RuntimeError("SceneFileManager is not available.")
+            sfm.new_scene()
+            return {"accepted": True, "loading": bool(getattr(sfm, "is_loading", False))}
+
+        return main_thread("scene.new", _new)
+
+    @mcp.tool(name="scene.serialize")
+    def scene_serialize() -> dict:
+        """Return the active scene JSON."""
+
+        def _serialize():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            return {"scene": getattr(scene, "name", ""), "json": scene.serialize()}
+
+        return main_thread("scene.serialize", _serialize)
+
+    @mcp.tool(name="scene.inspect")
+    def scene_inspect(depth: int = 2, include_components: bool = True) -> dict:
+        """Return a compact scene summary for agents."""
+
+        def _inspect():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            objects = list(scene.get_all_objects() or [])
+            roots = list(scene.get_root_objects() or [])
+            component_counts: dict[str, int] = {}
+            cameras = []
+            lights = []
+            scripts = []
+            for obj in objects:
+                comps = _all_components(obj)
+                for comp in comps:
+                    type_name = comp.get("type", "")
+                    component_counts[type_name] = component_counts.get(type_name, 0) + 1
+                    if type_name == "Camera":
+                        cameras.append({"id": int(obj.id), "name": str(obj.name)})
+                    elif type_name == "Light":
+                        lights.append({"id": int(obj.id), "name": str(obj.name)})
+                    elif comp.get("python"):
+                        scripts.append({
+                            "object_id": int(obj.id),
+                            "object_name": str(obj.name),
+                            "type": type_name,
+                            "script_guid": comp.get("script_guid", ""),
+                        })
+            return {
+                "scene": getattr(scene, "name", ""),
+                "object_count": len(objects),
+                "root_count": len(roots),
+                "component_counts": component_counts,
+                "cameras": cameras,
+                "lights": lights,
+                "scripts": scripts,
+                "roots": [
+                    _serialize_object(
+                        root,
+                        depth=max(int(depth), 0),
+                        include_components=bool(include_components),
+                        include_inactive=True,
+                    )
+                    for root in roots
+                ],
+            }
+
+        return main_thread("scene.inspect", _inspect)
+
+    @mcp.tool(name="gameobject.add_component")
+    def gameobject_add_component(
+        object_id: int,
+        component_type: str,
+        script_path: str = "",
+        fields: dict[str, Any] | None = None,
+    ) -> dict:
+        """Add a native, built-in wrapper, registered Python, or script component."""
+
+        def _add():
+            obj = find_game_object(object_id)
+            before_ids = _component_ids(obj)
+            is_py = False
+            comp = None
+
+            if script_path:
+                from Infernux.components import load_and_create_component
+                from Infernux.mcp.tools.common import get_asset_database
+                comp = load_and_create_component(script_path, asset_database=get_asset_database(), type_name=component_type)
+                if comp is None:
+                    raise RuntimeError(f"Script did not create component '{component_type}'.")
+                comp = obj.add_py_component(comp)
+                is_py = True
+            else:
+                comp = obj.add_component(component_type)
+                is_py = _is_python_script_component(comp)
+
+            if comp is None:
+                raise RuntimeError(f"Failed to add component '{component_type}'.")
+
+            for key, value in (fields or {}).items():
+                setattr(comp, key, _coerce_property_value(key, value))
+
+            from Infernux.engine.ui._inspector_undo import _record_add_component_compound
+            _record_add_component_compound(obj, component_type, comp, before_ids, is_py=is_py)
+            return {
+                "object_id": int(obj.id),
+                "component": serialize_component(comp),
+                "components": _all_components(obj),
+            }
+
+        return main_thread("gameobject.add_component", _add)
+
+    @mcp.tool(name="gameobject.get")
+    def gameobject_get(object_id: int, depth: int = 1, include_components: bool = True) -> dict:
+        """Return a GameObject snapshot by id."""
+
+        def _get():
+            obj = find_game_object(object_id)
+            return _serialize_object(
+                obj,
+                depth=max(int(depth), 0),
+                include_components=bool(include_components),
+                include_inactive=True,
+            )
+
+        return main_thread("gameobject.get", _get)
+
+    @mcp.tool(name="gameobject.get_children")
+    def gameobject_get_children(object_id: int = 0, include_components: bool = False) -> dict:
+        """Return root objects (object_id=0) or direct children of a GameObject."""
+
+        def _children():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            if int(object_id) == 0:
+                children = list(scene.get_root_objects() or [])
+                parent_id = 0
+            else:
+                obj = find_game_object(object_id)
+                children = list(obj.get_children() or [])
+                parent_id = int(obj.id)
+            return {
+                "parent_id": parent_id,
+                "children": [
+                    _serialize_object(
+                        child,
+                        depth=0,
+                        include_components=bool(include_components),
+                        include_inactive=True,
+                    )
+                    for child in children
+                ],
+            }
+
+        return main_thread("gameobject.get_children", _children)
+
+    @mcp.tool(name="gameobject.find")
+    def gameobject_find(
+        name: str = "",
+        tag: str = "",
+        component_type: str = "",
+        include_inactive: bool = True,
+        limit: int = 50,
+    ) -> dict:
+        """Find GameObjects by name, tag, and/or component type."""
+
+        def _find():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            matches = []
+            for obj in list(scene.get_all_objects() or []):
+                if not include_inactive and not bool(getattr(obj, "active", True)):
+                    continue
+                if name and name.lower() not in str(obj.name).lower():
+                    continue
+                if tag and str(getattr(obj, "tag", "")) != tag:
+                    continue
+                if component_type and _find_component(obj, component_type, 0) is None:
+                    continue
+                matches.append(_serialize_object(obj, depth=0, include_components=True, include_inactive=True))
+                if len(matches) >= max(int(limit), 1):
+                    break
+            return {"matches": matches}
+
+        return main_thread("gameobject.find", _find)
+
+    @mcp.tool(name="gameobject.set")
+    def gameobject_set(object_id: int, values: dict[str, Any]) -> dict:
+        """Set GameObject fields: name, active, tag, layer, is_static."""
+
+        def _set():
+            obj = find_game_object(object_id)
+            allowed = {"name", "active", "tag", "layer", "is_static"}
+            changed = {}
+            from Infernux.engine.ui._inspector_undo import _record_property
+            for key, value in (values or {}).items():
+                if key not in allowed:
+                    raise ValueError(f"Unsupported GameObject field: {key}")
+                old_value = getattr(obj, key)
+                new_value = int(value) if key == "layer" else bool(value) if key in {"active", "is_static"} else str(value)
+                _record_property(obj, key, old_value, new_value, f"Set GameObject {key}")
+                changed[key] = serialize_value(getattr(obj, key))
+            return {"object_id": int(obj.id), "changed": changed}
+
+        return main_thread("gameobject.set", _set)
+
+    @mcp.tool(name="gameobject.delete")
+    def gameobject_delete(object_id: int) -> dict:
+        """Delete a GameObject through the hierarchy undo tracker."""
+
+        def _delete():
+            obj = find_game_object(object_id)
+            name = str(obj.name)
+            from Infernux.engine.undo._trackers import HierarchyUndoTracker
+            HierarchyUndoTracker().record_delete(int(object_id), "MCP Delete GameObject")
+            return {"deleted": True, "object_id": int(object_id), "name": name}
+
+        return main_thread("gameobject.delete", _delete)
+
+    @mcp.tool(name="gameobject.duplicate")
+    def gameobject_duplicate(object_id: int, parent_id: int = 0, name: str = "", select: bool = True) -> dict:
+        """Duplicate a GameObject using Scene.instantiate_game_object."""
+
+        def _duplicate():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            source = find_game_object(object_id)
+            parent = scene.find_by_id(int(parent_id)) if parent_id else None
+            obj = scene.instantiate_game_object(source, parent)
+            if obj is None:
+                raise RuntimeError("Failed to duplicate GameObject.")
+            if name:
+                obj.name = str(name)
+            from Infernux.engine.undo._trackers import HierarchyUndoTracker
+            HierarchyUndoTracker().record_create(int(obj.id), "MCP Duplicate GameObject")
+            if select:
+                from Infernux.engine.ui.selection_manager import SelectionManager
+                SelectionManager.instance().select(int(obj.id))
+            return _serialize_object(obj, depth=1, include_components=True, include_inactive=True)
+
+        return main_thread("gameobject.duplicate", _duplicate)
+
+    @mcp.tool(name="gameobject.set_parent")
+    def gameobject_set_parent(object_id: int, parent_id: int = 0, world_position_stays: bool = True) -> dict:
+        """Set or clear a GameObject parent."""
+
+        def _set_parent():
+            obj = find_game_object(object_id)
+            old_parent = obj.get_parent()
+            new_parent = find_game_object(parent_id) if parent_id else None
+            obj.set_parent(new_parent, bool(world_position_stays))
+            from Infernux.engine.scene_manager import SceneFileManager
+            sfm = SceneFileManager.instance()
+            if sfm:
+                sfm.mark_dirty()
+            return {
+                "object_id": int(obj.id),
+                "parent_id": int(getattr(obj.get_parent(), "id", 0) or 0),
+                "old_parent_id": int(getattr(old_parent, "id", 0) or 0),
+            }
+
+        return main_thread("gameobject.set_parent", _set_parent)
+
+    @mcp.tool(name="gameobject.set_sibling_index")
+    def gameobject_set_sibling_index(object_id: int, index: int) -> dict:
+        """Move a GameObject within its current sibling list."""
+
+        def _set_sibling_index():
+            obj = find_game_object(object_id)
+            old_index = int(obj.transform.get_sibling_index())
+            obj.transform.set_sibling_index(int(index))
+            from Infernux.engine.scene_manager import SceneFileManager
+            sfm = SceneFileManager.instance()
+            if sfm:
+                sfm.mark_dirty()
+            return {
+                "object_id": int(obj.id),
+                "old_index": old_index,
+                "index": int(obj.transform.get_sibling_index()),
+                "parent_id": int(getattr(obj.get_parent(), "id", 0) or 0),
+            }
+
+        return main_thread("gameobject.set_sibling_index", _set_sibling_index)
+
+    @mcp.tool(name="transform.set")
+    def transform_set(object_id: int, values: dict[str, Any]) -> dict:
+        """Set Transform fields such as position, euler_angles, or local_scale."""
+
+        def _set():
+            obj = find_game_object(object_id)
+            trans = obj.transform
+            if trans is None:
+                raise RuntimeError(f"GameObject {object_id} has no Transform.")
+            allowed = {
+                "position",
+                "local_position",
+                "euler_angles",
+                "local_euler_angles",
+                "local_scale",
+            }
+            changed: dict[str, Any] = {}
+            from Infernux.engine.ui._inspector_undo import _record_property
+            for key, value in values.items():
+                if key not in allowed:
+                    raise ValueError(f"Unsupported Transform field: {key}")
+                old_value = getattr(trans, key)
+                new_value = coerce_vector3(value)
+                _record_property(trans, key, old_value, new_value, f"Set Transform {key}")
+                changed[key] = serialize_vector(getattr(trans, key))
+            return {"object_id": int(obj.id), "changed": changed}
+
+        return main_thread("transform.set", _set)
+
+    @mcp.tool(name="component.set_field")
+    def component_set_field(
+        object_id: int,
+        component_type: str,
+        field: str,
+        value: Any,
+        ordinal: int = 0,
+    ) -> dict:
+        """Set a field/property on a component attached to a GameObject."""
+
+        def _set():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, int(ordinal))
+            if comp is None:
+                raise FileNotFoundError(f"Component '{component_type}' was not found on GameObject {object_id}.")
+            old_value = getattr(comp, field)
+            new_value = _coerce_property_value(field, value)
+            from Infernux.engine.ui._inspector_undo import _record_property
+            _record_property(comp, field, old_value, new_value, f"Set {component_type}.{field}")
+            return {
+                "object_id": int(obj.id),
+                "component": serialize_component(comp),
+                "field": field,
+                "value": serialize_value(getattr(comp, field)),
+            }
+
+        return main_thread("component.set_field", _set)
+
+    @mcp.tool(name="component.get_field")
+    def component_get_field(object_id: int, component_type: str, field: str, ordinal: int = 0) -> dict:
+        """Read a field/property from a component attached to a GameObject."""
+
+        def _get():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, int(ordinal))
+            if comp is None:
+                raise FileNotFoundError(f"Component '{component_type}' was not found on GameObject {object_id}.")
+            return {
+                "object_id": int(obj.id),
+                "component": serialize_component(comp),
+                "field": field,
+                "value": serialize_value(getattr(comp, field)),
+            }
+
+        return main_thread("component.get_field", _get)
+
+    @mcp.tool(name="component.remove")
+    def component_remove(object_id: int, component_type: str, ordinal: int = 0) -> dict:
+        """Remove a native or Python component from a GameObject."""
+
+        def _remove():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, int(ordinal))
+            if comp is None:
+                raise FileNotFoundError(f"Component '{component_type}' was not found on GameObject {object_id}.")
+            is_py = _is_python_script_component(comp)
+            type_name = getattr(comp, "type_name", type(comp).__name__)
+            from Infernux.engine.undo import UndoManager
+            mgr = UndoManager.instance()
+            if mgr:
+                if is_py and hasattr(obj, "remove_py_component"):
+                    from Infernux.engine.undo._component_commands import RemovePyComponentCommand
+                    mgr.execute(RemovePyComponentCommand(int(obj.id), comp, "MCP Remove Component"))
+                else:
+                    from Infernux.engine.undo._component_commands import RemoveNativeComponentCommand
+                    mgr.execute(RemoveNativeComponentCommand(int(obj.id), str(type_name), comp, "MCP Remove Component"))
+            elif is_py and hasattr(obj, "remove_py_component"):
+                obj.remove_py_component(comp)
+            else:
+                obj.remove_component(comp)
+            return {"object_id": int(obj.id), "removed": str(type_name), "components": _all_components(obj)}
+
+        return main_thread("component.remove", _remove)
+
+    @mcp.tool(name="component.list_types")
+    def component_list_types() -> dict:
+        """List known built-in and Python component types."""
+
+        def _list():
+            import Infernux.components.builtin  # noqa: F401 - ensure built-ins register
+            from Infernux.components.builtin_component import BuiltinComponent
+            from Infernux.components.registry import get_all_types
+            builtin = [
+                _component_type_entry(name, cls, builtin=True)
+                for name, cls in sorted(BuiltinComponent._builtin_registry.items())
+            ]
+            scripts = [
+                _component_type_entry(name, cls, builtin=False)
+                for name, cls in sorted(get_all_types().items())
+                if not _is_builtin_family_class(cls)
+            ]
+            return {"builtin": builtin, "scripts": scripts}
+
+        return main_thread("component.list_types", _list)
+
+    @mcp.tool(name="component.describe_type")
+    def component_describe_type(component_type: str) -> dict:
+        """Describe serialized/inspector fields for a component type."""
+
+        def _describe():
+            cls = _component_class_for_name(component_type)
+            if cls is None:
+                raise FileNotFoundError(f"Component type '{component_type}' was not found.")
+            return _component_type_entry(component_type, cls, builtin=_is_builtin_component_class(cls), include_fields=True)
+
+        return main_thread("component.describe_type", _describe)
+
+
+def _serialize_object(obj, *, depth: int, include_components: bool, include_inactive: bool) -> dict[str, Any]:
+    children = []
+    if depth > 0:
+        try:
+            raw_children = list(obj.get_children() or [])
+        except Exception:
+            raw_children = []
+        children = [
+            _serialize_object(
+                child,
+                depth=depth - 1,
+                include_components=include_components,
+                include_inactive=include_inactive,
+            )
+            for child in raw_children
+            if include_inactive or bool(getattr(child, "active", True))
+        ]
+
+    data = {
+        "id": int(obj.id),
+        "name": str(obj.name),
+        "active": bool(getattr(obj, "active", True)),
+        "children": children,
+    }
+    if include_components:
+        data["components"] = _all_components(obj)
+    return data
+
+
+def _all_components(obj) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    seen: set[tuple[str, int]] = set()
+
+    def _append(comp) -> None:
+        data = serialize_component(comp)
+        component_id = int(data.get("component_id", 0) or 0)
+        key = (str(data.get("type", "")), component_id)
+        if component_id and key in seen:
+            return
+        if component_id:
+            seen.add(key)
+        items.append(data)
+
+    try:
+        for comp in (obj.get_components() or []):
+            _append(comp)
+    except Exception:
+        pass
+    try:
+        for comp in (obj.get_py_components() or []):
+            _append(comp)
+    except Exception:
+        pass
+    return items
+
+
+def _component_ids(obj) -> set[int]:
+    ids: set[int] = set()
+    try:
+        for comp in obj.get_components() or []:
+            component_id = getattr(comp, "component_id", 0)
+            if component_id:
+                ids.add(int(component_id))
+    except Exception:
+        pass
+    return ids
+
+
+def _find_component(obj, component_type: str, ordinal: int):
+    matches = []
+    try:
+        for comp in obj.get_components() or []:
+            if getattr(comp, "type_name", type(comp).__name__) == component_type:
+                matches.append(comp)
+    except Exception:
+        pass
+    try:
+        for comp in obj.get_py_components() or []:
+            if getattr(comp, "type_name", type(comp).__name__) == component_type or type(comp).__name__ == component_type:
+                matches.append(comp)
+    except Exception:
+        pass
+    if ordinal < 0 or ordinal >= len(matches):
+        return None
+    return matches[ordinal]
+
+
+def _coerce_property_value(field: str, value: Any) -> Any:
+    if isinstance(value, dict) and {"x", "y", "z"}.issubset(value.keys()):
+        return coerce_vector3(value)
+    return value
+
+
+def _is_python_script_component(comp) -> bool:
+    if getattr(comp, "_cpp_type_name", ""):
+        return False
+    script_guid = getattr(comp, "_script_guid", None)
+    if script_guid:
+        return True
+    try:
+        from Infernux.components.component import InxComponent
+        return isinstance(comp, InxComponent) and not getattr(comp, "_cpp_type_name", "")
+    except Exception:
+        return False
+
+
+def _is_builtin_component_class(cls) -> bool:
+    return bool(getattr(cls, "_cpp_type_name", ""))
+
+
+def _is_builtin_family_class(cls) -> bool:
+    module_name = str(getattr(cls, "__module__", ""))
+    return module_name.startswith("Infernux.components.builtin") or bool(getattr(cls, "_cpp_type_name", ""))
+
+
+def _component_class_for_name(component_type: str):
+    import Infernux.components.builtin  # noqa: F401 - ensure built-ins register
+    from Infernux.components.builtin_component import BuiltinComponent
+    from Infernux.components.registry import get_type
+
+    if component_type in BuiltinComponent._builtin_registry:
+        return BuiltinComponent._builtin_registry[component_type]
+    for name, cls in BuiltinComponent._builtin_registry.items():
+        if cls.__name__ == component_type or name.lower() == component_type.lower():
+            return cls
+    return get_type(component_type)
+
+
+def _component_type_entry(name: str, cls, *, builtin: bool, include_fields: bool = False) -> dict[str, Any]:
+    type_name = getattr(cls, "_cpp_type_name", "") or getattr(cls, "__name__", name)
+    entry = {
+        "type": str(type_name),
+        "class_name": getattr(cls, "__name__", str(name)),
+        "category": str(getattr(cls, "_component_category_", "")),
+        "builtin": bool(builtin),
+    }
+    if include_fields:
+        entry["fields"] = _component_field_schema(cls)
+    return entry
+
+
+def _component_field_schema(cls) -> list[dict[str, Any]]:
+    from Infernux.components.serialized_field import get_serialized_fields
+
+    fields = []
+    for name, meta in get_serialized_fields(cls).items():
+        enum_values = []
+        enum_type = getattr(meta, "enum_type", None)
+        if enum_type is not None:
+            try:
+                enum_values = [
+                    {"name": str(item.name), "value": int(item.value)}
+                    for item in list(enum_type)
+                ]
+            except Exception:
+                enum_values = []
+        fields.append({
+            "name": name,
+            "type": getattr(getattr(meta, "field_type", None), "name", str(getattr(meta, "field_type", ""))),
+            "default": serialize_value(getattr(meta, "default", None)),
+            "range": serialize_value(getattr(meta, "range", None)),
+            "tooltip": str(getattr(meta, "tooltip", "")),
+            "readonly": bool(getattr(meta, "readonly", False)),
+            "enum_values": enum_values,
+            "asset_type": str(getattr(meta, "asset_type", "") or ""),
+            "component_type": str(getattr(meta, "component_type", "") or ""),
+        })
+    return fields

--- a/python/Infernux/mcp/tools/scene.py
+++ b/python/Infernux/mcp/tools/scene.py
@@ -253,6 +253,7 @@ def register_scene_tools(mcp) -> None:
     @mcp.tool(name="gameobject.find")
     def gameobject_find(
         name: str = "",
+        path: str = "",
         tag: str = "",
         component_type: str = "",
         include_inactive: bool = True,
@@ -271,16 +272,115 @@ def register_scene_tools(mcp) -> None:
                     continue
                 if name and name.lower() not in str(obj.name).lower():
                     continue
+                if path and path.lower() not in _object_path(obj).lower():
+                    continue
                 if tag and str(getattr(obj, "tag", "")) != tag:
                     continue
                 if component_type and _find_component(obj, component_type, 0) is None:
                     continue
-                matches.append(_serialize_object(obj, depth=0, include_components=True, include_inactive=True))
+                data = _serialize_object(obj, depth=0, include_components=True, include_inactive=True)
+                data["path"] = _object_path(obj)
+                matches.append(data)
                 if len(matches) >= max(int(limit), 1):
                     break
             return {"matches": matches}
 
         return main_thread("gameobject.find", _find)
+
+    @mcp.tool(name="scene.find")
+    def scene_find(query: dict[str, Any], limit: int = 50) -> dict:
+        """Search scene objects by name/path/tag/layer/component."""
+
+        def _scene_find():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            criteria = query or {}
+            q_name = str(criteria.get("name", "")).lower()
+            q_path = str(criteria.get("path", "")).lower()
+            q_tag = str(criteria.get("tag", ""))
+            q_component = str(criteria.get("component_type", ""))
+            q_layer = criteria.get("layer", None)
+            matches = []
+            for obj in list(scene.get_all_objects() or []):
+                if q_name and q_name not in str(obj.name).lower():
+                    continue
+                obj_path = _object_path(obj)
+                if q_path and q_path not in obj_path.lower():
+                    continue
+                if q_tag and str(getattr(obj, "tag", "")) != q_tag:
+                    continue
+                if q_layer is not None and int(getattr(obj, "layer", -1)) != int(q_layer):
+                    continue
+                if q_component and _find_component(obj, q_component, 0) is None:
+                    continue
+                data = _serialize_object(obj, depth=0, include_components=True, include_inactive=True)
+                data["path"] = obj_path
+                matches.append(data)
+                if len(matches) >= max(int(limit), 1):
+                    break
+            return {"matches": matches}
+
+        return main_thread("scene.find", _scene_find)
+
+    @mcp.tool(name="gameobject.path")
+    def gameobject_path(object_id: int) -> dict:
+        """Return the hierarchy path for a GameObject."""
+
+        def _path():
+            obj = find_game_object(object_id)
+            return {"object_id": int(obj.id), "path": _object_path(obj)}
+
+        return main_thread("gameobject.path", _path)
+
+    @mcp.tool(name="gameobject.find_by_path")
+    def gameobject_find_by_path(path: str) -> dict:
+        """Find a GameObject by exact hierarchy path."""
+
+        def _find_by_path():
+            obj = _find_by_path_exact(path)
+            if obj is None:
+                raise FileNotFoundError(f"GameObject path not found: {path}")
+            data = _serialize_object(obj, depth=1, include_components=True, include_inactive=True)
+            data["path"] = _object_path(obj)
+            return data
+
+        return main_thread("gameobject.find_by_path", _find_by_path)
+
+    @mcp.tool(name="gameobject.ensure_path")
+    def gameobject_ensure_path(path: str, kind: str = "empty", select: bool = False) -> dict:
+        """Ensure a slash-separated hierarchy path exists."""
+
+        def _ensure_path():
+            from Infernux.engine.hierarchy_creation_service import HierarchyCreationService
+            if not path or not str(path).strip("/"):
+                raise ValueError("path must not be empty.")
+            created = []
+            parent_id = 0
+            current_path = ""
+            target_path = str(path).replace("\\", "/").strip("/")
+            for part in [p for p in target_path.split("/") if p]:
+                current_path = f"{current_path}/{part}" if current_path else part
+                existing = _find_by_path_exact(current_path)
+                if existing is not None:
+                    parent_id = int(existing.id)
+                    continue
+                entry = HierarchyCreationService.instance().create(
+                    kind if current_path == target_path else "empty",
+                    parent_id=parent_id,
+                    name=part,
+                    select=False,
+                )
+                created.append(entry)
+                parent_id = int(entry["id"])
+            if select and parent_id:
+                from Infernux.engine.ui.selection_manager import SelectionManager
+                SelectionManager.instance().select(parent_id)
+            final = find_game_object(parent_id)
+            return {"object_id": parent_id, "path": _object_path(final), "created": created}
+
+        return main_thread("gameobject.ensure_path", _ensure_path)
 
     @mcp.tool(name="gameobject.set")
     def gameobject_set(object_id: int, values: dict[str, Any]) -> dict:
@@ -314,6 +414,50 @@ def register_scene_tools(mcp) -> None:
             return {"deleted": True, "object_id": int(object_id), "name": name}
 
         return main_thread("gameobject.delete", _delete)
+
+    @mcp.tool(name="gameobject.batch_delete")
+    def gameobject_batch_delete(object_ids: list[int]) -> dict:
+        """Delete multiple GameObjects."""
+
+        def _batch_delete():
+            deleted = []
+            from Infernux.engine.undo._trackers import HierarchyUndoTracker
+            tracker = HierarchyUndoTracker()
+            for object_id in object_ids or []:
+                obj = find_game_object(int(object_id))
+                deleted.append({"id": int(obj.id), "name": str(obj.name), "path": _object_path(obj)})
+                tracker.record_delete(int(object_id), "MCP Batch Delete GameObject")
+            return {"deleted": deleted}
+
+        return main_thread("gameobject.batch_delete", _batch_delete)
+
+    @mcp.tool(name="gameobject.batch_create")
+    def gameobject_batch_create(items: list[dict[str, Any]]) -> dict:
+        """Create multiple hierarchy objects."""
+
+        def _batch_create():
+            from Infernux.engine.hierarchy_creation_service import HierarchyCreationService
+            created = []
+            for item in items or []:
+                parent_id = int(item.get("parent_id", 0) or 0)
+                parent_path = item.get("parent_path", "")
+                if parent_path:
+                    parent = _find_by_path_exact(parent_path)
+                    if parent is None:
+                        raise FileNotFoundError(f"Parent path not found: {parent_path}")
+                    parent_id = int(parent.id)
+                entry = HierarchyCreationService.instance().create(
+                    str(item.get("kind", "empty")),
+                    parent_id=parent_id,
+                    name=item.get("name") or None,
+                    select=bool(item.get("select", False)),
+                )
+                obj = find_game_object(int(entry["id"]))
+                entry["path"] = _object_path(obj)
+                created.append(entry)
+            return {"created": created}
+
+        return main_thread("gameobject.batch_create", _batch_create)
 
     @mcp.tool(name="gameobject.duplicate")
     def gameobject_duplicate(object_id: int, parent_id: int = 0, name: str = "", select: bool = True) -> dict:
@@ -382,6 +526,34 @@ def register_scene_tools(mcp) -> None:
 
         return main_thread("gameobject.set_sibling_index", _set_sibling_index)
 
+    @mcp.tool(name="scene.clear_generated")
+    def scene_clear_generated(name_prefix: str = "MCP", root_path: str = "") -> dict:
+        """Delete generated scene objects by root path or name prefix."""
+
+        def _clear():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            targets = []
+            if root_path:
+                root = _find_by_path_exact(root_path)
+                if root is not None:
+                    targets.append(root)
+            else:
+                for obj in scene.get_root_objects() or []:
+                    if str(obj.name).startswith(name_prefix):
+                        targets.append(obj)
+            from Infernux.engine.undo._trackers import HierarchyUndoTracker
+            tracker = HierarchyUndoTracker()
+            deleted = []
+            for obj in targets:
+                deleted.append({"id": int(obj.id), "name": str(obj.name), "path": _object_path(obj)})
+                tracker.record_delete(int(obj.id), "MCP Clear Generated")
+            return {"deleted": deleted}
+
+        return main_thread("scene.clear_generated", _clear)
+
     @mcp.tool(name="transform.set")
     def transform_set(object_id: int, values: dict[str, Any]) -> dict:
         """Set Transform fields such as position, euler_angles, or local_scale."""
@@ -439,6 +611,73 @@ def register_scene_tools(mcp) -> None:
 
         return main_thread("component.set_field", _set)
 
+    @mcp.tool(name="component.set_fields")
+    def component_set_fields(object_id: int, component_type: str, values: dict[str, Any], ordinal: int = 0) -> dict:
+        """Set multiple fields/properties on a component."""
+
+        def _set_fields():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, int(ordinal))
+            if comp is None:
+                raise FileNotFoundError(f"Component '{component_type}' was not found on GameObject {object_id}.")
+            from Infernux.engine.ui._inspector_undo import _record_property
+            changed = {}
+            for field, value in (values or {}).items():
+                old_value = getattr(comp, field)
+                new_value = _coerce_property_value(field, value)
+                _record_property(comp, field, old_value, new_value, f"Set {component_type}.{field}")
+                changed[field] = serialize_value(getattr(comp, field))
+            return {"object_id": int(obj.id), "component": serialize_component(comp), "changed": changed}
+
+        return main_thread("component.set_fields", _set_fields)
+
+    @mcp.tool(name="component.ensure")
+    def component_ensure(
+        object_id: int,
+        component_type: str,
+        script_path: str = "",
+        fields: dict[str, Any] | None = None,
+    ) -> dict:
+        """Return an existing component or add it if missing."""
+
+        def _ensure():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, 0)
+            created = False
+            if comp is None:
+                before_ids = _component_ids(obj)
+                if script_path:
+                    from Infernux.components import load_and_create_component
+                    from Infernux.mcp.tools.common import get_asset_database
+                    comp = load_and_create_component(script_path, asset_database=get_asset_database(), type_name=component_type)
+                    if comp is None:
+                        raise RuntimeError(f"Script did not create component '{component_type}'.")
+                    comp = obj.add_py_component(comp)
+                    is_py = True
+                else:
+                    comp = obj.add_component(component_type)
+                    is_py = _is_python_script_component(comp)
+                if comp is None:
+                    raise RuntimeError(f"Failed to add component '{component_type}'.")
+                from Infernux.engine.ui._inspector_undo import _record_add_component_compound
+                _record_add_component_compound(obj, component_type, comp, before_ids, is_py=is_py)
+                created = True
+            for key, value in (fields or {}).items():
+                setattr(comp, key, _coerce_property_value(key, value))
+            return {"object_id": int(obj.id), "created": created, "component": serialize_component(comp), "components": _all_components(obj)}
+
+        return main_thread("component.ensure", _ensure)
+
+    @mcp.tool(name="component.list_on_object")
+    def component_list_on_object(object_id: int) -> dict:
+        """List components attached to a GameObject."""
+
+        def _list_on_object():
+            obj = find_game_object(object_id)
+            return {"object_id": int(obj.id), "components": _all_components(obj)}
+
+        return main_thread("component.list_on_object", _list_on_object)
+
     @mcp.tool(name="component.get_field")
     def component_get_field(object_id: int, component_type: str, field: str, ordinal: int = 0) -> dict:
         """Read a field/property from a component attached to a GameObject."""
@@ -456,6 +695,19 @@ def register_scene_tools(mcp) -> None:
             }
 
         return main_thread("component.get_field", _get)
+
+    @mcp.tool(name="component.get")
+    def component_get(object_id: int, component_type: str, ordinal: int = 0) -> dict:
+        """Return component metadata and serializable field values."""
+
+        def _get_component():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, int(ordinal))
+            if comp is None:
+                raise FileNotFoundError(f"Component '{component_type}' was not found on GameObject {object_id}.")
+            return _component_snapshot(obj, comp)
+
+        return main_thread("component.get", _get_component)
 
     @mcp.tool(name="component.remove")
     def component_remove(object_id: int, component_type: str, ordinal: int = 0) -> dict:
@@ -517,6 +769,60 @@ def register_scene_tools(mcp) -> None:
             return _component_type_entry(component_type, cls, builtin=_is_builtin_component_class(cls), include_fields=True)
 
         return main_thread("component.describe_type", _describe)
+
+    @mcp.tool(name="component.describe_field")
+    def component_describe_field(component_type: str, field: str) -> dict:
+        """Describe one field on a component type."""
+
+        def _describe_field():
+            cls = _component_class_for_name(component_type)
+            if cls is None:
+                raise FileNotFoundError(f"Component type '{component_type}' was not found.")
+            for item in _component_field_schema(cls):
+                if item["name"] == field:
+                    return {"component_type": component_type, "field": item}
+            raise FileNotFoundError(f"Field '{field}' was not found on component type '{component_type}'.")
+
+        return main_thread("component.describe_field", _describe_field)
+
+    @mcp.tool(name="component.get_snapshot")
+    def component_get_snapshot(object_id: int, component_type: str, ordinal: int = 0) -> dict:
+        """Serialize a component snapshot for restore_snapshot."""
+
+        def _snapshot():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, int(ordinal))
+            if comp is None:
+                raise FileNotFoundError(f"Component '{component_type}' was not found on GameObject {object_id}.")
+            payload = ""
+            if hasattr(comp, "serialize"):
+                try:
+                    payload = comp.serialize()
+                except Exception:
+                    payload = ""
+            return {**_component_snapshot(obj, comp), "serialized": payload}
+
+        return main_thread("component.get_snapshot", _snapshot)
+
+    @mcp.tool(name="component.restore_snapshot")
+    def component_restore_snapshot(object_id: int, component_type: str, serialized: str, ordinal: int = 0) -> dict:
+        """Restore a component from a serialized component JSON snapshot."""
+
+        def _restore():
+            obj = find_game_object(object_id)
+            comp = _find_component(obj, component_type, int(ordinal))
+            if comp is None:
+                raise FileNotFoundError(f"Component '{component_type}' was not found on GameObject {object_id}.")
+            if not hasattr(comp, "deserialize"):
+                raise ValueError(f"Component '{component_type}' does not support deserialize().")
+            comp.deserialize(serialized)
+            from Infernux.engine.scene_manager import SceneFileManager
+            sfm = SceneFileManager.instance()
+            if sfm:
+                sfm.mark_dirty()
+            return _component_snapshot(obj, comp)
+
+        return main_thread("component.restore_snapshot", _restore)
 
 
 def _serialize_object(obj, *, depth: int, include_components: bool, include_inactive: bool) -> dict[str, Any]:
@@ -587,6 +893,32 @@ def _component_ids(obj) -> set[int]:
     return ids
 
 
+def _object_path(obj) -> str:
+    parts = []
+    current = obj
+    while current is not None:
+        parts.append(str(current.name))
+        try:
+            current = current.get_parent()
+        except Exception:
+            current = None
+    return "/".join(reversed(parts))
+
+
+def _find_by_path_exact(path: str):
+    from Infernux.lib import SceneManager
+    scene = SceneManager.instance().get_active_scene()
+    if not scene:
+        raise RuntimeError("No active scene.")
+    normalized = str(path).replace("\\", "/").strip("/")
+    if not normalized:
+        return None
+    for obj in list(scene.get_all_objects() or []):
+        if _object_path(obj).strip("/") == normalized:
+            return obj
+    return None
+
+
 def _find_component(obj, component_type: str, ordinal: int):
     matches = []
     try:
@@ -604,6 +936,25 @@ def _find_component(obj, component_type: str, ordinal: int):
     if ordinal < 0 or ordinal >= len(matches):
         return None
     return matches[ordinal]
+
+
+def _component_snapshot(obj, comp) -> dict[str, Any]:
+    fields = {}
+    try:
+        from Infernux.components.serialized_field import get_serialized_fields
+        for name in get_serialized_fields(type(comp)):
+            try:
+                fields[name] = serialize_value(getattr(comp, name))
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return {
+        "object_id": int(obj.id),
+        "object_name": str(obj.name),
+        "component": serialize_component(comp),
+        "fields": fields,
+    }
 
 
 def _coerce_property_value(field: str, value: Any) -> Any:

--- a/python/Infernux/mcp/tools/ui.py
+++ b/python/Infernux/mcp/tools/ui.py
@@ -1,0 +1,273 @@
+"""Semantic UI creation MCP tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from Infernux.mcp.tools.common import main_thread, register_tool_metadata, serialize_value
+
+
+def register_ui_tools(mcp) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="ui.create_canvas")
+    def ui_create_canvas(name: str = "Canvas", reference_width: int = 1920, reference_height: int = 1080, select: bool = False) -> dict:
+        """Create a UI Canvas."""
+
+        def _create():
+            obj, comp = _create_ui_object("canvas", name, 0)
+            comp.reference_width = int(reference_width)
+            comp.reference_height = int(reference_height)
+            _select_if(obj, select)
+            return _ui_snapshot(obj, comp)
+
+        return main_thread("ui.create_canvas", _create)
+
+    @mcp.tool(name="ui.create_text")
+    def ui_create_text(name: str = "Text", parent_id: int = 0, text: str = "New Text", rect: dict[str, Any] | None = None) -> dict:
+        """Create a UIText element."""
+
+        def _create():
+            obj, comp = _create_ui_object("text", name, int(parent_id or 0))
+            comp.text = str(text)
+            _apply_rect(comp, rect or {})
+            return _ui_snapshot(obj, comp)
+
+        return main_thread("ui.create_text", _create)
+
+    @mcp.tool(name="ui.create_button")
+    def ui_create_button(name: str = "Button", parent_id: int = 0, label: str = "Button", rect: dict[str, Any] | None = None) -> dict:
+        """Create a UIButton element."""
+
+        def _create():
+            obj, comp = _create_ui_object("button", name, int(parent_id or 0))
+            comp.label = str(label)
+            _apply_rect(comp, rect or {})
+            return _ui_snapshot(obj, comp)
+
+        return main_thread("ui.create_button", _create)
+
+    @mcp.tool(name="ui.create_image")
+    def ui_create_image(name: str = "Image", parent_id: int = 0, texture_path: str = "", rect: dict[str, Any] | None = None) -> dict:
+        """Create a UIImage element."""
+
+        def _create():
+            obj, comp = _create_ui_object("image", name, int(parent_id or 0))
+            comp.texture_path = str(texture_path or "")
+            _apply_rect(comp, rect or {})
+            return _ui_snapshot(obj, comp)
+
+        return main_thread("ui.create_image", _create)
+
+    @mcp.tool(name="ui.create_panel")
+    def ui_create_panel(name: str = "Panel", parent_id: int = 0, color: list | None = None, rect: dict[str, Any] | None = None) -> dict:
+        """Create a solid-color panel using UIImage."""
+
+        def _create():
+            obj, comp = _create_ui_object("image", name, int(parent_id or 0))
+            comp.texture_path = ""
+            comp.color = color or [0.1, 0.1, 0.1, 0.85]
+            _apply_rect(comp, rect or {})
+            return _ui_snapshot(obj, comp)
+
+        return main_thread("ui.create_panel", _create)
+
+    @mcp.tool(name="ui.set_rect")
+    def ui_set_rect(object_id: int, rect: dict[str, Any]) -> dict:
+        """Set x/y/width/height/rotation on a UI screen component."""
+
+        def _set_rect():
+            obj = _find_game_object(object_id)
+            comp = _find_ui_screen_component(obj)
+            if comp is None:
+                raise FileNotFoundError(f"GameObject {object_id} has no screen UI component.")
+            _apply_rect(comp, rect or {})
+            _mark_ui_dirty()
+            return _ui_snapshot(obj, comp)
+
+        return main_thread("ui.set_rect", _set_rect)
+
+    @mcp.tool(name="ui.set_text")
+    def ui_set_text(object_id: int, text: str) -> dict:
+        """Set text/label on UIText or UIButton."""
+
+        def _set_text():
+            obj = _find_game_object(object_id)
+            comp = _find_named_component(obj, {"UIText", "UIButton"})
+            if comp is None:
+                raise FileNotFoundError(f"GameObject {object_id} has no UIText or UIButton.")
+            if type(comp).__name__ == "UIButton":
+                comp.label = str(text)
+            else:
+                comp.text = str(text)
+            _mark_ui_dirty()
+            return _ui_snapshot(obj, comp)
+
+        return main_thread("ui.set_text", _set_text)
+
+    @mcp.tool(name="ui.inspect")
+    def ui_inspect() -> dict:
+        """Return a compact snapshot of UI canvases and elements."""
+
+        def _inspect():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            elements = []
+            for obj in scene.get_all_objects() or []:
+                comp = _find_ui_component(obj)
+                if comp is not None:
+                    elements.append(_ui_snapshot(obj, comp))
+            return {"elements": elements}
+
+        return main_thread("ui.inspect", _inspect)
+
+    @mcp.tool(name="ui.find_by_text")
+    def ui_find_by_text(text: str) -> dict:
+        """Find UIText/UIButton elements by visible text."""
+
+        def _find():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            needle = str(text).lower()
+            matches = []
+            for obj in scene.get_all_objects() or []:
+                comp = _find_named_component(obj, {"UIText", "UIButton"})
+                if comp is None:
+                    continue
+                visible = str(getattr(comp, "label", getattr(comp, "text", "")))
+                if needle in visible.lower():
+                    matches.append(_ui_snapshot(obj, comp))
+            return {"matches": matches}
+
+        return main_thread("ui.find_by_text", _find)
+
+
+def _create_ui_object(kind: str, name: str, parent_id: int):
+    from Infernux.lib import SceneManager
+    from Infernux.ui import UICanvas, UIText, UIButton
+    from Infernux.ui.ui_image import UIImage
+    scene = SceneManager.instance().get_active_scene()
+    if not scene:
+        raise RuntimeError("No active scene.")
+    if kind != "canvas" and not parent_id:
+        canvas = _find_first_canvas(scene)
+        if canvas is None:
+            canvas_obj, _canvas_comp = _create_ui_object("canvas", "Canvas", 0)
+            parent_id = int(canvas_obj.id)
+        else:
+            parent_id = int(canvas.id)
+    obj = scene.create_game_object(str(name or kind.title()))
+    if parent_id:
+        parent = scene.find_by_id(int(parent_id))
+        if parent is None:
+            raise FileNotFoundError(f"Parent GameObject {parent_id} was not found.")
+        obj.set_parent(parent)
+    cls = {"canvas": UICanvas, "text": UIText, "button": UIButton, "image": UIImage}[kind]
+    comp = cls()
+    obj.add_py_component(comp)
+    _mark_ui_dirty()
+    return obj, comp
+
+
+def _find_first_canvas(scene):
+    try:
+        for obj in scene.get_all_objects() or []:
+            if _find_named_component(obj, {"UICanvas"}) is not None:
+                return obj
+    except Exception:
+        pass
+    return None
+
+
+def _apply_rect(comp, rect: dict[str, Any]) -> None:
+    for key in ("x", "y", "width", "height", "rotation", "opacity", "corner_radius"):
+        if key in rect:
+            setattr(comp, key, float(rect[key]))
+
+
+def _ui_snapshot(obj, comp) -> dict[str, Any]:
+    data = {
+        "object_id": int(obj.id),
+        "name": str(obj.name),
+        "type": type(comp).__name__,
+        "parent_id": int(getattr(obj.get_parent(), "id", 0) or 0),
+        "fields": {},
+    }
+    for key in ("text", "label", "x", "y", "width", "height", "rotation", "opacity", "corner_radius", "reference_width", "reference_height", "texture_path", "color"):
+        if hasattr(comp, key):
+            data["fields"][key] = serialize_value(getattr(comp, key))
+    return data
+
+
+def _find_game_object(object_id: int):
+    from Infernux.mcp.tools.common import find_game_object
+    return find_game_object(object_id)
+
+
+def _find_named_component(obj, names: set[str]):
+    try:
+        for comp in obj.get_py_components() or []:
+            if type(comp).__name__ in names:
+                return comp
+    except Exception:
+        pass
+    return None
+
+
+def _find_ui_component(obj):
+    return _find_named_component(obj, {"UICanvas", "UIText", "UIButton", "UIImage"})
+
+
+def _find_ui_screen_component(obj):
+    try:
+        from Infernux.ui.inx_ui_screen_component import InxUIScreenComponent
+        for comp in obj.get_py_components() or []:
+            if isinstance(comp, InxUIScreenComponent):
+                return comp
+    except Exception:
+        pass
+    return None
+
+
+def _mark_ui_dirty() -> None:
+    try:
+        from Infernux.ui.ui_canvas_utils import invalidate_canvas_cache
+        invalidate_canvas_cache()
+    except Exception:
+        pass
+    try:
+        from Infernux.engine.scene_manager import SceneFileManager
+        sfm = SceneFileManager.instance()
+        if sfm:
+            sfm.mark_dirty()
+    except Exception:
+        pass
+
+
+def _select_if(obj, select: bool) -> None:
+    if not select:
+        return
+    try:
+        from Infernux.engine.ui.selection_manager import SelectionManager
+        SelectionManager.instance().select(int(obj.id))
+    except Exception:
+        pass
+
+
+def _register_metadata() -> None:
+    for name, summary in {
+        "ui.create_canvas": "Create a UICanvas root.",
+        "ui.create_text": "Create a UIText element.",
+        "ui.create_button": "Create a UIButton element.",
+        "ui.create_panel": "Create a solid-color panel.",
+        "ui.create_image": "Create a UIImage element.",
+        "ui.set_rect": "Set UI element rectangle.",
+        "ui.set_text": "Set text/label on a UI element.",
+        "ui.inspect": "Inspect UI elements.",
+        "ui.find_by_text": "Find UI elements by visible text.",
+    }.items():
+        register_tool_metadata(name, summary=summary)

--- a/python/Infernux/resources/supports/requirements.txt
+++ b/python/Infernux/resources/supports/requirements.txt
@@ -2,3 +2,5 @@
 # The engine checks these on every startup and auto-installs missing ones.
 # You can add your own packages here; lines starting with '#' are ignored.
 numba>=0.61.0
+mcp>=1.24,<2
+fastmcp

--- a/python/Infernux/ui/ui_texture_cache.py
+++ b/python/Infernux/ui/ui_texture_cache.py
@@ -68,7 +68,7 @@ class UITextureCache:
         project_root = get_project_root()
         if not project_root:
             return 0
-        abs_path = os.path.normpath(os.path.join(project_root, tex_path))
+        abs_path = os.path.normpath(tex_path if os.path.isabs(tex_path) else os.path.join(project_root, tex_path))
         if not os.path.isfile(abs_path):
             self._cache[key] = 0
             self._stamp[key] = 0
@@ -80,7 +80,7 @@ class UITextureCache:
             self._stamp[key] = 0
             return 0
 
-        if cached is not None and self._stamp.get(key) == stamp:
+        if cached is not None and cached != 0 and self._stamp.get(key) == stamp:
             return cached
 
         resource_key = f"ui_img|{key}"
@@ -92,8 +92,15 @@ class UITextureCache:
             nearest=False,
             srgb=False,
         )
-        self._cache[key] = tid
-        self._stamp[key] = int(stamp)
+        # Texture preview loading is asynchronous. A zero texture id means the
+        # request was queued or failed for this frame; do not cache it as final,
+        # or the UI will keep returning 0 forever for the same content stamp.
+        if tid != 0:
+            self._cache[key] = tid
+            self._stamp[key] = int(stamp)
+        else:
+            self._cache.pop(key, None)
+            self._stamp.pop(key, None)
         return tid
 
     def get_bound(self, engine):


### PR DESCRIPTION
## Summary

This branch introduces an MCP **basement** for Infernux: a FastMCP-backed server and a layered tool surface so agents can inspect and operate the editor/runtime through structured tools (scene graph, assets, camera, UI, materials, docs/capabilities, console, etc.). It adds **self-evolving project-defined tools**: Python modules under `Assets/AgentTools/` decorated with `@agent_tool`, registered at startup with validation and optional reload hooks, plus a minimal **trace** facility for recorded MCP-call diagnostics.

Alongside MCP work, the branch includes targeted engine/editor fixes needed for dogfooding (hierarchy creation refactor, texture/asset pipeline tweaks, renderer/outline/material/Vulkan adjustments, benchmark-driven fixes such as Flappy Bird). Dependencies and packaging (`pyproject.toml`, `runtime_requirements.py`, bundled `requirements.txt`) are extended where MCP stack imports require them.

## What changed

### MCP server and tools

- New MCP package: `python/Infernux/mcp/` — server bootstrap (`server.py`), threading helpers (`threading.py`), tool registration (`tools/__init__.py`), and modular tools under `tools/` including `common.py`, `assets.py`, `scene.py`, `camera.py`, `ui.py`, `material.py`, `editor.py`, `hierarchy.py`, `project.py`, `runtime.py`, `console.py`, `docs.py`, and **project tool management** (`project_tools.py`).
- **Project-defined agent tools**: `python/Infernux/mcp/project_tools/` — `decorators.py`, `registry.py`, `loadability.py`, `trace.py`, package `__init__.py`; integrates with editor bootstrap so project scripts can extend MCP without rebuilding core.

### Engine / editor integration

- Engine bootstrap and hierarchy: refactors toward `hierarchy_creation_service.py`; updates across `bootstrap.py`, `engine/__init__.py`, `engine.py`, and related UI/inspector paths (`project_utils.py`, inspector components, asset preview).
- Minor fixes in builtin components (e.g. `sprite_renderer.py`), `asset_types.py`, `ui_texture_cache.py`.

### Renderer / resources / C++

- CMake and renderer pipeline updates (`CMakeLists.txt`, `OutlineRenderer`, `VkCoreMaterial`, modular Vulkan core, material pipeline manager, outline rendering).
- New `VertexInputFilter.h`; texture loading expanded (`InxTextureLoader.cpp`, `TextureLoader.cpp`); asset database/importer touchpoints.
- `ProjectPanel.cpp` and related editor/renderer glue.

### Packaging

- `pyproject.toml` and `python/Infernux/resources/supports/requirements.txt` aligned with MCP/runtime deps.

## Verification

- [ ] Built the affected targets (CMake / native + Python packaging as applicable)
- [ ] Ran the relevant tests or static validation (`compileall` / smoke tests on MCP imports and editor startup)
- [ ] Updated docs if behavior or public APIs changed (capabilities/tools surfaced via MCP; restart behavior noted below)

## Notes for reviewers

- **Restart** the Infernux Editor (or the MCP server process) after deploying so new tools and project-tool discovery (`project_tools.*`, trace hooks, capability lists) load in the running session.
- **Risk surface**: large addition under `python/Infernux/mcp/` — prefer reviewing `server.py`, `tools/common.py`, `tools/__init__.py`, and `project_tools/` registry/loadability for threading and import-order concerns (circular imports were avoided via lazy registration paths).
- **Dogfood context**: renderer/asset changes support MCP-driven benchmarks (e.g. Flappy Bird sample); validate outline/material paths on Windows Vulkan if touching those areas.
- Hierarchy refactor consolidates creation logic; UI/inspector call sites were updated — sanity-check create/reparent flows in the editor.
