### PR TITLE
merge self-envolve mcp function

### DIFF
--- a/cpp/infernux/function/scene/Rigidbody.cpp
+++ b/cpp/infernux/function/scene/Rigidbody.cpp
@@ -785,9 +785,9 @@ void Rigidbody::SyncExternalMovesToPhysics()
     if (!posDiff && !rotDiff)
         return; // Transform unchanged since last physics write — nothing to do
 
-    INXLOG_WARN("Rigidbody::SyncExternalMovesToPhysics TELEPORT — posDiff=", posDiff, " rotDiff=", rotDiff,
-                " posDelta=", glm::length(currentPos - d.lastSyncedPosition),
-                " rotDelta=", (1.0f - std::abs(glm::dot(currentRot, d.lastSyncedRotation))));
+    // INXLOG_WARN("Rigidbody::SyncExternalMovesToPhysics TELEPORT — posDiff=", posDiff, " rotDiff=", rotDiff,
+    //             " posDelta=", glm::length(currentPos - d.lastSyncedPosition),
+    //             " rotDelta=", (1.0f - std::abs(glm::dot(currentRot, d.lastSyncedRotation))));
 
     // The user (gizmo / inspector) moved the object externally.
     // Teleport ALL sibling collider bodies to the new Transform position.

--- a/packaging/model/project_model.py
+++ b/packaging/model/project_model.py
@@ -316,8 +316,11 @@ class ProjectModel:
         # ── settings.json ───────────────────────────────────────────────
         project_python = ProjectModel._get_project_python(project_dir)
         site_packages = ProjectModel._get_site_packages(project_dir)
+        vscode_python = ProjectModel._vscode_python_path(project_dir)
         settings = {
-            "python.defaultInterpreterPath": project_python,
+            "python.defaultInterpreterPath": vscode_python,
+            "python.pythonPath": vscode_python,
+            "python.terminal.activateEnvironment": True,
             "python.analysis.typeCheckingMode": "basic",
             "python.analysis.autoImportCompletions": True,
             "python.analysis.extraPaths": [site_packages],
@@ -368,6 +371,7 @@ class ProjectModel:
             pyright_config = {
                 "venvPath": ".",
                 "venv": ".venv",
+                "pythonPath": ProjectModel._vscode_python_path(project_dir),
                 "pythonVersion": "3.12",
                 "typeCheckingMode": "basic",
                 "reportMissingModuleSource": False,
@@ -378,3 +382,12 @@ class ProjectModel:
         pyright_path = os.path.join(project_dir, "pyrightconfig.json")
         with open(pyright_path, "w", encoding="utf-8") as f:
             json.dump(pyright_config, f, indent=4, ensure_ascii=False)
+
+    @staticmethod
+    def _vscode_python_path(project_dir: str) -> str:
+        """Return the interpreter path VSCode should store in settings.json."""
+        if is_frozen():
+            return ProjectModel._get_project_python(project_dir).replace("\\", "/")
+        if sys.platform == "win32":
+            return "${workspaceFolder}/.venv/Scripts/python.exe"
+        return "${workspaceFolder}/.venv/bin/python"

--- a/python/Infernux/__init__.pyi
+++ b/python/Infernux/__init__.pyi
@@ -36,6 +36,7 @@ from Infernux.components import SerializableObject as SerializableObject
 # Builtin components
 from Infernux.components import Light as Light
 from Infernux.components import MeshRenderer as MeshRenderer
+from Infernux.components import SkinnedMeshRenderer as SkinnedMeshRenderer
 from Infernux.components import Camera as Camera
 from Infernux.components import Collider as Collider
 from Infernux.components import BoxCollider as BoxCollider
@@ -50,6 +51,7 @@ from Infernux.components import AudioSource as AudioSource
 from Infernux.components import AudioListener as AudioListener
 from Infernux.components import SpriteRenderer as SpriteRenderer
 from Infernux.components import SpiritAnimator as SpiritAnimator
+from Infernux.components import SkeletalAnimator as SkeletalAnimator
 # Decorators
 from Infernux.components import require_component as require_component
 from Infernux.components import disallow_multiple as disallow_multiple

--- a/python/Infernux/components/__init__.pyi
+++ b/python/Infernux/components/__init__.pyi
@@ -7,6 +7,7 @@ from .builtin_component import BuiltinComponent, CppProperty
 from .builtin import (
     Light as Light,
     MeshRenderer as MeshRenderer,
+    SkinnedMeshRenderer as SkinnedMeshRenderer,
     Camera as Camera,
     Collider as Collider,
     BoxCollider as BoxCollider,
@@ -19,6 +20,7 @@ from .builtin import (
     RigidbodyInterpolation as RigidbodyInterpolation,
     AudioSource as AudioSource,
     AudioListener as AudioListener,
+    SpriteRenderer as SpriteRenderer,
 )
 from Infernux.lib._Infernux import Transform as Transform, Component as Component
 from .serializable_object import SerializableObject as SerializableObject
@@ -40,10 +42,6 @@ from .ref_wrappers import (
     ComponentRef as ComponentRef,
     PrefabRef as PrefabRef,
 )
-from .inspector import (
-    ComponentInspector as ComponentInspector,
-    InspectorData as InspectorData,
-)
 from .script_loader import (
     load_component_from_file as load_component_from_file,
     load_all_components_from_file as load_all_components_from_file,
@@ -52,6 +50,8 @@ from .script_loader import (
     get_component_info as get_component_info,
     ScriptLoadError as ScriptLoadError,
 )
+from .spirit_animator import SpiritAnimator as SpiritAnimator
+from .skeletal_animator import SkeletalAnimator as SkeletalAnimator
 from .registry import (
     get_type as get_type,
     get_all_types as get_all_types,
@@ -78,6 +78,7 @@ __all__ = [
     "Transform",
     "Light",
     "MeshRenderer",
+    "SkinnedMeshRenderer",
     "Camera",
     "Collider",
     "BoxCollider",
@@ -90,6 +91,7 @@ __all__ = [
     "RigidbodyInterpolation",
     "AudioSource",
     "AudioListener",
+    "SpriteRenderer",
     "serialized_field",
     "int_field",
     "hide_field",
@@ -105,8 +107,6 @@ __all__ = [
     "get_serialized_fields",
     "get_field_value",
     "set_field_value",
-    "ComponentInspector",
-    "InspectorData",
     "load_component_from_file",
     "load_all_components_from_file",
     "create_component_instance",
@@ -128,4 +128,6 @@ __all__ = [
     "AddComponentMenu",
     "HelpURL",
     "Icon",
+    "SpiritAnimator",
+    "SkeletalAnimator",
 ]

--- a/python/Infernux/components/builtin/__init__.pyi
+++ b/python/Infernux/components/builtin/__init__.pyi
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .light import Light as Light
 from .mesh_renderer import MeshRenderer as MeshRenderer
+from .skinned_mesh_renderer import SkinnedMeshRenderer as SkinnedMeshRenderer
 from .camera import Camera as Camera
 from .collider import Collider as Collider
 from .box_collider import BoxCollider as BoxCollider
@@ -16,10 +17,12 @@ from .rigidbody import (
 )
 from .audio_source import AudioSource as AudioSource
 from .audio_listener import AudioListener as AudioListener
+from .sprite_renderer import SpriteRenderer as SpriteRenderer
 
 __all__ = [
     "Light",
     "MeshRenderer",
+    "SkinnedMeshRenderer",
     "Camera",
     "Collider",
     "BoxCollider",
@@ -32,4 +35,5 @@ __all__ = [
     "RigidbodyInterpolation",
     "AudioSource",
     "AudioListener",
+    "SpriteRenderer",
 ]

--- a/python/Infernux/components/builtin/audio_listener.pyi
+++ b/python/Infernux/components/builtin/audio_listener.pyi
@@ -3,7 +3,12 @@ from __future__ import annotations
 from Infernux.components.builtin_component import BuiltinComponent
 
 class AudioListener(BuiltinComponent):
-    """Represents the listener for 3D audio in the scene."""
+    """Represents the listener/ears for 3D audio in the scene.
+
+    Attach one AudioListener to the main camera in most games. The engine keeps
+    one active listener; additional enabled listeners remain registered but can
+    be standby instead of immediately replacing the active listener.
+    """
 
     _cpp_type_name: str
     _component_category_: str

--- a/python/Infernux/components/builtin/audio_source.pyi
+++ b/python/Infernux/components/builtin/audio_source.pyi
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from Infernux.components.builtin_component import BuiltinComponent
 
 class AudioSource(BuiltinComponent):
-    """Plays audio clips in the scene."""
+    """Multi-track audio playback component.
+
+    Infernux does not expose Unity's single ``clip`` field. Instead one
+    AudioSource owns ``track_count`` tracks. Assign each track with
+    ``set_track_clip(index, clip)`` or ``set_track_clip_by_guid(index, guid)``,
+    then call ``play(index)``. ``play_on_awake`` only auto-plays track 0.
+
+    For transient SFX, prefer ``play_one_shot(clip, volume_scale)`` rather than
+    creating temporary AudioSource objects. Sources are spatialized; for "2D"
+    audio, place the AudioSource on/near the AudioListener's GameObject.
+    """
 
     _cpp_type_name: str
     _component_category_: str
@@ -14,7 +24,7 @@ class AudioSource(BuiltinComponent):
 
     @property
     def track_count(self) -> int:
-        """The number of audio tracks on this source."""
+        """Number of audio tracks on this source, valid range 1..16."""
         ...
     @track_count.setter
     def track_count(self, value: int) -> None: ...
@@ -42,28 +52,28 @@ class AudioSource(BuiltinComponent):
 
     @property
     def loop(self) -> bool:
-        """Whether the audio clip loops when it reaches the end."""
+        """Whether all tracks loop when they reach the end."""
         ...
     @loop.setter
     def loop(self, value: bool) -> None: ...
 
     @property
     def play_on_awake(self) -> bool:
-        """Whether the audio source plays automatically on awake."""
+        """Whether track 0 plays automatically during component start."""
         ...
     @play_on_awake.setter
     def play_on_awake(self, value: bool) -> None: ...
 
     @property
     def min_distance(self) -> float:
-        """The minimum distance for 3D audio attenuation."""
+        """Distance where 3D attenuation begins."""
         ...
     @min_distance.setter
     def min_distance(self, value: float) -> None: ...
 
     @property
     def max_distance(self) -> float:
-        """The maximum distance for 3D audio attenuation."""
+        """Distance where 3D attenuation reaches minimum volume."""
         ...
     @max_distance.setter
     def max_distance(self, value: float) -> None: ...
@@ -77,7 +87,7 @@ class AudioSource(BuiltinComponent):
 
     @property
     def output_bus(self) -> str:
-        """The name of the audio mixer bus to route output to."""
+        """Output mixer/audio bus name. Currently script-only, not inspector field."""
         ...
     @output_bus.setter
     def output_bus(self, value: str) -> None: ...
@@ -85,7 +95,12 @@ class AudioSource(BuiltinComponent):
     # ---- Track management ----
 
     def set_track_clip(self, track_index: int, clip: Any) -> None:
-        """Assign an audio clip to the specified track."""
+        """Assign an AudioClip wrapper or native clip to a zero-based track.
+
+        ``clip`` can be ``Infernux.core.audio_clip.AudioClip`` or a native
+        ``Infernux.lib.AudioClip``. Keep the clip loaded for as long as the
+        source may play it.
+        """
         ...
     def get_track_clip(self, track_index: int) -> Any:
         """Return the audio clip assigned to the specified track."""
@@ -94,7 +109,11 @@ class AudioSource(BuiltinComponent):
         """Return the asset GUID of the clip on the specified track."""
         ...
     def set_track_clip_by_guid(self, track_index: int, guid: str) -> None:
-        """Assign an audio clip to a track by its asset GUID."""
+        """Assign an audio clip to a track by asset GUID.
+
+        Requires the AssetRegistry/AssetDatabase to be initialized. If GUID
+        resolution is unavailable, load by file path and call ``set_track_clip``.
+        """
         ...
     def set_track_volume(self, track_index: int, volume: float) -> None:
         """Set the volume of the specified track."""
@@ -106,13 +125,13 @@ class AudioSource(BuiltinComponent):
     # ---- Playback control ----
 
     def play(self, track_index: int = ...) -> None:
-        """Start playback on the specified track."""
+        """Start playback on the specified zero-based track."""
         ...
     def stop(self, track_index: int = ...) -> None:
-        """Stop playback on the specified track."""
+        """Stop playback on the specified zero-based track."""
         ...
     def play_one_shot(self, clip: Any, volume_scale: float = ...) -> None:
-        """Play an audio clip as a one-shot sound."""
+        """Play a transient clip using the source's pooled one-shot voices."""
         ...
     def stop_one_shots(self) -> None:
         """Stop all currently playing one-shot sounds."""
@@ -124,7 +143,7 @@ class AudioSource(BuiltinComponent):
         """Resume playback on the specified track."""
         ...
     def stop_all(self) -> None:
-        """Stop playback on all tracks and one-shots."""
+        """Stop playback on all tracks and pooled one-shot voices."""
         ...
     def is_track_playing(self, track_index: int) -> bool:
         """Return whether the specified track is currently playing."""

--- a/python/Infernux/components/ref_wrappers.py
+++ b/python/Infernux/components/ref_wrappers.py
@@ -548,8 +548,10 @@ class ComponentRef:
             return "None"
         # Try to get the GO name
         go_name = ""
-        if hasattr(comp, 'game_object') and comp.game_object:
-            go_name = getattr(comp.game_object, 'name', '')
+        try_go = getattr(comp, "_try_get_game_object", None)
+        go = try_go() if callable(try_go) else None
+        if go is not None:
+            go_name = getattr(go, "name", "")
         elif hasattr(comp, 'name'):
             go_name = comp.name or ""
         type_name = self._component_type or type(comp).__name__

--- a/python/Infernux/components/script_loader.pyi
+++ b/python/Infernux/components/script_loader.pyi
@@ -39,6 +39,15 @@ def load_component_from_file(file_path: str) -> Type[InxComponent]:
     ...
 
 
+def load_component_class_from_file(file_path: str, type_name: str = ...) -> Optional[Type[InxComponent]]:
+    """Load a specific component class from a Python file.
+
+    If ``type_name`` is empty, returns the first discovered InxComponent class.
+    Returns ``None`` when the class cannot be loaded.
+    """
+    ...
+
+
 def load_all_components_from_file(file_path: str) -> List[Type[InxComponent]]:
     """Load all InxComponent subclasses from a Python file.
 

--- a/python/Infernux/components/serialized_field.py
+++ b/python/Infernux/components/serialized_field.py
@@ -49,6 +49,31 @@ def set_field_change_hooks(
     _on_field_did_change = did_change
 
 
+def _call_field_will_change(instance: 'InxComponent', field_name: str, old_value: Any, new_value: Any) -> bool:
+    if _on_field_will_change is None:
+        return False
+    try:
+        return bool(_on_field_will_change(instance, field_name, old_value, new_value))
+    except Exception as exc:
+        Debug.log_suppressed(
+            f"serialized_field.will_change.{type(instance).__name__}.{field_name}",
+            exc,
+        )
+        return False
+
+
+def _call_field_did_change(instance: 'InxComponent', field_name: str, old_value: Any, new_value: Any) -> None:
+    if _on_field_did_change is None:
+        return
+    try:
+        _on_field_did_change(instance, field_name, old_value, new_value)
+    except Exception as exc:
+        Debug.log_suppressed(
+            f"serialized_field.did_change.{type(instance).__name__}.{field_name}",
+            exc,
+        )
+
+
 class FieldType(Enum):
     """Supported field types for serialization and inspector rendering."""
     INT = auto()
@@ -210,14 +235,14 @@ class SerializedFieldDescriptor:
                     from ._cds_bridge import cds_get
                     old_value = cds_get(self._cds_class_id, self._cds_field_id, self._cds_type_code, slot)
                     if old_value != value:
-                        if _on_field_will_change(instance, self.metadata.name, old_value, value):
+                        if _call_field_will_change(instance, self.metadata.name, old_value, value):
                             return
                 from ._cds_bridge import cds_set, cds_get as _cg
                 old = _cg(self._cds_class_id, self._cds_field_id, self._cds_type_code, slot)
                 cds_set(self._cds_class_id, self._cds_field_id, self._cds_type_code, slot, value)
                 if not getattr(instance, '_inf_deserializing', False):
                     if old != value and _on_field_did_change is not None:
-                        _on_field_did_change(instance, self.metadata.name, old, value)
+                        _call_field_did_change(instance, self.metadata.name, old, value)
                 return
 
         inst_id = id(instance)
@@ -227,7 +252,7 @@ class SerializedFieldDescriptor:
             with self._lock:
                 old_value = self._values.get(inst_id, self.metadata.default)
             if old_value != value:
-                if _on_field_will_change(instance, self.metadata.name, old_value, value):
+                if _call_field_will_change(instance, self.metadata.name, old_value, value):
                     return  # callback handled the write (undo recorded)
 
         # Normal set path
@@ -241,7 +266,7 @@ class SerializedFieldDescriptor:
         # Mark scene dirty via injectable callback
         if not getattr(instance, '_inf_deserializing', False):
             if old != value and _on_field_did_change is not None:
-                _on_field_did_change(instance, self.metadata.name, old, value)
+                _call_field_did_change(instance, self.metadata.name, old, value)
 
         # Periodic batch cleanup as a safety net for ref-cycle GC edge cases.
         self._set_count += 1
@@ -254,6 +279,81 @@ class SerializedFieldDescriptor:
         with self._lock:
             self._values.pop(inst_id, None)
             self._weak_refs.pop(inst_id, None)
+
+    def default_value(self) -> Any:
+        """Return a copy-safe default value for class-level fallback access."""
+        try:
+            return copy.deepcopy(self.metadata.default)
+        except Exception:
+            return self.metadata.default
+
+    def _coerce_other(self, other: Any) -> Any:
+        if isinstance(other, SerializedFieldDescriptor):
+            return other.default_value()
+        return other
+
+    def __repr__(self) -> str:
+        return repr(self.default_value())
+
+    def __str__(self) -> str:
+        return str(self.default_value())
+
+    def __format__(self, format_spec: str) -> str:
+        return format(self.default_value(), format_spec)
+
+    def __bool__(self) -> bool:
+        return bool(self.default_value())
+
+    def __int__(self) -> int:
+        return int(self.default_value())
+
+    def __float__(self) -> float:
+        return float(self.default_value())
+
+    def __index__(self) -> int:
+        return int(self.default_value())
+
+    def __lt__(self, other: Any) -> bool:
+        return self.default_value() < self._coerce_other(other)
+
+    def __le__(self, other: Any) -> bool:
+        return self.default_value() <= self._coerce_other(other)
+
+    def __gt__(self, other: Any) -> bool:
+        return self.default_value() > self._coerce_other(other)
+
+    def __ge__(self, other: Any) -> bool:
+        return self.default_value() >= self._coerce_other(other)
+
+    def __eq__(self, other: Any) -> bool:
+        return self.default_value() == self._coerce_other(other)
+
+    def __ne__(self, other: Any) -> bool:
+        return self.default_value() != self._coerce_other(other)
+
+    def __add__(self, other: Any) -> Any:
+        return self.default_value() + self._coerce_other(other)
+
+    def __radd__(self, other: Any) -> Any:
+        return self._coerce_other(other) + self.default_value()
+
+    def __sub__(self, other: Any) -> Any:
+        return self.default_value() - self._coerce_other(other)
+
+    def __rsub__(self, other: Any) -> Any:
+        return self._coerce_other(other) - self.default_value()
+
+    def __mul__(self, other: Any) -> Any:
+        return self.default_value() * self._coerce_other(other)
+
+    def __rmul__(self, other: Any) -> Any:
+        return self._coerce_other(other) * self.default_value()
+
+    def __truediv__(self, other: Any) -> Any:
+        return self.default_value() / self._coerce_other(other)
+
+    def __rtruediv__(self, other: Any) -> Any:
+        return self._coerce_other(other) / self.default_value()
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/python/Infernux/core/audio_clip.pyi
+++ b/python/Infernux/core/audio_clip.pyi
@@ -1,4 +1,10 @@
-"""Type stubs for Infernux.core.audio_clip."""
+"""Type stubs for Infernux.core.audio_clip.
+
+Agent note:
+    The runtime wrapper currently documents and reliably supports WAV loading.
+    Some older docs/UI filters may mention OGG/MP3, but the C++ decode path is
+    WAV-only until additional decoders are implemented.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +14,13 @@ from Infernux.lib import AudioClip as CppAudioClip
 
 
 class AudioClip:
-    """Pythonic wrapper around C++ AudioClip."""
+    """Pythonic wrapper around C++ AudioClip.
+
+    Use ``AudioClip.load("Assets/Audio/foo.wav")`` and pass the returned
+    wrapper (or ``clip.native``) to ``AudioSource.set_track_clip`` or
+    ``AudioSource.play_one_shot``. Do not unload a clip while an AudioSource is
+    still using it.
+    """
 
     def __init__(self, native: CppAudioClip) -> None:
         """Wrap an existing C++ AudioClip."""
@@ -17,7 +29,14 @@ class AudioClip:
     # Factory methods
     @staticmethod
     def load(file_path: str) -> Optional[AudioClip]:
-        """Load an audio clip from a file path (WAV, OGG, MP3)."""
+        """Load an audio clip from a file path.
+
+        Args:
+            file_path: Project or absolute path to a WAV file.
+
+        Returns:
+            ``AudioClip`` when decoding succeeds; otherwise ``None``.
+        """
         ...
     @staticmethod
     def from_native(native: CppAudioClip) -> AudioClip:
@@ -63,7 +82,12 @@ class AudioClip:
         """Enter context manager for resource management."""
         ...
     def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
-        """Exit context manager and unload audio data."""
+        """Exit context manager and unload audio data.
+
+        Avoid context-manager lifetime for clips assigned to persistent
+        AudioSource tracks, because the clip may unload while playback still
+        references it.
+        """
         ...
     def unload(self) -> None:
         """Unload the audio data from memory."""

--- a/python/Infernux/core/material.pyi
+++ b/python/Infernux/core/material.pyi
@@ -53,6 +53,9 @@ class Material:
     def dispose(self) -> None:
         """Release the underlying native material resources."""
         ...
+    def clone(self) -> Material:
+        """Create a deep copy of this material, including shader state and properties."""
+        ...
 
     # Properties
     @property

--- a/python/Infernux/engine/bootstrap.py
+++ b/python/Infernux/engine/bootstrap.py
@@ -298,9 +298,11 @@ class EditorBootstrap(BootstrapPanelsMixin, BootstrapSelectionMixin, BootstrapWi
 
         def will_change(instance, field_name, old_value, new_value):
             mgr = UndoManager.instance()
-            if (mgr and not mgr.is_executing and mgr.enabled
-                    and hasattr(instance, 'game_object')
-                    and instance.game_object is not None):
+            # Do not use hasattr(instance, "game_object"): the property raises
+            # RuntimeError when unbound; hasattr only catches AttributeError.
+            try_go = getattr(instance, "_try_get_game_object", None)
+            bound_go = try_go() if callable(try_go) else None
+            if (mgr and not mgr.is_executing and mgr.enabled and bound_go is not None):
                 pmm = PlayModeManager.instance()
                 if pmm is None or pmm.is_edit_mode:
                     mgr.execute(SetPropertyCommand(

--- a/python/Infernux/engine/resources_manager.py
+++ b/python/Infernux/engine/resources_manager.py
@@ -245,6 +245,9 @@ class ResourceChangeHandler(FileSystemEventHandler):
 
     def _process_asset_modified(self, src_path: str):
         """Handle asset content change on the main thread."""
+        if src_path.lower().endswith(".scene") and self._is_active_scene_file(src_path):
+            Debug.log_internal(f"[Scene Modified] ignored watcher echo for active scene: {os.path.basename(src_path)}")
+            return
         from Infernux.core.assets import AssetManager
         AssetManager.on_asset_modified(src_path)
         if self._asset_database:
@@ -252,6 +255,16 @@ class ResourceChangeHandler(FileSystemEventHandler):
         else:
             self._engine.modify_resources(src_path)
         self._emit_asset_changed(src_path, "modified")
+
+    @staticmethod
+    def _is_active_scene_file(path: str) -> bool:
+        try:
+            from Infernux.engine.scene_manager import SceneFileManager
+            sfm = SceneFileManager.instance()
+            active = getattr(sfm, "current_scene_path", "") if sfm else ""
+            return bool(active and os.path.abspath(path) == os.path.abspath(active))
+        except Exception:
+            return False
 
     def _check_script(self, file_path: str):
         """Check a Python script for syntax errors and hot-reload components."""

--- a/python/Infernux/mcp/__init__.py
+++ b/python/Infernux/mcp/__init__.py
@@ -1,5 +1,6 @@
 """Embedded MCP integration for Infernux Editor."""
 
+from Infernux.mcp.capabilities import current_config
 from Infernux.mcp.server import endpoint_url, is_running, start_server, stop_server
 
-__all__ = ["endpoint_url", "is_running", "start_server", "stop_server"]
+__all__ = ["current_config", "endpoint_url", "is_running", "start_server", "stop_server"]

--- a/python/Infernux/mcp/capabilities.py
+++ b/python/Infernux/mcp/capabilities.py
@@ -1,0 +1,193 @@
+"""Configurable capability gates for the Infernux MCP layer."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from typing import Any
+
+
+CONFIG_REL_PATH = os.path.join("ProjectSettings", "mcp_capabilities.json")
+
+DEFAULT_CAPABILITY_CONFIG: dict[str, Any] = {
+    "enabled": True,
+    "profile": "research_full",
+    "write_default_config_on_bootstrap": True,
+    "features": {
+        "self_description": True,
+        "executable_contracts": True,
+        "runtime_observation": True,
+        "batch_execution": True,
+        "transactions": True,
+        "trace_recorder": True,
+        "session_call_log": True,
+        "trace_to_tool_evolution": True,
+        "project_defined_tools": True,
+        "semantic_workflows": True,
+        "safety_validation": True,
+        "discovery_files": True,
+    },
+    "tool_groups": {
+        "docs": True,
+        "api": True,
+        "project": True,
+        "editor": True,
+        "scene": True,
+        "hierarchy": True,
+        "asset": True,
+        "material": True,
+        "renderstack": True,
+        "console": True,
+        "camera": True,
+        "runtime": True,
+        "ui": True,
+        "project_tool_management": True,
+        "project_defined_tools": True,
+        "research": True,
+        "transactions": True,
+    },
+    "disabled_tools": [],
+    "limits": {
+        "main_thread_timeout_ms": 30000,
+        "project_tool_timeout_ms": 60000,
+        "trace_argument_max_string": 240,
+        "session_log_result_max_string": 480,
+        "batch_max_steps": 100,
+        "transaction_max_tracked_paths": 1000,
+    },
+    "contracts": {
+        "require_summary": True,
+        "require_recovery": True,
+        "require_side_effects_for_mutations": True,
+        "grade_threshold": 0.70,
+    },
+    "evolution": {
+        "suggest_project_tools_from_failed_traces": True,
+        "suggest_project_tools_from_repeated_sequences": True,
+        "min_repeated_sequence_length": 3,
+        "generated_tool_root": "Assets/AgentTools",
+    },
+}
+
+_CURRENT_CONFIG: dict[str, Any] = copy.deepcopy(DEFAULT_CAPABILITY_CONFIG)
+_PROJECT_PATH = ""
+
+
+def configure(project_path: str, *, write_default: bool = True) -> dict[str, Any]:
+    """Load, merge, and optionally materialize project MCP capability config."""
+    global _CURRENT_CONFIG, _PROJECT_PATH
+    _PROJECT_PATH = os.path.abspath(project_path or "")
+    config = load_capability_config(_PROJECT_PATH)
+    _CURRENT_CONFIG = config
+    if write_default and bool(config.get("write_default_config_on_bootstrap", True)):
+        write_default_config(_PROJECT_PATH)
+    return copy.deepcopy(_CURRENT_CONFIG)
+
+
+def current_config() -> dict[str, Any]:
+    return copy.deepcopy(_CURRENT_CONFIG)
+
+
+def project_path() -> str:
+    return _PROJECT_PATH
+
+
+def config_path(project_path: str | None = None) -> str:
+    root = os.path.abspath(project_path or _PROJECT_PATH or "")
+    return os.path.join(root, CONFIG_REL_PATH)
+
+
+def load_capability_config(project_path: str) -> dict[str, Any]:
+    config = copy.deepcopy(DEFAULT_CAPABILITY_CONFIG)
+    path = config_path(project_path)
+    if not path or not os.path.isfile(path):
+        return config
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            _deep_merge(config, data)
+    except Exception:
+        return config
+    return config
+
+
+def write_default_config(project_path: str | None = None) -> str:
+    """Write a complete default-on config file if it does not exist yet."""
+    path = config_path(project_path)
+    if not path:
+        return ""
+    if os.path.isfile(path):
+        return path
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        json.dump(DEFAULT_CAPABILITY_CONFIG, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    return path
+
+
+def save_config(config: dict[str, Any] | None = None, project_path: str | None = None) -> str:
+    global _CURRENT_CONFIG
+    if config is not None:
+        _CURRENT_CONFIG = _normalized_config(config)
+    path = config_path(project_path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        json.dump(_CURRENT_CONFIG, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    return path
+
+
+def is_enabled() -> bool:
+    return bool(_CURRENT_CONFIG.get("enabled", True))
+
+
+def feature_enabled(name: str) -> bool:
+    return bool((_CURRENT_CONFIG.get("features") or {}).get(name, True))
+
+
+def tool_group_enabled(name: str) -> bool:
+    return bool((_CURRENT_CONFIG.get("tool_groups") or {}).get(name, True))
+
+
+def tool_enabled(name: str) -> bool:
+    return str(name) not in set(str(item) for item in _CURRENT_CONFIG.get("disabled_tools", []))
+
+
+def limit(name: str, default: Any = None) -> Any:
+    return (_CURRENT_CONFIG.get("limits") or {}).get(name, default)
+
+
+def set_feature(name: str, enabled: bool) -> dict[str, Any]:
+    _CURRENT_CONFIG.setdefault("features", {})[str(name)] = bool(enabled)
+    return current_config()
+
+
+def set_tool_group(name: str, enabled: bool) -> dict[str, Any]:
+    _CURRENT_CONFIG.setdefault("tool_groups", {})[str(name)] = bool(enabled)
+    return current_config()
+
+
+def set_tool_enabled(name: str, enabled: bool) -> dict[str, Any]:
+    disabled = set(str(item) for item in _CURRENT_CONFIG.get("disabled_tools", []))
+    if enabled:
+        disabled.discard(str(name))
+    else:
+        disabled.add(str(name))
+    _CURRENT_CONFIG["disabled_tools"] = sorted(disabled)
+    return current_config()
+
+
+def _normalized_config(config: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(DEFAULT_CAPABILITY_CONFIG)
+    _deep_merge(merged, config if isinstance(config, dict) else {})
+    return merged
+
+
+def _deep_merge(target: dict[str, Any], source: dict[str, Any]) -> None:
+    for key, value in source.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _deep_merge(target[key], value)
+        else:
+            target[key] = value

--- a/python/Infernux/mcp/project_tools/registry.py
+++ b/python/Infernux/mcp/project_tools/registry.py
@@ -17,7 +17,7 @@ from Infernux.mcp.project_tools.loadability import (
     validate_callable_schema,
     validate_file,
 )
-from Infernux.mcp.project_tools.trace import record_tool_call
+from Infernux.mcp.project_tools.trace import record_tool_call, record_tool_result
 from Infernux.mcp.threading import MainThreadCommandQueue
 
 
@@ -47,6 +47,13 @@ class ProjectToolRegistry:
         self.project_path = os.path.abspath(project_path)
 
     def discover(self) -> dict[str, Any]:
+        from Infernux.mcp.capabilities import feature_enabled
+
+        if not feature_enabled("project_defined_tools"):
+            self.tools.clear()
+            self.file_reports.clear()
+            self._audit("discover", True, "Project-defined tools are disabled by MCP capability config.")
+            return {"tool_count": 0, "loaded_files": [], "reports": [], "disabled": True}
         self.tools.clear()
         self.file_reports.clear()
         config = self._config()
@@ -149,11 +156,11 @@ class ProjectToolRegistry:
         definition = self.tools.get(name)
         if definition is None:
             result = fail("error.not_found", f"Project tool is not loaded: {name}")
-            record_tool_call(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), error="not loaded")
+            record_tool_result(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), result=result, error="not loaded")
             return result
         if name in self.disabled_tools:
             result = fail("error.disabled", f"Project tool is disabled: {name}")
-            record_tool_call(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), error="disabled")
+            record_tool_result(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), result=result, error="disabled")
             return result
 
         explain = explain_for(name, summary=definition.summary)
@@ -161,17 +168,19 @@ class ProjectToolRegistry:
             value = MainThreadCommandQueue.instance().run_sync(
                 name,
                 lambda: definition.callable(*args, **kwargs),
-                timeout_ms=60000,
+                timeout_ms=_project_tool_timeout_ms(),
             )
             result = value if _is_envelope(value) else ok(value, explain=explain)
             self._audit("call", True, f"Called {name}", tool=name)
             record_tool_call(name, ok=True, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs))
+            record_tool_result(name, ok=True, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), result=result)
             return result
         except Exception as exc:
             message = f"{type(exc).__name__}: {exc}"
             self._audit("call", False, message, tool=name, traceback_text="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
-            record_tool_call(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), error=message)
-            return fail("error.project_tool", message, hint="Use project_tools.audit and project_tools.validate to inspect this project-defined tool.", explain=explain)
+            result = fail("error.project_tool", message, hint="Use project_tools.audit and project_tools.validate to inspect this project-defined tool.", explain=explain)
+            record_tool_result(name, ok=False, elapsed_ms=_elapsed_ms(started), arguments=_arguments(definition, args, kwargs), result=result, error=message)
+            return result
 
     def _make_mcp_callable(self, name: str) -> Callable:
         definition = self.tools[name]
@@ -281,6 +290,14 @@ def _is_envelope(value: Any) -> bool:
 
 def _elapsed_ms(started: float) -> float:
     return (time.monotonic() - started) * 1000.0
+
+
+def _project_tool_timeout_ms() -> int:
+    try:
+        from Infernux.mcp.capabilities import limit
+        return int(limit("project_tool_timeout_ms", 60000) or 60000)
+    except Exception:
+        return 60000
 
 
 def _arguments(definition: ProjectToolDefinition | None, args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/python/Infernux/mcp/project_tools/trace.py
+++ b/python/Infernux/mcp/project_tools/trace.py
@@ -11,6 +11,56 @@ from typing import Any
 
 _active_trace: dict[str, Any] | None = None
 _last_trace: dict[str, Any] | None = None
+_session_project_path = ""
+_session_log_path = ""
+
+
+def start_session_log(project_path: str) -> dict[str, Any]:
+    """Clear and initialize the per-editor-session MCP call log."""
+    global _session_project_path, _session_log_path
+    _session_project_path = os.path.abspath(project_path or "")
+    _session_log_path = _session_log_file(_session_project_path)
+    os.makedirs(os.path.dirname(_session_log_path), exist_ok=True)
+    with open(_session_log_path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(json.dumps({
+            "event": "session_start",
+            "time": time.time(),
+            "project_path": _session_project_path,
+        }, ensure_ascii=False) + "\n")
+    return session_log_info()
+
+
+def session_log_info(project_path: str | None = None) -> dict[str, Any]:
+    path = _session_log_path or _session_log_file(project_path or _session_project_path)
+    exists = bool(path and os.path.isfile(path))
+    return {
+        "enabled": _session_log_enabled(),
+        "path": _rel(project_path or _session_project_path, path) if path else "",
+        "absolute_path": path,
+        "exists": exists,
+        "size": os.path.getsize(path) if exists else 0,
+    }
+
+
+def clear_session_log(project_path: str | None = None) -> dict[str, Any]:
+    return start_session_log(project_path or _session_project_path)
+
+
+def read_session_log(project_path: str | None = None, limit: int = 200) -> dict[str, Any]:
+    path = _session_log_path or _session_log_file(project_path or _session_project_path)
+    if not path or not os.path.isfile(path):
+        return {"entries": [], **session_log_info(project_path)}
+    entries = []
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                entries.append({"event": "raw", "text": line})
+    return {"entries": entries[-max(int(limit), 1):], **session_log_info(project_path)}
 
 
 def start_trace(project_path: str, task: str = "") -> dict[str, Any]:
@@ -53,10 +103,18 @@ def record_tool_call(
     ok: bool,
     elapsed_ms: float = 0.0,
     arguments: dict[str, Any] | None = None,
+    result: Any = None,
     error: str = "",
 ) -> None:
     if _active_trace is None:
+        _record_session_tool_call(name, ok=ok, elapsed_ms=elapsed_ms, arguments=arguments, result=result, error=error)
         return
+    try:
+        from Infernux.mcp.capabilities import feature_enabled
+        if not feature_enabled("trace_recorder"):
+            return
+    except Exception:
+        pass
     step = {
         "index": len(_active_trace["steps"]),
         "tool": str(name),
@@ -68,6 +126,27 @@ def record_tool_call(
     if error:
         step["error"] = str(error)
     _active_trace["steps"].append(step)
+    _record_session_tool_call(name, ok=ok, elapsed_ms=elapsed_ms, arguments=arguments, result=result, error=error)
+
+
+def record_tool_result(
+    name: str,
+    *,
+    ok: bool,
+    elapsed_ms: float = 0.0,
+    arguments: dict[str, Any] | None = None,
+    result: Any = None,
+    error: str = "",
+) -> None:
+    """Record a call with compact result data in the session log."""
+    _record_session_tool_call(
+        name,
+        ok=ok,
+        elapsed_ms=elapsed_ms,
+        arguments=arguments,
+        result=result,
+        error=error,
+    )
 
 
 def list_traces(project_path: str, limit: int = 50) -> list[dict[str, Any]]:
@@ -103,7 +182,76 @@ def _trace_dir(project_path: str) -> str:
     return os.path.join(os.path.abspath(project_path), ".infernux", "mcp_traces")
 
 
+def _session_log_file(project_path: str) -> str:
+    return os.path.join(os.path.abspath(project_path or "."), "Logs", "mcp_session.jsonl")
+
+
+def _record_session_tool_call(
+    name: str,
+    *,
+    ok: bool,
+    elapsed_ms: float = 0.0,
+    arguments: dict[str, Any] | None = None,
+    result: Any = None,
+    error: str = "",
+) -> None:
+    if not _session_log_enabled():
+        return
+    path = _session_log_path or _session_log_file(_session_project_path)
+    if not path:
+        return
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        entry = {
+            "event": "tool_call",
+            "time": time.time(),
+            "tool": str(name),
+            "ok": bool(ok),
+            "elapsed_ms": round(float(elapsed_ms), 3),
+        }
+        if arguments:
+            entry["arguments"] = _jsonable_summary(arguments)
+        if result is not None:
+            entry["result"] = _jsonable_summary(result, max_string=_session_result_max_string())
+        if error:
+            entry["error"] = str(error)
+        with open(path, "a", encoding="utf-8", newline="\n") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+
+def _session_log_enabled() -> bool:
+    try:
+        from Infernux.mcp.capabilities import feature_enabled
+        return feature_enabled("session_call_log")
+    except Exception:
+        return True
+
+
+def _session_result_max_string() -> int:
+    try:
+        from Infernux.mcp.capabilities import limit
+        return int(limit("session_log_result_max_string", 480) or 480)
+    except Exception:
+        return 480
+
+
+def _rel(project_path: str, path: str) -> str:
+    if not project_path or not path:
+        return path
+    try:
+        return os.path.relpath(os.path.abspath(path), os.path.abspath(project_path)).replace("\\", "/")
+    except Exception:
+        return path
+
+
 def _jsonable_summary(value: Any, *, max_string: int = 240) -> Any:
+    try:
+        from Infernux.mcp.capabilities import limit
+        max_string = int(limit("trace_argument_max_string", max_string) or max_string)
+    except Exception:
+        pass
     if value is None or isinstance(value, (bool, int, float)):
         return value
     if isinstance(value, str):

--- a/python/Infernux/mcp/project_tools/transactions.py
+++ b/python/Infernux/mcp/project_tools/transactions.py
@@ -1,0 +1,172 @@
+"""Best-effort transaction tracking for long-horizon MCP mutations."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import time
+import uuid
+from typing import Any
+
+
+_ACTIVE: "MCPTransaction | None" = None
+_LAST: dict[str, Any] | None = None
+
+
+class MCPTransaction:
+    def __init__(self, project_path: str, label: str = "") -> None:
+        self.project_path = os.path.abspath(project_path)
+        self.transaction_id = f"{time.strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}"
+        self.label = str(label or "")
+        self.started_at = time.time()
+        self.events: list[dict[str, Any]] = []
+        self._snapshots: dict[str, str] = {}
+        self._root = os.path.join(self.project_path, ".infernux", "mcp_transactions", self.transaction_id)
+        self._backup_root = os.path.join(self._root, "backups")
+
+    def record_path_before_change(self, path: str, operation: str = "modify") -> None:
+        file_path = self._resolve(path)
+        rel_path = self._rel(file_path)
+        if rel_path in self._snapshots:
+            return
+        exists = os.path.exists(file_path)
+        backup_path = ""
+        kind = "created"
+        if exists:
+            kind = "modified" if operation != "delete" else "deleted"
+            backup_path = self._snapshot(file_path, rel_path)
+        self._snapshots[rel_path] = backup_path
+        self.events.append({
+            "type": kind,
+            "operation": str(operation or ""),
+            "path": rel_path,
+            "backup": self._rel(backup_path) if backup_path else "",
+            "directory": bool(os.path.isdir(file_path)) if exists else False,
+        })
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "active": True,
+            "transaction_id": self.transaction_id,
+            "label": self.label,
+            "started_at": self.started_at,
+            "elapsed_seconds": max(0.0, time.time() - self.started_at),
+            "tracked_path_count": len(self.events),
+            "events": list(self.events),
+            "notes": [
+                "File and asset mutations are restorable when tools record their paths.",
+                "Scene hierarchy changes rely on editor undo support and may require explicit undo tools in future iterations.",
+            ],
+        }
+
+    def commit(self) -> dict[str, Any]:
+        return {
+            **self.status(),
+            "active": False,
+            "committed": True,
+            "ended_at": time.time(),
+        }
+
+    def rollback(self) -> dict[str, Any]:
+        restored = []
+        removed = []
+        failures = []
+        for event in reversed(self.events):
+            try:
+                target = self._resolve(event["path"])
+                if event["type"] == "created":
+                    if os.path.isdir(target):
+                        shutil.rmtree(target)
+                        removed.append(event["path"])
+                    elif os.path.isfile(target):
+                        os.remove(target)
+                        removed.append(event["path"])
+                else:
+                    backup = event.get("backup") or ""
+                    if not backup:
+                        continue
+                    backup_path = self._resolve(backup)
+                    if os.path.isdir(target):
+                        shutil.rmtree(target)
+                    elif os.path.isfile(target):
+                        os.remove(target)
+                    os.makedirs(os.path.dirname(target), exist_ok=True)
+                    if os.path.isdir(backup_path):
+                        shutil.copytree(backup_path, target)
+                    else:
+                        shutil.copy2(backup_path, target)
+                    restored.append(event["path"])
+            except Exception as exc:
+                failures.append({"path": event.get("path", ""), "error": f"{type(exc).__name__}: {exc}"})
+        return {
+            **self.status(),
+            "active": False,
+            "rolled_back": not failures,
+            "restored": restored,
+            "removed": removed,
+            "failures": failures,
+            "ended_at": time.time(),
+        }
+
+    def _snapshot(self, file_path: str, rel_path: str) -> str:
+        digest = hashlib.sha256(rel_path.encode("utf-8")).hexdigest()[:16]
+        backup_path = os.path.join(self._backup_root, digest)
+        os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+        if os.path.isdir(file_path):
+            shutil.copytree(file_path, backup_path)
+        else:
+            os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+            shutil.copy2(file_path, backup_path)
+        return backup_path
+
+    def _resolve(self, path: str) -> str:
+        raw = os.path.abspath(path if os.path.isabs(path) else os.path.join(self.project_path, path))
+        if os.path.commonpath([self.project_path, raw]) != self.project_path:
+            raise ValueError("Transaction path must stay inside the project.")
+        return raw
+
+    def _rel(self, path: str) -> str:
+        return os.path.relpath(os.path.abspath(path), self.project_path).replace("\\", "/")
+
+
+def begin(project_path: str, label: str = "") -> dict[str, Any]:
+    global _ACTIVE
+    if _ACTIVE is not None:
+        raise RuntimeError(f"Transaction already active: {_ACTIVE.transaction_id}")
+    _ACTIVE = MCPTransaction(project_path, label=label)
+    return _ACTIVE.status()
+
+
+def status() -> dict[str, Any]:
+    if _ACTIVE is None:
+        return {"active": False, "last": _LAST}
+    return _ACTIVE.status()
+
+
+def commit() -> dict[str, Any]:
+    global _ACTIVE, _LAST
+    if _ACTIVE is None:
+        return {"active": False, "committed": False, "message": "No active transaction."}
+    result = _ACTIVE.commit()
+    _LAST = result
+    _ACTIVE = None
+    return result
+
+
+def rollback() -> dict[str, Any]:
+    global _ACTIVE, _LAST
+    if _ACTIVE is None:
+        return {"active": False, "rolled_back": False, "message": "No active transaction."}
+    result = _ACTIVE.rollback()
+    _LAST = result
+    _ACTIVE = None
+    return result
+
+
+def record_path_before_change(project_path: str, path: str, operation: str = "modify") -> None:
+    if _ACTIVE is None:
+        return
+    if os.path.commonpath([os.path.abspath(project_path), _ACTIVE.project_path]) != _ACTIVE.project_path:
+        return
+    _ACTIVE.record_path_before_change(path, operation=operation)

--- a/python/Infernux/mcp/server.py
+++ b/python/Infernux/mcp/server.py
@@ -36,10 +36,40 @@ def start_server(project_path: str, *, host: str = HOST, port: int = PORT) -> bo
         return False
 
     _project_path = project_path
+    from Infernux.mcp.capabilities import configure, feature_enabled, is_enabled
+    capability_config = configure(project_path, write_default=True)
+    if not is_enabled():
+        Debug.log_internal("Infernux MCP server disabled by ProjectSettings/mcp_capabilities.json")
+        return False
+    if feature_enabled("session_call_log"):
+        try:
+            from Infernux.mcp.project_tools.trace import start_session_log
+            info = start_session_log(project_path)
+            Debug.log_internal(f"Infernux MCP session log initialized: {info.get('path')}")
+        except Exception as exc:
+            Debug.log_suppressed("Infernux.mcp.start_session_log", exc)
     _server = FastMCP(SERVER_NAME)
+
+    # Friendly GET probe on PATH — avoids noisy 404 when IDEs/clients hit /mcp without POST.
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+
+    @_server.custom_route(PATH, methods=["GET"])  # type: ignore[attr-defined]
+    async def _mcp_get_probe(request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "name": SERVER_NAME,
+                "message": "MCP endpoint is alive. Use POST/streamable-http for MCP calls.",
+                "transport": "streamable-http",
+                "path": PATH,
+                "url": endpoint_url(host=host, port=int(port)),
+            }
+        )
+
     from Infernux.mcp.tools import register_all_tools
-    register_all_tools(_server, project_path)
-    _write_discovery_files(project_path, host=host, port=int(port))
+    register_all_tools(_server, project_path, capability_config)
+    if feature_enabled("discovery_files"):
+        _write_discovery_files(project_path, host=host, port=int(port))
 
     def _run() -> None:
         last_error = None

--- a/python/Infernux/mcp/tools/__init__.py
+++ b/python/Infernux/mcp/tools/__init__.py
@@ -2,31 +2,107 @@
 
 from __future__ import annotations
 
-from Infernux.mcp.tools.assets import register_asset_tools
-from Infernux.mcp.tools.camera import register_camera_tools
-from Infernux.mcp.tools.console import register_console_tools
-from Infernux.mcp.tools.docs import register_docs_tools
-from Infernux.mcp.tools.editor import register_editor_tools
-from Infernux.mcp.tools.hierarchy import register_hierarchy_tools
-from Infernux.mcp.tools.material import register_material_tools
-from Infernux.mcp.tools.project import register_project_tools
-from Infernux.mcp.tools.project_tools import register_project_defined_tools, register_project_tool_management
-from Infernux.mcp.tools.runtime import register_runtime_tools
-from Infernux.mcp.tools.scene import register_scene_tools
-from Infernux.mcp.tools.ui import register_ui_tools
+from typing import Any
+
+from Infernux.mcp import capabilities
 
 
-def register_all_tools(mcp, project_path: str) -> None:
-    register_docs_tools(mcp, project_path)
-    register_project_tools(mcp, project_path)
-    register_editor_tools(mcp)
-    register_scene_tools(mcp)
-    register_hierarchy_tools(mcp)
-    register_asset_tools(mcp, project_path)
-    register_material_tools(mcp, project_path)
-    register_console_tools(mcp)
-    register_camera_tools(mcp)
-    register_runtime_tools(mcp)
-    register_ui_tools(mcp)
-    register_project_tool_management(mcp, project_path)
-    register_project_defined_tools(mcp, project_path)
+def register_all_tools(mcp, project_path: str, config: dict[str, Any] | None = None) -> None:
+    """Register all enabled MCP tool groups.
+
+    The import style is intentionally lazy so disabled groups do not pull in
+    optional editor subsystems during startup.
+    """
+    config = config or capabilities.current_config()
+    if not bool(config.get("enabled", True)):
+        return
+    gated_mcp = _ToolGate(mcp, config)
+
+    if _group(config, "docs"):
+        from Infernux.mcp.tools.docs import register_docs_tools
+        register_docs_tools(gated_mcp, project_path, config)
+    if _group(config, "api"):
+        from Infernux.mcp.tools.api import register_api_tools
+        register_api_tools(gated_mcp)
+    if _group(config, "project"):
+        from Infernux.mcp.tools.project import register_project_tools
+        register_project_tools(gated_mcp, project_path)
+    if _group(config, "editor"):
+        from Infernux.mcp.tools.editor import register_editor_tools
+        register_editor_tools(gated_mcp)
+    if _group(config, "scene"):
+        from Infernux.mcp.tools.scene import register_scene_tools
+        register_scene_tools(gated_mcp)
+    if _group(config, "hierarchy"):
+        from Infernux.mcp.tools.hierarchy import register_hierarchy_tools
+        register_hierarchy_tools(gated_mcp)
+    if _group(config, "asset"):
+        from Infernux.mcp.tools.assets import register_asset_tools
+        register_asset_tools(gated_mcp, project_path)
+    if _group(config, "material"):
+        from Infernux.mcp.tools.material import register_material_tools
+        register_material_tools(gated_mcp, project_path)
+    if _group(config, "renderstack"):
+        from Infernux.mcp.tools.renderstack import register_renderstack_tools
+        register_renderstack_tools(gated_mcp)
+    if _group(config, "console"):
+        from Infernux.mcp.tools.console import register_console_tools
+        register_console_tools(gated_mcp)
+    if _group(config, "camera"):
+        from Infernux.mcp.tools.camera import register_camera_tools
+        register_camera_tools(gated_mcp)
+    if _group(config, "runtime") and _feature(config, "runtime_observation"):
+        from Infernux.mcp.tools.runtime import register_runtime_tools
+        register_runtime_tools(gated_mcp)
+    if _group(config, "ui"):
+        from Infernux.mcp.tools.ui import register_ui_tools
+        register_ui_tools(gated_mcp)
+    if _group(config, "transactions") and _feature(config, "transactions"):
+        from Infernux.mcp.tools.transactions import register_transaction_tools
+        register_transaction_tools(gated_mcp, project_path)
+    if _group(config, "research"):
+        from Infernux.mcp.tools.research import register_research_tools
+        register_research_tools(gated_mcp, project_path)
+    if _group(config, "project_tool_management") and _feature(config, "project_defined_tools"):
+        from Infernux.mcp.tools.project_tools import register_project_tool_management
+        register_project_tool_management(gated_mcp, project_path)
+    if _group(config, "project_defined_tools") and _feature(config, "project_defined_tools"):
+        from Infernux.mcp.tools.project_tools import register_project_defined_tools
+        register_project_defined_tools(gated_mcp, project_path)
+
+
+def _feature(config: dict[str, Any], name: str) -> bool:
+    return bool((config.get("features") or {}).get(name, True))
+
+
+def _group(config: dict[str, Any], name: str) -> bool:
+    return bool((config.get("tool_groups") or {}).get(name, True))
+
+
+class _ToolGate:
+    def __init__(self, mcp, config: dict[str, Any]) -> None:
+        self._mcp = mcp
+        self._disabled = set(str(item) for item in config.get("disabled_tools", []))
+
+    def tool(self, *args, **kwargs):
+        name = kwargs.get("name")
+        if name is None and args:
+            name = args[0]
+        if name and str(name) in self._disabled:
+            def _skip(fn):
+                return fn
+            return _skip
+        decorator = self._mcp.tool(*args, **kwargs)
+
+        def _register(fn):
+            try:
+                from Infernux.mcp.tools.common import register_tool_signature
+                register_tool_signature(str(name or getattr(fn, "__name__", "")), fn)
+            except Exception:
+                pass
+            return decorator(fn)
+
+        return _register
+
+    def __getattr__(self, name: str):
+        return getattr(self._mcp, name)

--- a/python/Infernux/mcp/tools/api.py
+++ b/python/Infernux/mcp/tools/api.py
@@ -1,0 +1,847 @@
+"""Subsystem API and shader/audio knowledge tools for agents."""
+
+from __future__ import annotations
+
+import inspect
+import ast
+import os
+from typing import Any
+
+from Infernux.mcp.tools.common import issue_knowledge_token, ok, register_tool_metadata, serialize_value
+
+
+PROPERTY_TYPES = {
+    "Float": "material.set_float(name, value)",
+    "Float2": "material.set_vector2(name, x, y)",
+    "Float3": "material.set_vector3(name, x, y, z)",
+    "Float4": "material.set_vector4(name, x, y, z, w)",
+    "Color": "material.set_color(name, r, g, b, a)",
+    "Int": "material.set_int(name, value)",
+    "Mat4": "material.set_param(name, matrix_value)",
+    "Texture2D": "material.set_texture(name, texture_or_guid_or_path)",
+}
+
+
+SUBSYSTEM_GUIDES: dict[str, dict[str, Any]] = {
+    "api": {
+        "summary": "Agent-facing API discovery policy for a young, fast-moving engine.",
+        "concepts": [
+            "Do not guess unfamiliar Infernux APIs from Unity or other engines.",
+            "For Python-layer APIs, call api.search(query), then api.get(symbol_or_module). The index is generated from .pyi stubs first, then .py source.",
+            "For components, call component.list_types and component.describe_type before setting fields.",
+            "For shader authoring, call shader.guide, shader.catalog, and shader.describe because shader behavior is C++/compiler-backed and annotation-driven.",
+            "For MCP tools, call mcp.catalog.search or mcp.catalog.recommend before choosing tools.",
+        ],
+        "workflow": [
+            "1. Search: api.search('audio source play one shot') or mcp.catalog.recommend(intent).",
+            "2. Inspect: api.get('AudioSource') or component.describe_type('AudioSource').",
+            "3. Act: use scene/component/asset tools with the exact fields and signatures returned.",
+            "4. Validate: use runtime.read_errors, console.read, or subsystem-specific describe/report tools.",
+        ],
+        "symbols": ["api.search", "api.get", "mcp.catalog.search", "component.describe_type", "shader.guide"],
+    },
+    "shader": {
+        "summary": "Three-layer shader authoring model: surface fragment/vertex shaders, shading models, and GLSL libraries/templates.",
+        "concepts": [
+            "Shader authoring is NOT a normal Python-reflection API. It is parsed and compiled by the C++ shader/material pipeline, so this guide is manually curated.",
+            "Fragment surface shaders are .frag files with @shader_id, @shading_model, optional @queue, and @property annotations.",
+            "Vertex shaders are .vert files with @shader_id. Materials may set vert_shader_name and frag_shader_name separately.",
+            "Shading models are .shadingmodel files with @shader_id and @target blocks such as forward or gbuffer.",
+            "Library files are .glsl files imported with @import; do not assign them directly as Material shaders.",
+            "Material properties are declared in the first 50 lines using @property: name, Type, default[, HDR].",
+            "Surface shaders implement void surface(out SurfaceData s). Start with s = InitSurfaceData().",
+            "Common built-in varyings include v_TexCoord, v_Color, v_WorldPos, and normal/tangent data supplied by the standard vertex path.",
+            "RenderGraph fullscreen effects use fullscreen_triangle.vert automatically and bind fragment shader IDs through p.fullscreen_quad(shader_id).",
+        ],
+        "workflow": [
+            "Call shader.catalog to discover built-in shader IDs and examples.",
+            "Call shader.describe(shader_id, kind='fragment') before binding a material to a custom fragment shader.",
+            "Create .frag/.vert through asset.create_builtin_resource(kind='shader') or asset.write_text.",
+            "After editing shader files, call asset.refresh and use Shader.reload(shader_id) from scripts if runtime reload is needed.",
+            "For materials, use Material.create_lit/create_unlit, then set vert_shader_name/frag_shader_name or set_shader for matching IDs.",
+        ],
+        "common_mistakes": [
+            "Do not put @shader_id only in comments; the parser expects lines that start with @shader_id: near the top.",
+            "Do not assign a .shadingmodel or .glsl library as Material.frag_shader_name.",
+            "Do not invent property names in Material unless the shader declares them or intentionally uses dynamic properties.",
+            "Texture2D defaults are symbolic names such as white; material values should be texture GUID/path/wrapper, not a vec4.",
+            "Do not assume Shader.reload is fully bound for every runtime path; prefer asset.refresh and material/pipeline refresh tools when available.",
+        ],
+        "rules": {
+            "file_kinds": {
+                ".frag": "Surface fragment shader. Requires @shader_id and usually @shading_model. Declares material @property annotations.",
+                ".vert": "Vertex shader. Requires @shader_id. Use for custom vertex deformation or varyings.",
+                ".shadingmodel": "Lighting/evaluation model. Referenced by @shading_model; not assigned directly to Material.",
+                ".glsl": "Shared library code. Imported with @import; not assigned directly to Material.",
+            },
+            "annotations": {
+                "@shader_id": "Unique shader id used by materials/render graph. Keep it near the top; Inspector/Python catalog scans only early lines.",
+                "@shading_model": "Fragment surface shader only; names a .shadingmodel shader id such as pbr or unlit. It resolves through the C++ shader id map.",
+                "@queue": "Render queue integer, e.g. 2000 opaque, 3000 transparent.",
+                "@property": "Material property declaration: @property: name, Type, default[, HDR].",
+                "@import": "Import a .glsl or shading helper id. Imports use shader_id, not filenames; .shadingmodel ids are internally namespaced.",
+                "@target": "Shading model target block such as forward or gbuffer. Used inside .shadingmodel files.",
+                "@hidden": "Hide internal shader from normal shader selection catalogs.",
+                "@surface_type": "opaque or transparent. transparent defaults queue/blend/depth/pass_tag when unset.",
+                "@blend/@blend_mode": "off, alpha, additive, or premultiply.",
+                "@alpha_test/@alpha_clip": "Enables cutout behavior and affects shadow variants.",
+            },
+            "entry_points": {
+                "surface": "Preferred fragment workflow: void surface(out SurfaceData s). If no main() exists, engine injects templates, varyings, outputs, and shading-model evaluate().",
+                "vertex": "Optional vertex deformation hook: void vertex(inout VertexInput v).",
+                "main": "Advanced path. If author supplies main() or explicit layout(location=...), auto interface/template injection may be skipped; the author owns bindings and IO.",
+            },
+            "builtins": {
+                "surface_data": "Use s = InitSurfaceData(); then set fields such as albedo, alpha, emission, normalWS, metallic, smoothness, occlusion.",
+                "common_varyings": ["v_TexCoord", "v_Color", "v_WorldPos", "v_Normal", "v_Tangent", "v_ViewDepth"],
+                "common_uniforms": ["material", "_Globals", "lighting"],
+                "material_ubo": "MaterialProperties is exposed as global 'material'. Texture2D properties become sampler2D bindings managed by the compiler.",
+            },
+            "reload_limitations": [
+                "File watcher reload primarily handles .vert and .frag.",
+                "Editing .glsl, .shadingmodel, or _templates/*.glsl may require touching/reloading a dependent .vert/.frag or restarting/invalidation.",
+                "Shader.reload in Python is not a complete substitute for C++ file reload paths in every build.",
+            ],
+            "material_binding": [
+                "Use material.vert_shader_name for vertex shader id.",
+                "Use material.frag_shader_name for fragment shader id.",
+                "Do not bind .glsl libraries or .shadingmodel files directly as material shaders.",
+                "Use material.get_properties MCP to inspect shader.vertex, shader.fragment, render_queue, and synced properties.",
+            ],
+            "property_types": PROPERTY_TYPES,
+        },
+        "symbols": ["Shader", "Material", "shader.catalog", "shader.describe", "shader.guide"],
+    },
+    "audio": {
+        "summary": "Audio uses AudioListener for the ears, AudioSource for multi-track playback, and AudioClip for WAV assets.",
+        "concepts": [
+            "AudioListener should usually be attached to the main camera. Only one listener is active at a time.",
+            "AudioSource is multi-track: set track_count, assign clips per track, then play(track_index).",
+            "AudioClip.load(path) returns an AudioClip wrapper or None; pass clip or clip.native to AudioSource methods.",
+            "Use play_one_shot(clip, volume_scale) for transient SFX rather than creating many temporary AudioSource objects.",
+        ],
+        "workflow": [
+            "Ensure a GameObject has AudioSource and the camera has AudioListener.",
+            "Load WAV assets with AudioClip.load('Assets/Audio/name.wav').",
+            "Assign clips with source.set_track_clip(index, clip) or set_track_clip_by_guid(index, guid).",
+            "Use source.volume/pitch/mute/loop/play_on_awake for source-level behavior.",
+            "Use source.set_track_volume(index, value), play(index), pause(index), stop(index), stop_all().",
+        ],
+        "common_mistakes": [
+            "Do not use source.clip = clip; this engine exposes per-track clips instead.",
+            "Track indices are zero-based and must be below source.track_count.",
+            "AudioClip.load currently documents WAV loading; avoid assuming MP3/OGG unless the asset importer says so.",
+            "Attach one AudioListener to the main camera instead of adding listeners to many objects.",
+        ],
+        "symbols": ["AudioSource", "AudioListener", "AudioClip", "audio.guide"],
+    },
+    "component": {
+        "summary": "Python components inherit InxComponent; built-ins expose CppProperty fields and delegate methods.",
+        "concepts": [
+            "Use component.list_types and component.describe_type for exact component fields.",
+            "Use serialized_field for script fields that should persist and appear in the inspector.",
+            "Use lifecycle methods awake/start/update/late_update/on_enable/on_disable/on_destroy.",
+        ],
+        "symbols": ["InxComponent", "serialized_field", "component.describe_type", "component.list_types"],
+    },
+    "material": {
+        "summary": "Material wraps InxMaterial and stores shader selection, render state, and typed shader properties.",
+        "concepts": [
+            "Material.create_lit uses default_lit; Material.create_unlit uses default_unlit.",
+            "Use vert_shader_name and frag_shader_name when vertex/fragment shader IDs differ.",
+            "Use set_color/set_float/set_int/set_vector*/set_texture based on shader @property declarations.",
+        ],
+        "symbols": ["Material", "shader.describe", "material.create", "material.set_property"],
+    },
+    "ui": {
+        "summary": "Screen-space UI uses UICanvas plus UIText, UIImage, UIButton, pointer events, and persistent UIEventEntry bindings.",
+        "concepts": [
+            "Create a UICanvas root, then child UI elements such as UIText, UIImage, and UIButton.",
+            "Positions and sizes are in canvas design pixels, scaled by UICanvas.compute_scale for the Game View.",
+            "Use api.get('UICanvas'), api.get('UIText'), api.get('UIButton'), and api.get('InxUIScreenComponent') before scripting UI.",
+            "UIButton.on_click is a runtime UIEvent; persistent callbacks use on_click_entries.",
+        ],
+        "symbols": ["UICanvas", "UIText", "UIImage", "UIButton", "UIEvent", "PointerEventData"],
+    },
+}
+
+
+_API_INDEX: dict[str, Any] | None = None
+
+
+def register_api_tools(mcp) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="api.subsystems")
+    def api_subsystems() -> dict:
+        """List documented engine subsystems available to agents."""
+        return ok({
+            "agent_guidance": _agent_api_guidance(),
+            "subsystems": [
+                {"name": name, "summary": guide["summary"], "symbols": guide.get("symbols", [])}
+                for name, guide in sorted(SUBSYSTEM_GUIDES.items())
+            ],
+            "python_api": _api_index_summary(),
+        })
+
+    @mcp.tool(name="api.get")
+    def api_get(name: str) -> dict:
+        """Return a subsystem guide or symbol API page."""
+        key = str(name or "").strip()
+        guide = SUBSYSTEM_GUIDES.get(key.lower())
+        if guide is not None:
+            payload = {"kind": "subsystem", "name": key.lower(), **guide}
+            if key.lower() in {"shader", "audio", "ui", "material"}:
+                lock_scope = "shader" if key.lower() == "material" else key.lower()
+                payload["knowledge_lock"] = issue_knowledge_token(lock_scope, source_tool=f"api.get:{key.lower()}")
+            return ok(payload)
+        symbol = _symbol_doc(key)
+        if symbol:
+            return ok({"kind": "symbol", **symbol})
+        module_doc = _module_doc(key)
+        if module_doc:
+            return ok({"kind": "module", **module_doc})
+        index = _api_index()
+        return ok({
+            "found": False,
+            "available_subsystems": sorted(SUBSYSTEM_GUIDES),
+            "available_symbols": sorted(index["symbols"]),
+            "available_modules": sorted(index["modules"]),
+        })
+
+    @mcp.tool(name="api.search")
+    def api_search(query: str, limit: int = 20) -> dict:
+        """Search subsystem guides, symbols, shader IDs, and component names."""
+        query_l = str(query or "").lower()
+        matches = []
+        for name, guide in SUBSYSTEM_GUIDES.items():
+            haystack = " ".join([
+                name,
+                guide.get("summary", ""),
+                " ".join(guide.get("concepts", [])),
+                " ".join(guide.get("symbols", [])),
+            ]).lower()
+            score = _score(query_l, haystack)
+            if score:
+                matches.append({"kind": "subsystem", "name": name, "summary": guide["summary"], "score": score})
+        index = _api_index()
+        for name in index["symbols"]:
+            doc = _symbol_doc(name)
+            haystack = " ".join([
+                name,
+                doc.get("doc", ""),
+                " ".join(m["name"] for m in doc.get("methods", [])),
+                " ".join(p["name"] for p in doc.get("properties", [])),
+                " ".join(a["name"] for a in doc.get("attributes", [])),
+            ]).lower()
+            score = _score(query_l, haystack)
+            if score:
+                matches.append({
+                    "kind": "symbol",
+                    "name": name,
+                    "module": doc.get("module", ""),
+                    "summary": doc.get("doc", "").splitlines()[0] if doc.get("doc") else "",
+                    "score": score,
+                })
+        for name, module in index["modules"].items():
+            haystack = " ".join([name, module.get("path", ""), " ".join(module.get("symbols", []))]).lower()
+            score = _score(query_l, haystack)
+            if score:
+                matches.append({"kind": "module", "name": name, "summary": module.get("path", ""), "score": score})
+        for shader in _scan_shaders():
+            haystack = " ".join([shader["shader_id"], shader["kind"], shader.get("path", ""), " ".join(shader.get("imports", []))]).lower()
+            score = _score(query_l, haystack)
+            if score:
+                matches.append({"kind": "shader", "name": shader["shader_id"], "shader_kind": shader["kind"], "summary": shader.get("path", ""), "score": score})
+        matches.sort(key=lambda item: (-item["score"], item["kind"], item["name"]))
+        return ok({"query": query, "matches": matches[: max(int(limit or 20), 1)]})
+
+    @mcp.tool(name="shader.guide")
+    def shader_guide(topic: str = "") -> dict:
+        """Return shader authoring rules, property annotation syntax, and examples."""
+        guide = dict(SUBSYSTEM_GUIDES["shader"])
+        guide["property_types"] = PROPERTY_TYPES
+        guide["examples"] = _shader_examples()
+        guide["knowledge_lock"] = issue_knowledge_token("shader", source_tool="shader.guide")
+        if topic:
+            guide["topic"] = topic
+        return ok(guide)
+
+    @mcp.tool(name="shader.catalog")
+    def shader_catalog(kind: str = "", include_hidden: bool = False) -> dict:
+        """List shader IDs from project and built-in shader roots."""
+        shaders = [
+            item
+            for item in _scan_shaders()
+            if (not kind or item["kind"] == kind or item["extension"].lstrip(".") == kind)
+            and (include_hidden or not item.get("hidden"))
+        ]
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for item in shaders:
+            grouped.setdefault(item["kind"], []).append(item)
+        return ok({"shaders": shaders, "grouped": grouped, "property_types": PROPERTY_TYPES})
+
+    @mcp.tool(name="shader.describe")
+    def shader_describe(shader_id: str, kind: str = "") -> dict:
+        """Describe a shader file, annotations, material properties, and usage."""
+        shader_id_l = str(shader_id or "").strip().lower()
+        candidates = [
+            item for item in _scan_shaders()
+            if item["shader_id"].lower() == shader_id_l and (not kind or item["kind"] == kind or item["extension"].lstrip(".") == kind)
+        ]
+        if not candidates:
+            return ok({"found": False, "shader_id": shader_id, "available": [item["shader_id"] for item in _scan_shaders()]})
+        return ok({"shader_id": shader_id, "matches": candidates, "usage": _shader_usage(candidates)})
+
+    @mcp.tool(name="audio.guide")
+    def audio_guide(topic: str = "") -> dict:
+        """Return AudioSource/AudioListener/AudioClip usage guidance."""
+        guide = dict(SUBSYSTEM_GUIDES["audio"])
+        guide["examples"] = _audio_examples()
+        guide["symbols"] = [_symbol_doc(name) for name in ("AudioSource", "AudioListener", "AudioClip")]
+        guide["knowledge_lock"] = issue_knowledge_token("audio", source_tool="audio.guide")
+        if topic:
+            guide["topic"] = topic
+        return ok(guide)
+
+
+def _symbol_doc(symbol: str) -> dict[str, Any]:
+    key = str(symbol or "").strip()
+    index = _api_index()
+    entry = index["symbols"].get(key)
+    candidates = _symbol_candidates(index, key)
+    if "." not in key and len(candidates) > 1:
+        preferred = _preferred_symbol_candidate(candidates)
+        if preferred is not None:
+            entry = preferred
+    if entry is None and "." in key:
+        module_name, _, attr = key.rpartition(".")
+        entry = index["symbols"].get(attr)
+        if entry is not None and entry.get("module") != module_name:
+            entry = None
+    if entry is None:
+        lowered = key.lower()
+        matches = [item for name, item in index["symbols"].items() if name.lower() == lowered or item.get("qualname", "").lower() == lowered]
+        if len(matches) == 1:
+            entry = matches[0]
+    if entry is None:
+        return {}
+    doc = dict(entry)
+    if "." not in key and len(candidates) > 1:
+        doc["ambiguous_short_name"] = True
+        doc["alternatives"] = [
+            {"name": item.get("name", ""), "qualname": item.get("qualname", ""), "module": item.get("module", ""), "source": item.get("source", "")}
+            for item in candidates
+        ]
+        doc["recommendation"] = "Use api.get with the module-qualified name from alternatives for deterministic results."
+    runtime = _runtime_symbol_doc(doc.get("module", ""), doc.get("name", ""))
+    if runtime:
+        doc.setdefault("runtime_doc", runtime.get("doc", ""))
+        doc.setdefault("runtime_module", runtime.get("module", ""))
+        if not doc.get("doc"):
+            doc["doc"] = runtime.get("doc", "")
+        if not doc.get("methods"):
+            doc["methods"] = runtime.get("methods", [])
+        if not doc.get("properties"):
+            doc["properties"] = runtime.get("properties", [])
+    return doc
+
+
+def _symbol_candidates(index: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    lowered = str(key or "").lower()
+    seen: set[str] = set()
+    candidates = []
+    for item in index["symbols"].values():
+        qualname = str(item.get("qualname", ""))
+        if qualname in seen:
+            continue
+        if str(item.get("name", "")).lower() == lowered or qualname.lower() == lowered:
+            candidates.append(item)
+            seen.add(qualname)
+    return candidates
+
+
+def _preferred_symbol_candidate(candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
+    prefixes = (
+        "Infernux.components.builtin.",
+        "Infernux.components.",
+        "Infernux.ui.",
+        "Infernux.core.",
+        "Infernux.renderstack.",
+    )
+    for prefix in prefixes:
+        for item in candidates:
+            if str(item.get("module", "")).startswith(prefix):
+                return item
+    return candidates[0] if candidates else None
+
+
+def _runtime_symbol_doc(module_name: str, attr: str) -> dict[str, Any]:
+    try:
+        module = __import__(module_name, fromlist=[attr])
+        obj = getattr(module, attr)
+    except Exception:
+        return {}
+    methods = []
+    properties = []
+    for name, member in inspect.getmembers(obj):
+        if name.startswith("_"):
+            continue
+        if isinstance(member, property):
+            properties.append({"name": name, "doc": inspect.getdoc(member) or ""})
+        elif inspect.isfunction(member) or inspect.ismethod(member):
+            try:
+                signature = str(inspect.signature(member))
+            except Exception:
+                signature = "(...)"
+            methods.append({"name": name, "signature": signature, "doc": inspect.getdoc(member) or ""})
+    return {
+        "name": attr,
+        "module": module_name,
+        "doc": inspect.getdoc(obj) or "",
+        "methods": methods,
+        "properties": properties,
+    }
+
+
+def _module_doc(name: str) -> dict[str, Any]:
+    index = _api_index()
+    module = index["modules"].get(str(name or "").strip())
+    if module is None:
+        lowered = str(name or "").strip().lower()
+        matches = [item for key, item in index["modules"].items() if key.lower() == lowered]
+        if len(matches) == 1:
+            module = matches[0]
+    return dict(module) if module else {}
+
+
+def _api_index_summary() -> dict[str, int]:
+    index = _api_index()
+    return {
+        "module_count": len(index["modules"]),
+        "symbol_count": len(index["symbols"]),
+        "stub_symbol_count": sum(1 for item in index["symbols"].values() if item.get("source") == "stub"),
+    }
+
+
+def _api_index() -> dict[str, Any]:
+    global _API_INDEX
+    if _API_INDEX is not None:
+        return _API_INDEX
+    modules: dict[str, Any] = {}
+    symbols: dict[str, Any] = {}
+    roots = _python_api_roots()
+    seen_stems: set[str] = set()
+    for root in roots:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [name for name in dirnames if name not in {"__pycache__", ".mypy_cache"} and not name.startswith(".")]
+            for filename in filenames:
+                if not filename.endswith(".pyi"):
+                    continue
+                path = os.path.join(dirpath, filename)
+                module_name = _module_name_for_path(path)
+                seen_stems.add(os.path.splitext(path)[0])
+                _merge_module_api(modules, symbols, module_name, path, source="stub")
+    for root in roots:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [name for name in dirnames if name not in {"__pycache__", ".mypy_cache"} and not name.startswith(".")]
+            for filename in filenames:
+                if not filename.endswith(".py") or filename.startswith("_"):
+                    continue
+                path = os.path.join(dirpath, filename)
+                if os.path.splitext(path)[0] in seen_stems:
+                    continue
+                module_name = _module_name_for_path(path)
+                _merge_module_api(modules, symbols, module_name, path, source="python")
+    _API_INDEX = {"modules": modules, "symbols": symbols}
+    return _API_INDEX
+
+
+def _python_api_roots() -> list[str]:
+    return [os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))]
+
+
+def _module_name_for_path(path: str) -> str:
+    root = _python_api_roots()[0]
+    package_parent = os.path.dirname(root)
+    rel = os.path.relpath(os.path.abspath(path), package_parent)
+    module = os.path.splitext(rel)[0].replace(os.sep, ".")
+    if module.endswith(".__init__"):
+        module = module[: -len(".__init__")]
+    return module
+
+
+def _merge_module_api(
+    modules: dict[str, Any],
+    symbols: dict[str, Any],
+    module_name: str,
+    path: str,
+    *,
+    source: str,
+) -> None:
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            tree = ast.parse(f.read(), filename=path)
+    except Exception:
+        return
+    module_doc = ast.get_docstring(tree) or ""
+    module_symbols = []
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            entry = _class_entry(module_name, node, path, source)
+            _store_symbol(symbols, entry)
+            module_symbols.append(node.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and not node.name.startswith("_"):
+            entry = _function_entry(module_name, node, path, source)
+            _store_symbol(symbols, entry)
+            module_symbols.append(node.name)
+    modules[module_name] = {
+        "name": module_name,
+        "path": _project_rel(path),
+        "source": source,
+        "doc": module_doc,
+        "symbols": sorted(module_symbols),
+    }
+
+
+def _store_symbol(symbols: dict[str, Any], entry: dict[str, Any]) -> None:
+    name = entry["name"]
+    existing = symbols.get(name)
+    if (
+        existing is None
+        or _symbol_priority(entry) > _symbol_priority(existing)
+        or (existing.get("source") != "stub" and entry.get("source") == "stub")
+    ):
+        symbols[name] = entry
+    symbols[entry["qualname"]] = entry
+
+
+def _symbol_priority(entry: dict[str, Any]) -> int:
+    module = str(entry.get("module", ""))
+    if module.startswith("Infernux.components.builtin."):
+        return 50
+    if module.startswith("Infernux.components."):
+        return 40
+    if module.startswith("Infernux.ui."):
+        return 35
+    if module.startswith("Infernux.core."):
+        return 30
+    if module.startswith("Infernux.renderstack."):
+        return 25
+    if module.startswith("Infernux.lib."):
+        return 10
+    return 0
+
+
+def _class_entry(module_name: str, node: ast.ClassDef, path: str, source: str) -> dict[str, Any]:
+    methods = []
+    properties = []
+    attributes = []
+    for item in node.body:
+        if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name) and not item.target.id.startswith("_"):
+            attributes.append({
+                "name": item.target.id,
+                "type": _expr_to_source(item.annotation),
+                "doc": _inline_attribute_doc(node.body, item),
+            })
+            continue
+        if isinstance(item, ast.Assign):
+            for target in item.targets:
+                if isinstance(target, ast.Name) and not target.id.startswith("_"):
+                    attributes.append({
+                        "name": target.id,
+                        "type": "",
+                        "doc": _inline_attribute_doc(node.body, item),
+                    })
+            continue
+        if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) or item.name.startswith("_"):
+            continue
+        decorators = [_decorator_name(dec) for dec in item.decorator_list]
+        if "property" in decorators:
+            properties.append({"name": item.name, "type": _return_annotation(item), "doc": ast.get_docstring(item) or ""})
+        elif any(dec.endswith(".setter") for dec in decorators):
+            continue
+        else:
+            methods.append({"name": item.name, "signature": _signature_from_ast(item), "doc": ast.get_docstring(item) or ""})
+    return {
+        "name": node.name,
+        "qualname": f"{module_name}.{node.name}",
+        "module": module_name,
+        "kind": "class",
+        "source": source,
+        "path": _project_rel(path),
+        "doc": ast.get_docstring(node) or "",
+        "bases": [_expr_to_source(base) for base in node.bases],
+        "attributes": attributes,
+        "methods": methods,
+        "properties": properties,
+    }
+
+
+def _function_entry(module_name: str, node: ast.FunctionDef | ast.AsyncFunctionDef, path: str, source: str) -> dict[str, Any]:
+    return {
+        "name": node.name,
+        "qualname": f"{module_name}.{node.name}",
+        "module": module_name,
+        "kind": "function",
+        "source": source,
+        "path": _project_rel(path),
+        "doc": ast.get_docstring(node) or "",
+        "signature": _signature_from_ast(node),
+        "attributes": [],
+        "methods": [],
+        "properties": [],
+    }
+
+
+def _inline_attribute_doc(body: list[ast.stmt], item: ast.stmt) -> str:
+    try:
+        index = body.index(item)
+    except ValueError:
+        return ""
+    if index + 1 >= len(body):
+        return ""
+    next_item = body[index + 1]
+    if isinstance(next_item, ast.Expr) and isinstance(next_item.value, ast.Constant) and isinstance(next_item.value.value, str):
+        return str(next_item.value.value)
+    return ""
+
+
+def _signature_from_ast(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    args = []
+    positional = list(node.args.posonlyargs) + list(node.args.args)
+    defaults = [None] * (len(positional) - len(node.args.defaults)) + list(node.args.defaults)
+    for arg, default in zip(positional, defaults):
+        args.append(_format_arg(arg, default))
+    if node.args.vararg:
+        args.append("*" + _format_arg(node.args.vararg, None))
+    elif node.args.kwonlyargs:
+        args.append("*")
+    for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults):
+        args.append(_format_arg(arg, default))
+    if node.args.kwarg:
+        args.append("**" + _format_arg(node.args.kwarg, None))
+    ret = _return_annotation(node)
+    return f"({', '.join(args)})" + (f" -> {ret}" if ret else "")
+
+
+def _format_arg(arg: ast.arg, default: ast.expr | None) -> str:
+    text = arg.arg
+    if arg.annotation is not None:
+        text += f": {_expr_to_source(arg.annotation)}"
+    if default is not None:
+        text += f" = {_expr_to_source(default)}"
+    return text
+
+
+def _return_annotation(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    return _expr_to_source(node.returns) if node.returns is not None else ""
+
+
+def _decorator_name(node: ast.expr) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _decorator_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Call):
+        return _decorator_name(node.func)
+    return ""
+
+
+def _expr_to_source(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return "..."
+
+
+def _scan_shaders() -> list[dict[str, Any]]:
+    from Infernux.engine.ui import inspector_shader_utils as shader_utils
+
+    results = []
+    for root in shader_utils._get_shader_search_roots():
+        if not root or not os.path.isdir(root):
+            continue
+        for dirpath, _dirs, filenames in os.walk(root):
+            for filename in filenames:
+                ext = os.path.splitext(filename)[1].lower()
+                if ext not in {".vert", ".frag", ".glsl", ".shadingmodel"}:
+                    continue
+                path = os.path.join(dirpath, filename)
+                annotations = _parse_shader_annotations(path)
+                shader_id = annotations.get("shader_id") or os.path.splitext(filename)[0]
+                kind = {
+                    ".vert": "vertex",
+                    ".frag": "fragment",
+                    ".glsl": "library",
+                    ".shadingmodel": "shading_model",
+                }[ext]
+                results.append({
+                    "shader_id": shader_id,
+                    "kind": kind,
+                    "extension": ext,
+                    "path": _project_rel(path),
+                    "hidden": annotations.get("hidden", False),
+                    "properties": shader_utils.parse_shader_properties(path) if ext in {".vert", ".frag"} else [],
+                    "imports": annotations.get("imports", []),
+                    "targets": annotations.get("targets", []),
+                    "shading_model": annotations.get("shading_model", ""),
+                    "queue": annotations.get("queue", ""),
+                })
+    results.sort(key=lambda item: (item["kind"], item["shader_id"], item["path"]))
+    return results
+
+
+def _parse_shader_annotations(path: str) -> dict[str, Any]:
+    annotations: dict[str, Any] = {"imports": [], "targets": []}
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            for i, line in enumerate(f):
+                if i > 120:
+                    break
+                stripped = line.strip().lstrip("/ ")
+                if stripped == "@hidden":
+                    annotations["hidden"] = True
+                elif stripped.startswith("@shader_id:"):
+                    annotations["shader_id"] = stripped.split(":", 1)[1].strip()
+                elif stripped.startswith("@import:"):
+                    annotations.setdefault("imports", []).append(stripped.split(":", 1)[1].strip())
+                elif stripped.startswith("@target:"):
+                    annotations.setdefault("targets", []).append(stripped.split(":", 1)[1].strip())
+                elif stripped.startswith("@shading_model:"):
+                    annotations["shading_model"] = stripped.split(":", 1)[1].strip()
+                elif stripped.startswith("@queue:"):
+                    annotations["queue"] = stripped.split(":", 1)[1].strip()
+    except OSError:
+        pass
+    return annotations
+
+
+def _shader_usage(candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    kinds = {item["kind"] for item in candidates}
+    usage = {
+        "material_binding": [],
+        "notes": [],
+        "next_tools": ["shader.catalog", "asset.create_builtin_resource", "asset.write_text", "asset.refresh", "material.create"],
+    }
+    if "vertex" in kinds:
+        usage["material_binding"].append("material.vert_shader_name = '<shader_id>'")
+    if "fragment" in kinds:
+        usage["material_binding"].append("material.frag_shader_name = '<shader_id>'")
+    if "shading_model" in kinds:
+        usage["notes"].append("Reference this from a .frag surface shader with @shading_model: <shader_id>; do not bind it directly as a material fragment shader.")
+    if "library" in kinds:
+        usage["notes"].append("Import this from .frag/.vert/.shadingmodel code with @import; do not bind it directly to Material.")
+    return usage
+
+
+def _shader_examples() -> dict[str, str]:
+    return {
+        "surface_fragment": (
+            "#version 450\n\n"
+            "@shader_id: my_unlit\n"
+            "@shading_model: unlit\n"
+            "@queue: 2000\n"
+            "@property: baseColor, Color, [1.0, 0.8, 0.4, 1.0]\n"
+            "@property: texSampler, Texture2D, white\n\n"
+            "void surface(out SurfaceData s) {\n"
+            "    s = InitSurfaceData();\n"
+            "    vec4 texColor = texture(texSampler, v_TexCoord);\n"
+            "    s.albedo = texColor.rgb * material.baseColor.rgb;\n"
+            "    s.alpha = texColor.a * material.baseColor.a;\n"
+            "}\n"
+        ),
+        "material_binding": (
+            "from Infernux.core.material import Material\n"
+            "mat = Material.create_unlit('MyMat')\n"
+            "mat.vert_shader_name = 'standard'\n"
+            "mat.frag_shader_name = 'my_unlit'\n"
+            "mat.set_color('baseColor', 1.0, 0.8, 0.4, 1.0)\n"
+        ),
+        "shading_model": (
+            "@shader_id: my_lighting\n"
+            "@import: lighting\n\n"
+            "@target: forward\n"
+            "void evaluate(in SurfaceData s, out vec4 color) {\n"
+            "    color = vec4(s.albedo + s.emission, s.alpha);\n"
+            "}\n"
+        ),
+        "fullscreen_effect_fragment": (
+            "#version 450\n\n"
+            "@shader_id: my_post_fx\n"
+            "@property: intensity, Float, 0.5\n\n"
+            "// Use with RenderGraph pass builder: p.fullscreen_quad('my_post_fx')\n"
+        ),
+    }
+
+
+def _audio_examples() -> dict[str, str]:
+    return {
+        "multi_track": (
+            "from Infernux.components.builtin import AudioSource, AudioListener\n"
+            "from Infernux.core.audio_clip import AudioClip\n\n"
+            "source = self.game_object.get_component(AudioSource)\n"
+            "source.track_count = 2\n"
+            "bgm = AudioClip.load('Assets/Audio/bgm.wav')\n"
+            "sfx = AudioClip.load('Assets/Audio/click.wav')\n"
+            "source.set_track_clip(0, bgm)\n"
+            "source.set_track_clip(1, sfx)\n"
+            "source.loop = True\n"
+            "source.play(0)\n"
+            "source.play_one_shot(sfx, 0.8)\n"
+        ),
+        "listener": "Attach AudioListener to the main camera GameObject; do not create multiple active listeners.",
+    }
+
+
+def _score(query: str, haystack: str) -> int:
+    tokens = [token for token in query.split() if token]
+    if not tokens:
+        return 1
+    return sum(1 for token in tokens if token in haystack)
+
+
+def _agent_api_guidance() -> list[str]:
+    return [
+        "Infernux is new and changes quickly. Do not infer unknown APIs from Unity; query them first.",
+        "Use api.search(query) for Python/stub-backed APIs, then api.get(symbol_or_module) for signatures and docstrings.",
+        "Use component.describe_type(component_type) before component.set_field/component.set_fields.",
+        "Use shader.guide, shader.catalog, and shader.describe for shader authoring because shader behavior is C++/annotation/compiler-backed.",
+        "When a guide returns data.knowledge_lock.token, pass that token as knowledge_token to gated write tools for that subsystem.",
+        "Use mcp.catalog.search or mcp.catalog.recommend before selecting MCP tools for unfamiliar tasks.",
+    ]
+
+
+def _project_rel(path: str) -> str:
+    try:
+        from Infernux.engine.project_context import get_project_root
+        root = get_project_root()
+        if root:
+            return os.path.relpath(os.path.abspath(path), os.path.abspath(root)).replace("\\", "/")
+    except Exception:
+        pass
+    return str(path).replace("\\", "/")
+
+
+def _register_metadata() -> None:
+    for name, summary, category, tags in [
+        ("api.subsystems", "List documented engine subsystems and API entry points.", "foundation/api", ["api", "subsystem", "docs"]),
+        ("api.get", "Return a subsystem guide or symbol API page.", "foundation/api", ["api", "docs", "symbol"]),
+        ("api.search", "Search subsystem guides, symbols, shader IDs, and component names.", "foundation/api", ["api", "search"]),
+        ("shader.guide", "Return shader authoring rules and examples.", "shader/guide", ["shader", "guide", "glsl"]),
+        ("shader.catalog", "List project and built-in shader IDs.", "shader/catalog", ["shader", "catalog", "vertex", "fragment", "shadingmodel"]),
+        ("shader.describe", "Describe shader annotations, properties, and material binding usage.", "shader/catalog", ["shader", "properties", "material"]),
+        ("audio.guide", "Return AudioSource, AudioListener, and AudioClip usage guidance.", "audio/guide", ["audio", "guide", "script"]),
+    ]:
+        register_tool_metadata(
+            name,
+            summary=summary,
+            category=category,
+            tags=tags,
+            level="foundation" if name.startswith("api.") else "semantic",
+            aliases=["script api", "engine api", "how to use", "查询API"] + tags,
+            next_suggested_tools=["api.search", "api.get", "component.describe_type"],
+        )

--- a/python/Infernux/mcp/tools/assets.py
+++ b/python/Infernux/mcp/tools/assets.py
@@ -8,10 +8,13 @@ import shutil
 
 from Infernux.mcp.tools.common import (
     get_asset_database,
+    ensure_not_active_scene_file,
     main_thread,
     notify_asset_changed,
+    require_knowledge_token,
     resolve_project_dir,
     resolve_project_path,
+    track_project_path_before_change,
 )
 
 
@@ -22,13 +25,41 @@ def register_asset_tools(mcp, project_path: str) -> None:
         name: str,
         directory: str = "Assets",
         shader_type: str = "frag",
+        knowledge_token: str = "",
     ) -> dict:
         """Create a built-in resource type: folder, script, material, shader, or scene."""
 
         def _create():
+            if str(kind or "").strip().lower() in {"shader", "material"}:
+                require_knowledge_token("shader", knowledge_token, required_tool="shader.guide")
             return _create_builtin(project_path, kind, name, directory, shader_type)
 
-        return main_thread("asset.create_builtin_resource", _create)
+        return main_thread(
+            "asset.create_builtin_resource",
+            _create,
+            arguments={"kind": kind, "name": name, "directory": directory, "shader_type": shader_type, "knowledge_token": knowledge_token},
+        )
+
+    @mcp.tool(name="asset.ensure_folder")
+    def asset_ensure_folder(path: str) -> dict:
+        """Ensure a project folder exists; succeeds if it already exists."""
+
+        def _ensure_folder():
+            folder = resolve_project_path(project_path, path)
+            if os.path.exists(folder) and not os.path.isdir(folder):
+                raise FileExistsError(f"Path exists but is not a folder: {path}")
+            existed = os.path.isdir(folder)
+            if not existed:
+                track_project_path_before_change(project_path, folder, "ensure_folder")
+                os.makedirs(folder, exist_ok=True)
+                notify_asset_changed(folder, "created")
+            return {
+                "path": os.path.relpath(folder, project_path).replace("\\", "/"),
+                "created": not existed,
+                "existed": existed,
+            }
+
+        return main_thread("asset.ensure_folder", _ensure_folder, arguments={"path": path})
 
     @mcp.tool(name="asset.create_script")
     def asset_create_script(name: str, directory: str = "Assets") -> dict:
@@ -36,14 +67,19 @@ def register_asset_tools(mcp, project_path: str) -> None:
         return main_thread(
             "asset.create_script",
             lambda: _create_builtin(project_path, "script", name, directory, "frag"),
+            arguments={"name": name, "directory": directory},
         )
 
     @mcp.tool(name="asset.create_material")
-    def asset_create_material(name: str, directory: str = "Assets") -> dict:
+    def asset_create_material(name: str, directory: str = "Assets", knowledge_token: str = "") -> dict:
         """Create a material resource from the editor template."""
         return main_thread(
             "asset.create_material",
-            lambda: _create_builtin(project_path, "material", name, directory, "frag"),
+            lambda: (
+                require_knowledge_token("shader", knowledge_token, required_tool="shader.guide")
+                or _create_builtin(project_path, "material", name, directory, "frag")
+            ),
+            arguments={"name": name, "directory": directory, "knowledge_token": knowledge_token},
         )
 
     @mcp.tool(name="asset.list")
@@ -89,7 +125,7 @@ def register_asset_tools(mcp, project_path: str) -> None:
                         break
             return {"root": os.path.relpath(root, project_path).replace("\\", "/"), "entries": entries}
 
-        return main_thread("asset.list", _list)
+        return main_thread("asset.list", _list, arguments={"directory": directory, "recursive": recursive, "include_meta": include_meta, "limit": limit})
 
     @mcp.tool(name="asset.search")
     def asset_search(query: str, directory: str = "Assets", extensions: list[str] | None = None, limit: int = 100) -> dict:
@@ -113,7 +149,7 @@ def register_asset_tools(mcp, project_path: str) -> None:
                         return {"matches": matches}
             return {"matches": matches}
 
-        return main_thread("asset.search", _search)
+        return main_thread("asset.search", _search, arguments={"query": query, "directory": directory, "extensions": extensions or [], "limit": limit})
 
     @mcp.tool(name="asset.read_text")
     def asset_read_text(path: str, max_bytes: int = 262144) -> dict:
@@ -145,6 +181,8 @@ def register_asset_tools(mcp, project_path: str) -> None:
             existed = os.path.exists(file_path)
             if existed and not overwrite:
                 raise FileExistsError(f"File already exists: {path}")
+            ensure_not_active_scene_file(project_path, file_path, "write")
+            track_project_path_before_change(project_path, file_path, "write_text")
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, "w", encoding="utf-8", newline="\n") as f:
                 f.write(text or "")
@@ -155,7 +193,7 @@ def register_asset_tools(mcp, project_path: str) -> None:
                 "created": not existed,
             }
 
-        return main_thread("asset.write_text", _write)
+        return main_thread("asset.write_text", _write, arguments={"path": path, "text_bytes": len((text or "").encode("utf-8")), "overwrite": overwrite})
 
     @mcp.tool(name="asset.edit_text")
     def asset_edit_text(path: str, old_text: str, new_text: str, count: int = 1) -> dict:
@@ -172,6 +210,8 @@ def register_asset_tools(mcp, project_path: str) -> None:
                 raise ValueError("old_text was not found.")
             replace_count = -1 if int(count) <= 0 else int(count)
             updated = original.replace(old_text, new_text, replace_count)
+            ensure_not_active_scene_file(project_path, file_path, "edit")
+            track_project_path_before_change(project_path, file_path, "edit_text")
             with open(file_path, "w", encoding="utf-8", newline="\n") as f:
                 f.write(updated)
             notify_asset_changed(file_path, "modified")
@@ -195,6 +235,8 @@ def register_asset_tools(mcp, project_path: str) -> None:
             if not os.path.exists(target):
                 raise FileNotFoundError(f"Path not found: {path}")
             is_dir = os.path.isdir(target)
+            ensure_not_active_scene_file(project_path, target, "delete")
+            track_project_path_before_change(project_path, target, "delete")
             try:
                 from Infernux.engine.ui.project_file_ops import delete_item
                 delete_item(target, get_asset_database())
@@ -269,13 +311,19 @@ def register_asset_tools(mcp, project_path: str) -> None:
             dst = resolve_project_path(project_path, new_path)
             if not os.path.exists(src):
                 raise FileNotFoundError(f"Path not found: {path}")
+            ensure_not_active_scene_file(project_path, dst, "move to")
             if os.path.exists(dst):
                 if not overwrite:
                     raise FileExistsError(f"Destination already exists: {new_path}")
+                ensure_not_active_scene_file(project_path, dst, "overwrite")
+                track_project_path_before_change(project_path, dst, "overwrite")
                 if os.path.isdir(dst):
                     shutil.rmtree(dst)
                 else:
                     os.remove(dst)
+            ensure_not_active_scene_file(project_path, src, "move")
+            track_project_path_before_change(project_path, src, "move")
+            track_project_path_before_change(project_path, dst, "create")
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             adb = get_asset_database()
             try:
@@ -307,6 +355,11 @@ def register_asset_tools(mcp, project_path: str) -> None:
             src = resolve_project_path(project_path, path)
             if not os.path.exists(src):
                 raise FileNotFoundError(f"Path not found: {path}")
+            dst_hint = os.path.join(os.path.dirname(src), new_name)
+            ensure_not_active_scene_file(project_path, src, "rename")
+            ensure_not_active_scene_file(project_path, dst_hint, "rename to")
+            track_project_path_before_change(project_path, src, "rename")
+            track_project_path_before_change(project_path, dst_hint, "create")
             try:
                 from Infernux.engine.ui.project_file_ops import do_rename
                 dst = do_rename(src, new_name, get_asset_database())
@@ -331,13 +384,18 @@ def register_asset_tools(mcp, project_path: str) -> None:
             dst = resolve_project_path(project_path, new_path)
             if not os.path.exists(src):
                 raise FileNotFoundError(f"Path not found: {path}")
+            ensure_not_active_scene_file(project_path, src, "copy")
+            ensure_not_active_scene_file(project_path, dst, "copy to")
             if os.path.exists(dst):
                 if not overwrite:
                     raise FileExistsError(f"Destination already exists: {new_path}")
+                ensure_not_active_scene_file(project_path, dst, "overwrite")
+                track_project_path_before_change(project_path, dst, "overwrite")
                 if os.path.isdir(dst):
                     shutil.rmtree(dst)
                 else:
                     os.remove(dst)
+            track_project_path_before_change(project_path, dst, "copy")
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             if os.path.isdir(src):
                 shutil.copytree(src, dst)
@@ -425,6 +483,8 @@ def register_asset_tools(mcp, project_path: str) -> None:
             existed = os.path.exists(file_path)
             if existed and not overwrite:
                 raise FileExistsError(f"File already exists: {path}")
+            ensure_not_active_scene_file(project_path, file_path, "write")
+            track_project_path_before_change(project_path, file_path, "write_json")
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, "w", encoding="utf-8", newline="\n") as f:
                 json.dump(value, f, ensure_ascii=False, indent=int(indent))
@@ -432,7 +492,7 @@ def register_asset_tools(mcp, project_path: str) -> None:
             notify_asset_changed(file_path, "modified" if existed else "created")
             return {"path": os.path.relpath(file_path, project_path).replace("\\", "/"), "bytes": os.path.getsize(file_path), "created": not existed}
 
-        return main_thread("asset.write_json", _write_json)
+        return main_thread("asset.write_json", _write_json, arguments={"path": path, "overwrite": overwrite, "indent": indent})
 
     @mcp.tool(name="asset.patch_text")
     def asset_patch_text(path: str, replacements: list[dict[str, str]]) -> dict:
@@ -454,6 +514,8 @@ def register_asset_tools(mcp, project_path: str) -> None:
                     raise ValueError(f"Patch text was not found: {old[:80]!r}")
                 text = text.replace(old, new, -1 if count <= 0 else count)
                 trace.append({"old": old[:80], "hits": hits, "replaced": hits if count <= 0 else min(hits, count)})
+            ensure_not_active_scene_file(project_path, file_path, "patch")
+            track_project_path_before_change(project_path, file_path, "patch_text")
             with open(file_path, "w", encoding="utf-8", newline="\n") as f:
                 f.write(text)
             notify_asset_changed(file_path, "modified")
@@ -470,27 +532,41 @@ def _create_builtin(project_path: str, kind: str, name: str, directory: str, sha
     adb = get_asset_database()
     normalized = kind.strip().lower()
     if normalized == "folder":
-        success, message = ops.create_folder(target_dir, name)
         path = os.path.join(target_dir, name.strip())
+        if os.path.isdir(path):
+            success, message = True, "Folder already exists."
+            existed = True
+        elif os.path.exists(path):
+            rel_path = os.path.relpath(path, project_path).replace("\\", "/")
+            raise FileExistsError(f"Path exists but is not a folder: {rel_path}")
+        else:
+            track_project_path_before_change(project_path, path, "create_builtin")
+            success, message = ops.create_folder(target_dir, name)
+            existed = False
     elif normalized == "script":
-        success, message = ops.create_script(target_dir, name, adb)
         file_name = name if name.endswith(".py") else name + ".py"
+        track_project_path_before_change(project_path, os.path.join(target_dir, file_name), "create_builtin")
+        success, message = ops.create_script(target_dir, name, adb)
         path = os.path.join(target_dir, file_name)
+        existed = False
     elif normalized == "material":
-        success, message = ops.create_material(target_dir, name, adb)
         base = name[:-4] if name.endswith(".mat") else name
+        track_project_path_before_change(project_path, os.path.join(target_dir, base + ".mat"), "create_builtin")
+        success, message = ops.create_material(target_dir, name, adb)
         path = os.path.join(target_dir, base + ".mat")
+        existed = False
     elif normalized == "shader":
-        success, message = ops.create_shader(target_dir, name, shader_type, adb)
         base = name
         for ext in (".vert", ".frag", ".glsl"):
             if base.endswith(ext):
                 base = base[: -len(ext)]
                 break
+        track_project_path_before_change(project_path, os.path.join(target_dir, base + "." + shader_type), "create_builtin")
+        success, message = ops.create_shader(target_dir, name, shader_type, adb)
         path = os.path.join(target_dir, base + "." + shader_type)
+        existed = False
     elif normalized == "scene":
-        success, message = ops.create_scene(target_dir, name, adb)
-        path = message if success else ""
+        raise ValueError("MCP agents must manage .scene files through scene.save/open/new, not asset.create_builtin_resource(kind='scene').")
     else:
         raise ValueError("kind must be one of: folder, script, material, shader, scene")
 
@@ -506,6 +582,10 @@ def _create_builtin(project_path: str, kind: str, name: str, directory: str, sha
     return {
         "kind": normalized,
         "name": name,
-        "path": path,
+        "path": os.path.relpath(path, project_path).replace("\\", "/") if path else "",
+        "absolute_path": path,
         "guid": guid,
+        "created": not existed,
+        "existed": existed,
+        "message": message,
     }

--- a/python/Infernux/mcp/tools/camera.py
+++ b/python/Infernux/mcp/tools/camera.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import math
+from typing import Any
+
 from Infernux.mcp.tools.common import coerce_vector3, main_thread, register_tool_metadata
 
 
@@ -54,6 +57,103 @@ def register_camera_tools(mcp) -> None:
             return {"object_id": int(object_id), "applied": applied}
 
         return main_thread("camera.set_main", _set)
+
+    @mcp.tool(name="camera.describe_view")
+    def camera_describe_view(camera_id: int = 0) -> dict:
+        """Describe a camera's transform, projection, and viewport."""
+
+        def _describe():
+            cam = _resolve_camera_object(camera_id, create_if_missing=False)
+            comp = _find_component(cam, "Camera")
+            if comp is None:
+                raise ValueError(f"GameObject {int(cam.id)} does not have a Camera component.")
+            return {"camera": _camera_snapshot(cam, comp)}
+
+        return main_thread("camera.describe_view", _describe, arguments={"camera_id": camera_id})
+
+    @mcp.tool(name="camera.visibility_report")
+    def camera_visibility_report(
+        camera_id: int = 0,
+        target_ids: list[int] | None = None,
+        target_query: dict[str, Any] | None = None,
+        padding: float = 0.08,
+    ) -> dict:
+        """Report whether targets are inside the camera viewport."""
+
+        def _report():
+            cam = _resolve_camera_object(camera_id, create_if_missing=False)
+            comp = _find_component(cam, "Camera")
+            if comp is None:
+                raise ValueError(f"GameObject {int(cam.id)} does not have a Camera component.")
+            targets = _resolve_targets(target_ids or [], target_query or {})
+            return _visibility_report(cam, comp, targets, float(padding))
+
+        return main_thread(
+            "camera.visibility_report",
+            _report,
+            arguments={"camera_id": camera_id, "target_ids": target_ids or [], "target_query": target_query or {}},
+        )
+
+    @mcp.tool(name="camera.frame_targets")
+    def camera_frame_targets(
+        camera_id: int = 0,
+        target_ids: list[int] | None = None,
+        target_query: dict[str, Any] | None = None,
+        padding: float = 0.18,
+        mode: str = "move_or_zoom",
+    ) -> dict:
+        """Adjust camera position or orthographic size to frame target objects."""
+
+        def _frame():
+            cam = _resolve_camera_object(camera_id, create_if_missing=True)
+            comp = _find_component(cam, "Camera")
+            if comp is None:
+                raise ValueError(f"GameObject {int(cam.id)} does not have a Camera component.")
+            targets = _resolve_targets(target_ids or [], target_query or {})
+            if not targets:
+                raise FileNotFoundError("No target objects matched target_ids or target_query.")
+            bounds = _combined_bounds(targets)
+            applied = _apply_frame(cam, comp, bounds, float(padding), str(mode or "move_or_zoom"))
+            _try_set_scene_main_camera(int(cam.id))
+            _mark_scene_dirty()
+            report = _visibility_report(cam, comp, targets, float(padding))
+            return {"camera": _camera_snapshot(cam, comp), "targets": [_target_entry(obj) for obj in targets], "bounds": bounds, "applied": applied, "visibility": report}
+
+        return main_thread(
+            "camera.frame_targets",
+            _frame,
+            arguments={"camera_id": camera_id, "target_ids": target_ids or [], "target_query": target_query or {}, "padding": padding, "mode": mode},
+        )
+
+    @mcp.tool(name="camera.look_at")
+    def camera_look_at(
+        camera_id: int = 0,
+        target_id: int = 0,
+        position: dict | list | tuple = None,
+        distance: float = 0.0,
+        height: float = 0.0,
+    ) -> dict:
+        """Point a camera at a target object or world position."""
+
+        def _look_at():
+            cam = _resolve_camera_object(camera_id, create_if_missing=True)
+            if _find_component(cam, "Camera") is None:
+                raise ValueError(f"GameObject {int(cam.id)} does not have a Camera component.")
+            if target_id:
+                target = _find_game_object(int(target_id))
+                target_pos = _target_center(target)
+            elif position is not None:
+                value = coerce_vector3(position)
+                target_pos = [float(value.x), float(value.y), float(value.z)]
+            else:
+                raise ValueError("camera.look_at requires target_id or position.")
+            _look_at_position(cam, target_pos, float(distance or 0.0), float(height or 0.0))
+            _try_set_scene_main_camera(int(cam.id))
+            _mark_scene_dirty()
+            comp = _find_component(cam, "Camera")
+            return {"camera": _camera_snapshot(cam, comp), "target_position": target_pos}
+
+        return main_thread("camera.look_at", _look_at, arguments={"camera_id": camera_id, "target_id": target_id, "position": position})
 
     @mcp.tool(name="camera.attach_to_target")
     def camera_attach_to_target(
@@ -221,6 +321,18 @@ def _ensure_camera_object() -> dict:
     return HierarchyCreationService.instance().create("rendering.camera", name="Main Camera", select=False)
 
 
+def _resolve_camera_object(camera_id: int = 0, *, create_if_missing: bool):
+    if int(camera_id or 0):
+        return _find_game_object(int(camera_id))
+    cameras = _find_cameras()
+    chosen = _pick_main_camera(cameras)
+    if chosen is None:
+        if not create_if_missing:
+            raise FileNotFoundError("No camera found.")
+        chosen = _ensure_camera_object()
+    return _find_game_object(int(chosen["id"]))
+
+
 def _try_set_scene_main_camera(object_id: int) -> bool:
     from Infernux.lib import SceneManager
     scene = SceneManager.instance().get_active_scene()
@@ -260,6 +372,335 @@ def _find_component(obj, component_type: str):
     return None
 
 
+def _resolve_targets(target_ids: list[int], target_query: dict[str, Any]) -> list[Any]:
+    targets = []
+    seen: set[int] = set()
+    for object_id in target_ids or []:
+        obj = _find_game_object(int(object_id))
+        seen.add(int(obj.id))
+        targets.append(obj)
+    if target_query:
+        from Infernux.lib import SceneManager
+        scene = SceneManager.instance().get_active_scene()
+        if not scene:
+            raise RuntimeError("No active scene.")
+        for obj in list(scene.get_all_objects() or []):
+            if int(obj.id) in seen:
+                continue
+            if _matches_target_query(obj, target_query):
+                seen.add(int(obj.id))
+                targets.append(obj)
+    if not targets and not target_query:
+        targets = _default_subjects()
+    return targets
+
+
+def _default_subjects(limit: int = 8) -> list[Any]:
+    from Infernux.lib import SceneManager
+    scene = SceneManager.instance().get_active_scene()
+    if not scene:
+        raise RuntimeError("No active scene.")
+    scored = []
+    for obj in list(scene.get_all_objects() or []):
+        score = _subject_score(obj)
+        if score > 0:
+            scored.append((score, obj))
+    scored.sort(key=lambda item: (-item[0], str(getattr(item[1], "name", ""))))
+    return [obj for _score, obj in scored[: max(int(limit), 1)]]
+
+
+def _matches_target_query(obj, query: dict[str, Any]) -> bool:
+    query = query or {}
+    name = str(getattr(obj, "name", "")).lower()
+    path = _object_path(obj).lower()
+    if query.get("name_contains") and str(query["name_contains"]).lower() not in name:
+        return False
+    if query.get("path_contains") and str(query["path_contains"]).lower() not in path:
+        return False
+    if query.get("component_type") and _find_component(obj, str(query["component_type"])) is None:
+        return False
+    component_any = [str(item) for item in query.get("component_any", []) or []]
+    if component_any and not any(_find_component(obj, item) is not None for item in component_any):
+        return False
+    if query.get("tag") and str(getattr(obj, "tag", "")) != str(query["tag"]):
+        return False
+    return True
+
+
+def _subject_score(obj) -> int:
+    names = set(_component_names(obj))
+    lower = str(getattr(obj, "name", "")).lower()
+    score = 0
+    if names.intersection({"MeshRenderer", "SpriteRenderer", "SkinnedMeshRenderer"}):
+        score += 6
+    if names and not names.issubset({"Transform", "Camera", "Light", "UICanvas", "UIText", "UIButton", "UIImage", "RenderStack"}):
+        score += 2
+    for token, weight in {"player": 5, "main": 4, "target": 4, "subject": 4, "board": 3, "piece": 2, "ball": 2}.items():
+        if token in lower:
+            score += weight
+    if names.intersection({"Camera", "Light"}) and not names.intersection({"MeshRenderer", "SpriteRenderer", "SkinnedMeshRenderer"}):
+        score -= 8
+    return score
+
+
+def _visibility_report(cam, comp, targets: list[Any], padding: float) -> dict[str, Any]:
+    viewport_w = max(int(getattr(comp, "pixel_width", 0) or 0), 1)
+    viewport_h = max(int(getattr(comp, "pixel_height", 0) or 0), 1)
+    if viewport_w == 1:
+        viewport_w = 1920
+    if viewport_h == 1:
+        viewport_h = 1080
+    margin_x = viewport_w * max(float(padding), 0.0)
+    margin_y = viewport_h * max(float(padding), 0.0)
+    target_reports = []
+    all_points = []
+    for target in targets:
+        world_points = _bounds_points(_object_bounds(target))
+        screen_points = [_world_to_screen(comp, point) for point in world_points]
+        screen_points = [point for point in screen_points if point is not None]
+        visible = bool(screen_points) and all(
+            margin_x <= point[0] <= viewport_w - margin_x and margin_y <= point[1] <= viewport_h - margin_y
+            for point in screen_points
+        )
+        all_points.extend(screen_points)
+        target_reports.append({
+            **_target_entry(target),
+            "visible_with_padding": visible,
+            "screen_bounds": _screen_bounds(screen_points),
+            "screen_points": screen_points,
+        })
+    overall = bool(all_points) and all(
+        margin_x <= point[0] <= viewport_w - margin_x and margin_y <= point[1] <= viewport_h - margin_y
+        for point in all_points
+    )
+    return {
+        "camera": _camera_snapshot(cam, comp),
+        "viewport": {"width": viewport_w, "height": viewport_h, "padding": float(padding)},
+        "all_visible_with_padding": overall,
+        "targets": target_reports,
+        "screen_bounds": _screen_bounds(all_points),
+        "suggestion": _visibility_suggestion(_screen_bounds(all_points), viewport_w, viewport_h, margin_x, margin_y),
+    }
+
+
+def _apply_frame(cam, comp, bounds: dict[str, Any], padding: float, mode: str) -> dict[str, Any]:
+    center = bounds["center"]
+    size = bounds["size"]
+    trans = cam.transform
+    projection_mode = int(getattr(comp, "projection_mode", 0) or 0)
+    try:
+        from Infernux.lib import Vector3
+    except Exception:
+        Vector3 = None
+    if projection_mode == 1:
+        half_height = max(size[1] * 0.5, size[0] * 0.5 / max(float(getattr(comp, "aspect_ratio", 1.778) or 1.778), 0.1), 0.5)
+        new_size = half_height * (1.0 + max(float(padding), 0.0) * 2.0)
+        if mode in {"move", "move_or_zoom", "zoom"}:
+            try:
+                comp.orthographic_size = float(new_size)
+            except Exception:
+                pass
+        old_pos = _vec(trans.position)
+        if mode in {"move", "move_or_zoom"} and Vector3 is not None:
+            trans.position = Vector3(float(center[0]), float(center[1]), float(old_pos[2]))
+        return {"mode": mode, "projection": "orthographic", "orthographic_size": float(getattr(comp, "orthographic_size", new_size)), "center": center}
+
+    radius = max(max(size) * 0.5, 0.5)
+    fov = max(float(getattr(comp, "field_of_view", 60.0) or 60.0), 1.0)
+    distance = radius / max(math.tan(math.radians(fov) * 0.5), 0.01)
+    distance *= 1.0 + max(float(padding), 0.0) * 2.5
+    height = max(size[1] * 0.18, 0.0)
+    _look_at_position(cam, center, distance, height)
+    return {"mode": mode, "projection": "perspective", "distance": distance, "center": center}
+
+
+def _look_at_position(cam, target_pos: list[float], distance: float = 0.0, height: float = 0.0) -> None:
+    trans = cam.transform
+    pos = _vec(trans.position)
+    if distance > 0.0:
+        direction = _normalize([pos[0] - target_pos[0], pos[1] - target_pos[1], pos[2] - target_pos[2]])
+        if _length(direction) < 0.001:
+            direction = [0.0, 0.25, -1.0]
+        pos = [
+            target_pos[0] + direction[0] * distance,
+            target_pos[1] + direction[1] * distance + float(height),
+            target_pos[2] + direction[2] * distance,
+        ]
+        from Infernux.lib import Vector3
+        trans.position = Vector3(float(pos[0]), float(pos[1]), float(pos[2]))
+    dx = target_pos[0] - pos[0]
+    dy = target_pos[1] - pos[1]
+    dz = target_pos[2] - pos[2]
+    yaw = math.degrees(math.atan2(dx, dz))
+    flat = math.sqrt(dx * dx + dz * dz)
+    pitch = -math.degrees(math.atan2(dy, max(flat, 0.0001)))
+    from Infernux.lib import Vector3
+    trans.euler_angles = Vector3(float(pitch), float(yaw), 0.0)
+
+
+def _combined_bounds(objects: list[Any]) -> dict[str, Any]:
+    boxes = [_object_bounds(obj) for obj in objects]
+    min_v = [min(box["min"][i] for box in boxes) for i in range(3)]
+    max_v = [max(box["max"][i] for box in boxes) for i in range(3)]
+    center = [(min_v[i] + max_v[i]) * 0.5 for i in range(3)]
+    size = [max_v[i] - min_v[i] for i in range(3)]
+    return {"min": min_v, "max": max_v, "center": center, "size": size}
+
+
+def _object_bounds(obj) -> dict[str, Any]:
+    points = []
+    for item in _object_and_descendants(obj):
+        points.extend(_approx_object_points(item))
+    if not points:
+        points = [_target_center(obj)]
+    min_v = [min(point[i] for point in points) for i in range(3)]
+    max_v = [max(point[i] for point in points) for i in range(3)]
+    center = [(min_v[i] + max_v[i]) * 0.5 for i in range(3)]
+    size = [max_v[i] - min_v[i] for i in range(3)]
+    return {"min": min_v, "max": max_v, "center": center, "size": size}
+
+
+def _object_and_descendants(obj) -> list[Any]:
+    result = [obj]
+    try:
+        children = list(obj.get_children() or [])
+    except Exception:
+        children = []
+    for child in children:
+        result.extend(_object_and_descendants(child))
+    return result
+
+
+def _approx_object_points(obj) -> list[list[float]]:
+    pos = _target_center(obj)
+    scale = _vector_list(getattr(getattr(obj, "transform", None), "local_scale", None), default=[1.0, 1.0, 1.0])
+    half = [max(abs(scale[i]) * 0.5, 0.05) for i in range(3)]
+    if not set(_component_names(obj)).intersection({"MeshRenderer", "SpriteRenderer", "SkinnedMeshRenderer"}):
+        half = [0.05, 0.05, 0.05]
+    return [
+        [pos[0] - half[0], pos[1] - half[1], pos[2] - half[2]],
+        [pos[0] + half[0], pos[1] + half[1], pos[2] + half[2]],
+    ]
+
+
+def _bounds_points(bounds: dict[str, Any]) -> list[list[float]]:
+    mn = bounds["min"]
+    mx = bounds["max"]
+    return [
+        [x, y, z]
+        for x in (mn[0], mx[0])
+        for y in (mn[1], mx[1])
+        for z in (mn[2], mx[2])
+    ]
+
+
+def _world_to_screen(comp, point: list[float]) -> list[float] | None:
+    try:
+        value = comp.world_to_screen_point(float(point[0]), float(point[1]), float(point[2]))
+        if value is None:
+            return None
+        return [float(value[0]), float(value[1])]
+    except Exception:
+        return None
+
+
+def _screen_bounds(points: list[list[float]]) -> dict[str, Any]:
+    if not points:
+        return {"available": False}
+    min_v = [min(point[i] for point in points) for i in range(2)]
+    max_v = [max(point[i] for point in points) for i in range(2)]
+    return {"available": True, "min": min_v, "max": max_v, "center": [(min_v[0] + max_v[0]) * 0.5, (min_v[1] + max_v[1]) * 0.5], "size": [max_v[0] - min_v[0], max_v[1] - min_v[1]]}
+
+
+def _visibility_suggestion(bounds: dict[str, Any], width: int, height: int, margin_x: float, margin_y: float) -> dict[str, Any]:
+    if not bounds.get("available"):
+        return {"status": "unknown", "message": "No screen-space points were available. Try camera.frame_targets."}
+    dx = 0.0
+    dy = 0.0
+    if bounds["min"][0] < margin_x:
+        dx = bounds["min"][0] - margin_x
+    elif bounds["max"][0] > width - margin_x:
+        dx = bounds["max"][0] - (width - margin_x)
+    if bounds["min"][1] < margin_y:
+        dy = bounds["min"][1] - margin_y
+    elif bounds["max"][1] > height - margin_y:
+        dy = bounds["max"][1] - (height - margin_y)
+    if abs(dx) <= 1e-4 and abs(dy) <= 1e-4:
+        return {"status": "ok", "message": "Targets fit inside the camera view with padding."}
+    return {"status": "needs_adjustment", "screen_offset": [dx, dy], "message": "Targets exceed the padded viewport; use camera.frame_targets."}
+
+
+def _camera_snapshot(cam, comp) -> dict[str, Any]:
+    return {
+        "id": int(cam.id),
+        "name": str(cam.name),
+        "position": _vec(cam.transform.position),
+        "euler_angles": _vec(cam.transform.euler_angles),
+        "projection_mode": int(getattr(comp, "projection_mode", 0) or 0),
+        "field_of_view": float(getattr(comp, "field_of_view", 60.0) or 60.0),
+        "orthographic_size": float(getattr(comp, "orthographic_size", 0.0) or 0.0),
+        "near_clip": float(getattr(comp, "near_clip", 0.0) or 0.0),
+        "far_clip": float(getattr(comp, "far_clip", 0.0) or 0.0),
+        "aspect_ratio": float(getattr(comp, "aspect_ratio", 1.778) or 1.778),
+        "pixel_width": int(getattr(comp, "pixel_width", 0) or 0),
+        "pixel_height": int(getattr(comp, "pixel_height", 0) or 0),
+    }
+
+
+def _target_entry(obj) -> dict[str, Any]:
+    return {"id": int(obj.id), "name": str(obj.name), "path": _object_path(obj), "components": _component_names(obj)}
+
+
+def _target_center(obj) -> list[float]:
+    return _vector_list(getattr(getattr(obj, "transform", None), "position", None))
+
+
+def _component_names(obj) -> list[str]:
+    names: list[str] = []
+    try:
+        for comp in obj.get_components() or []:
+            names.append(str(getattr(comp, "type_name", type(comp).__name__)))
+    except Exception:
+        pass
+    try:
+        for comp in obj.get_py_components() or []:
+            type_name = str(getattr(comp, "type_name", type(comp).__name__))
+            if type_name not in names:
+                names.append(type_name)
+    except Exception:
+        pass
+    return names
+
+
+def _object_path(obj) -> str:
+    parts = []
+    current = obj
+    while current is not None:
+        parts.append(str(current.name))
+        try:
+            current = current.get_parent()
+        except Exception:
+            current = None
+    return "/".join(reversed(parts))
+
+
+def _vector_list(value, default: list[float] | None = None) -> list[float]:
+    if value is None:
+        return list(default or [0.0, 0.0, 0.0])
+    return [float(getattr(value, axis, 0.0)) for axis in ("x", "y", "z")]
+
+
+def _length(value: list[float]) -> float:
+    return math.sqrt(sum(part * part for part in value))
+
+
+def _normalize(value: list[float]) -> list[float]:
+    length = _length(value)
+    if length <= 0.0001:
+        return [0.0, 0.0, 0.0]
+    return [part / length for part in value]
+
+
 def _mark_scene_dirty() -> None:
     try:
         from Infernux.engine.scene_manager import SceneFileManager
@@ -279,9 +720,21 @@ def _register_metadata() -> None:
         "camera.find_main": "Find cameras and pick the best main camera candidate.",
         "camera.ensure_main": "Reuse an existing main camera or create one if missing.",
         "camera.set_main": "Set Scene.main_camera when the engine binding supports it.",
+        "camera.describe_view": "Describe camera transform, projection, and viewport.",
+        "camera.visibility_report": "Report whether target objects fit inside a camera view.",
+        "camera.frame_targets": "Move or zoom a camera to frame target objects.",
+        "camera.look_at": "Point a camera at a target object or world position.",
         "camera.attach_to_target": "Parent a camera to a target with local offset.",
         "camera.setup_third_person": "Configure a third-person camera rig.",
         "camera.setup_2d_card_game": "Configure an orthographic camera for card/UI games.",
         "lighting.ensure_default": "Ensure a directional light exists.",
     }.items():
-        register_tool_metadata(name, summary=summary, next_suggested_tools=["scene.inspect", "runtime.read_errors"])
+        category = "scene/lighting" if name.startswith("lighting.") else "camera/framing"
+        register_tool_metadata(
+            name,
+            summary=summary,
+            category=category,
+            tags=["camera", "view", "framing", "visibility"] if name.startswith("camera.") else ["light", "scene"],
+            aliases=["frame subject", "fit target", "main camera", "相机", "主体照全"] if name.startswith("camera.") else ["default light"],
+            next_suggested_tools=["scene.query.summary", "scene.query.subjects", "camera.visibility_report", "runtime.read_errors"],
+        )

--- a/python/Infernux/mcp/tools/common.py
+++ b/python/Infernux/mcp/tools/common.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
 import os
+import secrets
 import time
 from typing import Any, Callable
 
@@ -12,29 +14,88 @@ MCP_PROTOCOL_VERSION = "2025-03-26"
 MCP_SERVER_VERSION = "0.2.0"
 
 _TOOL_METADATA: dict[str, dict[str, Any]] = {}
+_KNOWLEDGE_TOKENS: dict[str, dict[str, Any]] = {}
+
+
+class KnowledgeTokenError(Exception):
+    def __init__(self, scope: str, required_tool: str, provided: str = "") -> None:
+        self.scope = str(scope or "")
+        self.required_tool = str(required_tool or "")
+        self.provided = str(provided or "")
+        super().__init__(
+            f"Invalid or missing knowledge token for '{self.scope}'. "
+            f"Call {self.required_tool} first to learn the required knowledge and receive a temporary token."
+        )
+
+
+def issue_knowledge_token(scope: str, *, source_tool: str, ttl_seconds: int = 7200) -> dict[str, Any]:
+    """Issue a temporary proof that the agent requested subsystem knowledge."""
+    normalized_scope = str(scope or "").strip().lower()
+    token = f"{normalized_scope}.{secrets.token_urlsafe(18)}"
+    expires_at = time.time() + max(int(ttl_seconds or 7200), 60)
+    _KNOWLEDGE_TOKENS[token] = {
+        "scope": normalized_scope,
+        "source_tool": str(source_tool or ""),
+        "expires_at": expires_at,
+    }
+    return {
+        "scope": normalized_scope,
+        "token": token,
+        "expires_at": expires_at,
+        "ttl_seconds": max(int(ttl_seconds or 7200), 60),
+        "usage": "Pass this value as knowledge_token to gated MCP tools for this subsystem.",
+    }
+
+
+def require_knowledge_token(scope: str, token: str, *, required_tool: str) -> None:
+    """Raise KnowledgeTokenError unless *token* is a live token for *scope*."""
+    normalized_scope = str(scope or "").strip().lower()
+    token = str(token or "").strip()
+    record = _KNOWLEDGE_TOKENS.get(token)
+    if not record or record.get("scope") != normalized_scope or float(record.get("expires_at", 0.0)) < time.time():
+        raise KnowledgeTokenError(normalized_scope, required_tool, token)
 
 
 def register_tool_metadata(
     name: str,
     *,
     summary: str = "",
+    category: str = "",
+    tags: list[str] | None = None,
+    level: str = "semantic",
+    aliases: list[str] | None = None,
     parameters: dict[str, Any] | None = None,
+    preconditions: list[str] | None = None,
+    postconditions: list[str] | None = None,
     side_effects: list[str] | None = None,
     next_suggested_tools: list[str] | None = None,
     recovery: list[str] | None = None,
     examples: list[dict[str, Any]] | None = None,
     concepts: dict[str, str] | None = None,
+    invariants: list[str] | None = None,
+    risk_level: str = "medium",
+    feature: str = "",
 ) -> None:
     """Register human/agent-facing metadata for a tool."""
     _TOOL_METADATA[name] = {
         "name": name,
         "summary": summary,
+        "category": str(category or _default_tool_category(name)),
+        "tags": _normalized_string_list(tags),
+        "level": str(level or "semantic"),
+        "aliases": _normalized_string_list(aliases),
         "parameters": parameters or {},
+        "returns": {},
+        "preconditions": preconditions or [],
+        "postconditions": postconditions or [],
         "side_effects": side_effects or [],
         "next_suggested_tools": next_suggested_tools or [],
         "recovery": recovery or [],
         "examples": examples or [],
         "concepts": concepts or {},
+        "invariants": invariants or [],
+        "risk_level": str(risk_level or "medium"),
+        "feature": str(feature or ""),
     }
 
 
@@ -44,14 +105,161 @@ def get_tool_metadata(name: str) -> dict[str, Any]:
         meta = {
             "name": name,
             "summary": "No detailed metadata registered yet.",
+            "category": _default_tool_category(name),
+            "tags": [],
+            "level": "semantic",
+            "aliases": [],
             "parameters": {},
+            "returns": {},
+            "preconditions": [],
+            "postconditions": [],
             "side_effects": [],
             "next_suggested_tools": [],
             "recovery": ["Use mcp.capabilities or mcp.list_tools_verbose to inspect available tools."],
             "examples": [],
             "concepts": {},
+            "invariants": [],
+            "risk_level": "medium",
+            "feature": "",
         }
     return meta
+
+
+def register_tool_signature(name: str, fn: Callable) -> None:
+    """Merge callable signature details into existing tool metadata."""
+    tool_name = str(name or getattr(fn, "__name__", ""))
+    if not tool_name:
+        return
+    meta = get_tool_metadata(tool_name)
+    signature = _callable_signature_schema(fn)
+    existing_params = meta.get("parameters") or {}
+    if existing_params:
+        merged_params = dict(existing_params)
+        for key, value in signature.get("properties", {}).items():
+            merged_params.setdefault(key, value)
+    else:
+        merged_params = signature.get("properties", {})
+    meta["parameters"] = merged_params
+    meta["required_parameters"] = signature.get("required", [])
+    meta["signature"] = signature.get("signature", "")
+    meta.setdefault("returns", signature.get("returns", {}))
+    if not meta.get("returns"):
+        meta["returns"] = signature.get("returns", {})
+    doc = inspect.getdoc(fn) or ""
+    meta["doc"] = doc or meta.get("doc", "")
+    if doc and (not meta.get("summary") or str(meta.get("summary", "")).startswith("No detailed")):
+        meta["summary"] = doc.splitlines()[0].strip()
+    if not meta.get("examples"):
+        meta["examples"] = [{
+            "description": f"Minimal argument payload for {tool_name}. Replace placeholders before calling.",
+            "arguments": _example_arguments(signature.get("properties", {}), signature.get("required", [])),
+        }]
+    _TOOL_METADATA[tool_name] = meta
+
+
+def _callable_signature_schema(fn: Callable) -> dict[str, Any]:
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return {"properties": {}, "required": [], "signature": "(...)"}
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for name, param in sig.parameters.items():
+        if name.startswith("_"):
+            continue
+        item: dict[str, Any] = {
+            "kind": str(param.kind).replace("Parameter.", ""),
+            "annotation": _annotation_name(param.annotation),
+        }
+        if param.default is inspect._empty:
+            required.append(name)
+        else:
+            item["default"] = _jsonable_default(param.default)
+        properties[name] = item
+    return {
+        "properties": properties,
+        "required": required,
+        "signature": str(sig),
+        "returns": {
+            "annotation": _annotation_name(sig.return_annotation),
+            "envelope": "MCP tools return {'ok': true, 'data': ...} on success or {'ok': false, 'error': ...} on failure.",
+        },
+    }
+
+
+def _annotation_name(annotation: Any) -> str:
+    if annotation is inspect._empty:
+        return "Any"
+    return str(annotation).replace("typing.", "")
+
+
+def _jsonable_default(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if isinstance(value, dict):
+        return dict(value)
+    return repr(value)
+
+
+def _example_arguments(properties: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    args: dict[str, Any] = {}
+    for name, schema in properties.items():
+        if name not in required and "default" in schema:
+            args[name] = schema["default"]
+            continue
+        args[name] = _placeholder_for_annotation(str(schema.get("annotation", "Any")), name)
+    return args
+
+
+def _placeholder_for_annotation(annotation: str, name: str) -> Any:
+    lowered = annotation.lower()
+    if "bool" in lowered:
+        return False
+    if "int" in lowered:
+        return 0
+    if "float" in lowered:
+        return 0.0
+    if "list" in lowered:
+        return []
+    if "dict" in lowered:
+        return {}
+    if "str" in lowered:
+        return f"<{name}>"
+    return None
+
+
+def _default_tool_category(name: str) -> str:
+    prefix = str(name).split(".", 1)[0]
+    return {
+        "mcp": "foundation/discovery",
+        "engine": "foundation/concepts",
+        "workflow": "foundation/workflows",
+        "project": "project/info",
+        "project_tools": "project/tools",
+        "transaction": "project/transactions",
+        "asset": "assets/files",
+        "editor": "editor/state",
+        "runtime": "runtime/observation",
+        "console": "runtime/console",
+        "scene": "scene/query",
+        "gameobject": "scene/object",
+        "hierarchy": "scene/create",
+        "transform": "scene/transform",
+        "component": "scene/component",
+        "camera": "camera/framing",
+        "lighting": "scene/lighting",
+        "ui": "ui/screen",
+        "material": "assets/materials",
+        "renderstack": "renderstack/pipeline",
+    }.get(prefix, "misc/other")
+
+
+def _normalized_string_list(values: list[str] | None) -> list[str]:
+    if not values:
+        return []
+    return [str(value) for value in values if str(value)]
 
 
 def list_tool_metadata() -> list[dict[str, Any]]:
@@ -109,41 +317,330 @@ def fail(
     return payload
 
 
-def main_thread(name: str, fn, *, timeout_ms: int = 30000, explain: dict[str, Any] | None = None) -> dict[str, Any]:
+def main_thread(
+    name: str,
+    fn,
+    *,
+    timeout_ms: int = 30000,
+    explain: dict[str, Any] | None = None,
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     response_explain = explain or explain_for(name)
+    timeout_ms = _configured_timeout_ms(timeout_ms)
     started = time.monotonic()
+    guard_failure = _scene_guard_failure(name, response_explain)
+    if guard_failure is not None:
+        _record_trace(name, False, started, guard_failure.get("error", {}).get("message", ""), arguments=arguments, result=guard_failure)
+        return guard_failure
     try:
         result = ok(MainThreadCommandQueue.instance().run_sync(name, fn, timeout_ms=timeout_ms), explain=response_explain)
-        _record_trace(name, True, started)
+        _record_trace(name, True, started, arguments=arguments, result=result)
         return result
     except TimeoutError as exc:
-        _record_trace(name, False, started, str(exc))
-        return fail(
+        result = fail(
             "error.timeout",
             str(exc),
             hint="The editor main thread did not process this command in time. Ensure the editor is not blocked by a modal operation.",
             explain=response_explain,
         )
+        _record_trace(name, False, started, str(exc), arguments=arguments, result=result)
+        return result
     except ValueError as exc:
-        _record_trace(name, False, started, str(exc))
-        return fail("error.invalid_argument", str(exc), hint="Check parameter schema with mcp.help or component.describe_type.", explain=response_explain)
+        result = fail("error.invalid_argument", str(exc), hint="Check parameter schema with mcp.help or component.describe_type.", explain=response_explain)
+        _record_trace(name, False, started, str(exc), arguments=arguments, result=result)
+        return result
     except FileExistsError as exc:
-        _record_trace(name, False, started, str(exc))
-        return fail("error.exists", str(exc), hint="Use overwrite=true or choose a different path/name.", explain=response_explain)
+        result = fail("error.exists", str(exc), hint="Treat existing folders as reusable. Use asset.ensure_folder, asset.list, or overwrite=true for files when appropriate.", explain=response_explain)
+        _record_trace(name, False, started, str(exc), arguments=arguments, result=result)
+        return result
     except FileNotFoundError as exc:
-        _record_trace(name, False, started, str(exc))
-        return fail("error.not_found", str(exc), hint="Use scene.inspect, gameobject.find, or asset.search to locate valid targets.", explain=response_explain)
+        result = fail("error.not_found", str(exc), hint="Use scene.inspect, gameobject.find, or asset.search to locate valid targets.", explain=response_explain)
+        _record_trace(name, False, started, str(exc), arguments=arguments, result=result)
+        return result
+    except KnowledgeTokenError as exc:
+        result = fail(
+            "error.knowledge_token_required",
+            str(exc),
+            hint=f"Call {exc.required_tool} to obtain a fresh knowledge token, then retry with knowledge_token=<token>.",
+            explain={
+                **response_explain,
+                "recovery": [
+                    f"Call {exc.required_tool} and read the returned guide.",
+                    "Copy data.knowledge_lock.token from the guide response.",
+                    "Retry this tool with knowledge_token set to that token.",
+                ],
+                "next_suggested_tools": [exc.required_tool, "api.search", "mcp.catalog.search"],
+            },
+        )
+        result["data"] = {
+            "scope": exc.scope,
+            "provided_token": exc.provided,
+            "required_tool": exc.required_tool,
+        }
+        _record_trace(name, False, started, str(exc), arguments=arguments, result=result)
+        return result
     except Exception as exc:
-        _record_trace(name, False, started, str(exc))
-        return fail("error.internal", str(exc), hint="Read console.read and retry with a smaller operation.", explain=response_explain)
+        result = fail("error.internal", str(exc), hint="Read console.read and retry with a smaller operation.", explain=response_explain)
+        _record_trace(name, False, started, str(exc), arguments=arguments, result=result)
+        return result
 
 
-def _record_trace(name: str, ok_flag: bool, started: float, error: str = "") -> None:
+def _record_trace(
+    name: str,
+    ok_flag: bool,
+    started: float,
+    error: str = "",
+    arguments: dict[str, Any] | None = None,
+    result: Any = None,
+) -> None:
     try:
-        from Infernux.mcp.project_tools.trace import record_tool_call
-        record_tool_call(name, ok=ok_flag, elapsed_ms=(time.monotonic() - started) * 1000.0, error=error)
+        from Infernux.mcp.capabilities import feature_enabled
+        from Infernux.mcp.project_tools.trace import record_tool_call, record_tool_result
+        elapsed_ms = (time.monotonic() - started) * 1000.0
+        if feature_enabled("trace_recorder"):
+            record_tool_call(name, ok=ok_flag, elapsed_ms=elapsed_ms, arguments=arguments, result=result, error=error)
+        else:
+            record_tool_result(name, ok=ok_flag, elapsed_ms=elapsed_ms, arguments=arguments, result=result, error=error)
     except Exception:
         pass
+
+
+def _configured_timeout_ms(default: int) -> int:
+    try:
+        from Infernux.mcp.capabilities import limit
+        return int(limit("main_thread_timeout_ms", default) or default)
+    except Exception:
+        return int(default)
+
+
+def _scene_guard_failure(name: str, explain: dict[str, Any]) -> dict[str, Any] | None:
+    try:
+        from Infernux.engine.scene_manager import SceneFileManager
+        sfm = SceneFileManager.instance()
+    except Exception:
+        return None
+    if sfm is None:
+        return None
+    status = scene_status()
+    if name in {"scene.open", "scene.new", "scene.save"}:
+        if status["play_state"] != "edit":
+            return _state_guard_fail(
+                "error.play_mode_active",
+                f"{name} is not allowed while Play Mode is active. Stop Play Mode first.",
+                status,
+                explain,
+                next_tools=["editor.stop", "runtime.wait", "scene.status"],
+            )
+        if status["loading"]:
+            return _state_guard_fail(
+                "error.scene_loading",
+                f"{name} is not allowed while a scene load/new operation is pending.",
+                status,
+                explain,
+                next_tools=["runtime.wait", "scene.status"],
+            )
+    if name in {"scene.open", "scene.new"} and status["dirty"]:
+        return _state_guard_fail(
+            "error.scene_dirty",
+            "The active scene has unsaved changes. Save it before switching scenes.",
+            status,
+            explain,
+            next_tools=["scene.save", "scene.status"],
+        )
+    if _is_edit_mode_mutation(name):
+        if status["play_state"] != "edit":
+            return _state_guard_fail(
+                "error.play_mode_active",
+                f"{name} mutates the editor scene and is not allowed while Play Mode is active.",
+                status,
+                explain,
+                next_tools=["editor.stop", "runtime.wait", "scene.status"],
+            )
+        if status["loading"]:
+            return _state_guard_fail(
+                "error.scene_loading",
+                f"{name} mutates the editor scene and is not allowed while a scene load/new operation is pending.",
+                status,
+                explain,
+                next_tools=["runtime.wait", "scene.status"],
+            )
+    if _requires_saved_scene_file(name) and not status["path"]:
+        return _state_guard_fail(
+            "error.scene_unsaved",
+            "The active scene has not been saved to a .scene file yet. Save it before mutating the scene through MCP.",
+            status,
+            explain,
+            next_tools=["scene.save", "scene.status"],
+        )
+    return None
+
+
+def _state_guard_fail(
+    code: str,
+    message: str,
+    status: dict[str, Any],
+    explain: dict[str, Any],
+    *,
+    next_tools: list[str],
+) -> dict[str, Any]:
+    result = fail(
+        code,
+        message,
+        hint="Inspect data.status and call the suggested next tools before retrying.",
+        explain={
+            **explain,
+            "recovery": [
+                "Call scene.status to inspect the active scene path and dirty flag.",
+                "If the scene is unsaved, call scene.save with data.suggested_save_path or another path under Assets/.",
+                "If Play Mode is active, call editor.stop before editor-scene mutations.",
+                "If scene loading is pending, wait before retrying.",
+                "Retry the original MCP operation after the save succeeds.",
+            ],
+            "next_suggested_tools": next_tools,
+        },
+    )
+    result["data"] = {"status": status, **status}
+    return result
+
+
+def _is_edit_mode_mutation(name: str) -> bool:
+    return _requires_saved_scene_file(name) or name in {"scene.open", "scene.new", "scene.save"}
+
+
+def _requires_saved_scene_file(name: str) -> bool:
+    exact = {
+        "hierarchy.create_object",
+        "gameobject.add_component",
+        "gameobject.delete",
+        "gameobject.batch_delete",
+        "gameobject.batch_create",
+        "gameobject.duplicate",
+        "gameobject.set",
+        "gameobject.set_parent",
+        "gameobject.set_sibling_index",
+        "gameobject.ensure_path",
+        "gameobject.clone_from_json",
+        "gameobject.set_tag_layer",
+        "transform.set",
+        "component.ensure",
+        "component.set_field",
+        "component.set_fields",
+        "component.remove",
+        "component.restore_snapshot",
+        "camera.ensure_main",
+        "camera.set_main",
+        "camera.attach_to_target",
+        "camera.setup_third_person",
+        "camera.setup_2d_card_game",
+        "camera.frame_targets",
+        "camera.look_at",
+        "lighting.ensure_default",
+        "renderstack.find_or_create",
+        "renderstack.set_pipeline",
+        "renderstack.add_pass",
+        "renderstack.remove_pass",
+        "renderstack.set_pass_enabled",
+        "renderstack.set_pass_params",
+    }
+    if name in exact:
+        return True
+    return name.startswith("ui.") and name not in {"ui.inspect", "ui.find_by_text"}
+
+
+def scene_status() -> dict[str, Any]:
+    path = ""
+    dirty = False
+    loading = False
+    scene_name = ""
+    suggested = ""
+    play_state = "edit"
+    try:
+        from Infernux.engine.scene_manager import SceneFileManager
+        sfm = SceneFileManager.instance()
+        if sfm is not None:
+            path = str(getattr(sfm, "current_scene_path", "") or "")
+            dirty = bool(getattr(sfm, "is_dirty", False))
+            loading = bool(getattr(sfm, "is_loading", False))
+            if not path:
+                default_path = getattr(sfm, "_default_scene_save_path", lambda: None)()
+                suggested = _project_rel(default_path) if default_path else ""
+        try:
+            from Infernux.engine.play_mode import PlayModeManager
+            pmm = PlayModeManager.instance()
+            play_state = getattr(getattr(pmm, "state", None), "name", "edit").lower() if pmm else "edit"
+        except Exception:
+            play_state = "edit"
+    except Exception:
+        pass
+    try:
+        from Infernux.lib import SceneManager
+        scene = SceneManager.instance().get_active_scene()
+        scene_name = str(getattr(scene, "name", "") if scene else "")
+    except Exception:
+        pass
+    return {
+        "scene": scene_name,
+        "path": _project_rel(path) if path else "",
+        "absolute_path": path,
+        "dirty": dirty,
+        "loading": loading,
+        "play_state": play_state,
+        "saved_to_file": bool(path),
+        "suggested_save_path": suggested,
+        "requires_save_before_mcp_mutation": not bool(path),
+    }
+
+
+def ensure_not_active_scene_file(project_path: str, file_path: str, operation: str) -> None:
+    """Prevent generic asset tools from editing scene files outside scene APIs."""
+    target = os.path.abspath(file_path)
+    if _path_is_or_contains_scene_file(target):
+        raise ValueError(
+            f"Refusing to {operation} .scene files through generic asset tools. "
+            "Use scene.save for the active scene, scene.open to switch scenes, or close the scene before file-level scene maintenance."
+        )
+    try:
+        from Infernux.engine.scene_manager import SceneFileManager
+        sfm = SceneFileManager.instance()
+        active = os.path.abspath(str(getattr(sfm, "current_scene_path", "") or "")) if sfm else ""
+    except Exception:
+        active = ""
+    if not active:
+        return
+    is_active_scene = target == active
+    contains_active_scene = os.path.isdir(target) and os.path.commonpath([target, active]) == target
+    if is_active_scene or contains_active_scene:
+        raise ValueError(
+            f"Refusing to {operation} the active scene file through generic asset tools. "
+            "Use scene.save for the active scene, or save/close the scene before replacing its file."
+        )
+
+
+def _path_is_or_contains_scene_file(path: str) -> bool:
+    if path.lower().endswith(".scene"):
+        return True
+    if os.path.isdir(path):
+        try:
+            for base, dirs, files in os.walk(path):
+                dirs[:] = [d for d in dirs if d not in {".git", "__pycache__"}]
+                if any(name.lower().endswith(".scene") for name in files):
+                    return True
+        except Exception:
+            return False
+    return False
+
+
+def _project_rel(path: str | None) -> str:
+    if not path:
+        return ""
+    try:
+        from Infernux.engine.project_context import get_project_root
+        root = get_project_root()
+        if root:
+            return os.path.relpath(os.path.abspath(path), os.path.abspath(root)).replace("\\", "/")
+    except Exception:
+        pass
+    return str(path)
 
 
 def register_and_tool(mcp, name: str, **metadata: Any) -> Callable:
@@ -223,6 +720,18 @@ def notify_asset_changed(path: str, action: str = "modified") -> None:
                 return
             except Exception:
                 pass
+
+
+def track_project_path_before_change(project_path: str, path: str, operation: str = "modify") -> None:
+    """Record a best-effort transaction snapshot before mutating a project path."""
+    try:
+        from Infernux.mcp.capabilities import feature_enabled
+        if not feature_enabled("transactions"):
+            return
+        from Infernux.mcp.project_tools.transactions import record_path_before_change
+        record_path_before_change(project_path, path, operation=operation)
+    except Exception:
+        pass
 
 
 def serialize_vector(value) -> Any:

--- a/python/Infernux/mcp/tools/docs.py
+++ b/python/Infernux/mcp/tools/docs.py
@@ -6,7 +6,7 @@ import json
 import urllib.request
 from typing import Any
 
-from Infernux.mcp import server
+from Infernux.mcp import capabilities, server
 from Infernux.mcp.threading import MainThreadCommandQueue
 from Infernux.mcp.tools.common import (
     MCP_PROTOCOL_VERSION,
@@ -72,7 +72,7 @@ CONCEPTS: dict[str, dict[str, Any]] = {
     "AssetDatabase": {
         "summary": "Tracks Assets/ files and maps project paths to GUIDs.",
         "notes": [
-            "Generated files should stay under Assets/Generated/<GameName>/ when possible.",
+            "Generated or agent-authored files should follow the user's requested path or the existing project/module structure.",
             "Call asset.refresh after external writes if the editor does not auto-import immediately.",
         ],
         "tools": ["asset.list", "asset.search", "asset.resolve", "asset.refresh"],
@@ -142,7 +142,7 @@ WORKFLOWS: dict[str, dict[str, Any]] = {
     "card_game_shell": {
         "summary": "Create folders, scripts, JSON data, orthographic camera, and UI roots for a Balatro-style prototype.",
         "steps": [
-            "Create Assets/Generated/<GameName>/Scripts, Data, Materials, Scenes.",
+            "Create project folders under the user-requested feature/module path, such as Assets/<FeatureName>/Scripts, Data, Materials, Scenes.",
             "Write data model and controller scripts.",
             "Use camera.setup_2d_card_game.",
             "Create UI Canvas hierarchy for menu, run screen, hand, shop, and game over.",
@@ -165,7 +165,51 @@ WORKFLOWS: dict[str, dict[str, Any]] = {
 }
 
 
-def register_docs_tools(mcp, project_path: str) -> None:
+INTENT_RECOMMENDATIONS: dict[str, dict[str, Any]] = {
+    "camera_frame_subject": {
+        "match": ["camera", "frame", "view", "visible", "subject", "target", "照全", "相机", "主体", "看不全"],
+        "summary": "Diagnose the main camera view and frame likely subject objects.",
+        "tools": [
+            "mcp.catalog.search",
+            "scene.query.summary",
+            "scene.query.subjects",
+            "camera.find_main",
+            "camera.visibility_report",
+            "camera.frame_targets",
+        ],
+    },
+    "find_scene_objects": {
+        "match": ["find", "query", "object", "name", "component", "gameobject", "查找", "物体", "名字"],
+        "summary": "Find GameObjects by name, path, component, tag, layer, or activity.",
+        "tools": ["scene.query.objects", "gameobject.get", "gameobject.describe_spatial"],
+    },
+    "renderstack_postprocess": {
+        "match": ["renderstack", "render stack", "postprocess", "bloom", "pipeline", "渲染", "后处理"],
+        "summary": "Inspect and edit the scene RenderStack pipeline and effects.",
+        "tools": [
+            "renderstack.find_or_create",
+            "renderstack.inspect",
+            "renderstack.list_pipelines",
+            "renderstack.list_passes",
+            "renderstack.add_pass",
+            "renderstack.set_pass_params",
+        ],
+    },
+    "shader_authoring": {
+        "match": ["shader", "glsl", "material", "fragment", "vertex", "shadingmodel", "着色器", "材质"],
+        "summary": "Discover shader architecture, annotations, property declarations, and material binding rules.",
+        "tools": ["shader.guide", "shader.catalog", "shader.describe", "api.get", "material.create", "asset.create_builtin_resource"],
+    },
+    "audio_authoring": {
+        "match": ["audio", "sound", "music", "sfx", "listener", "audiosource", "audioclip", "音频", "声音"],
+        "summary": "Understand AudioSource multi-track playback, AudioClip loading, and AudioListener placement.",
+        "tools": ["audio.guide", "api.get", "component.describe_type", "gameobject.add_component"],
+    },
+}
+
+
+def register_docs_tools(mcp, project_path: str, config: dict[str, Any] | None = None) -> None:
+    config = config or capabilities.current_config()
     _register_metadata()
 
     @mcp.tool(name="mcp.ping")
@@ -204,19 +248,37 @@ def register_docs_tools(mcp, project_path: str) -> None:
     def mcp_capabilities() -> dict:
         """Return high-level capability groups and known tool names."""
         return ok({
+            "agent_guidance": [
+                "Infernux APIs are new and engine-specific. Do not guess unfamiliar Python, component, shader, audio, or UI APIs.",
+                "Use api.search(query) and api.get(name) for Python/stub-backed APIs before writing scripts.",
+                "Use component.describe_type(component_type) before mutating component fields.",
+                "Use shader.guide, shader.catalog, and shader.describe before creating or binding shaders.",
+                "Some write tools require a knowledge_token from the matching guide, e.g. shader.guide, audio.guide, or api.get('ui').",
+                "Use mcp.catalog.search or mcp.catalog.recommend before selecting MCP tools.",
+            ],
+            "catalog": _catalog_tree(),
             "groups": {
-                "foundation": ["mcp.ping", "mcp.version", "mcp.discovery", "mcp.health", "mcp.help"],
+                "foundation": ["mcp.ping", "mcp.version", "mcp.discovery", "mcp.health", "mcp.help", "mcp.catalog.list"],
+                "api": ["api.subsystems", "api.search", "api.get", "shader.guide", "audio.guide"],
+                "shader": ["shader.guide", "shader.catalog", "shader.describe"],
+                "audio": ["audio.guide", "component.describe_type"],
                 "self_description": ["engine.concepts", "engine.concept.get", "workflow.list", "workflow.help"],
-                "scene": ["scene.inspect", "scene.get_hierarchy", "scene.save", "scene.open", "scene.new"],
-                "gameobject": ["hierarchy.create_object", "gameobject.find", "gameobject.get", "gameobject.set_parent"],
+                "scene": ["scene.status", "scene.inspect", "scene.get_hierarchy", "scene.query.summary", "scene.query.objects"],
+                "scene_lifecycle": ["scene.save", "scene.open", "scene.new"],
+                "gameobject": ["hierarchy.create_object", "gameobject.find", "gameobject.get", "gameobject.describe_spatial"],
                 "component": ["component.list_types", "component.describe_type", "component.set_field"],
-                "asset": ["asset.list", "asset.search", "asset.read_text", "asset.write_text", "asset.refresh"],
-                "camera": ["camera.find_main", "camera.ensure_main", "camera.setup_2d_card_game"],
+                "asset": ["asset.ensure_folder", "asset.list", "asset.search", "asset.read_text", "asset.write_text", "asset.refresh"],
+                "camera": ["camera.find_main", "camera.describe_view", "camera.visibility_report", "camera.frame_targets"],
+                "renderstack": ["renderstack.inspect", "renderstack.list_pipelines", "renderstack.add_pass", "renderstack.set_pass_params"],
                 "runtime": ["editor.play", "runtime.wait", "runtime.run_for", "runtime.read_errors"],
                 "project_tools": ["project_tools.list", "project_tools.reload", "project_tools.validate", "project_tools.audit"],
                 "trace": ["mcp.trace.start", "mcp.trace.stop", "mcp.trace.current", "mcp.trace.list"],
+                "session_log": ["mcp.session_log.info", "mcp.session_log.read", "mcp.session_log.clear"],
+                "transactions": ["transaction.begin", "transaction.status", "transaction.commit", "transaction.rollback"],
+                "research": ["mcp.config.get", "mcp.contracts.list", "mcp.contracts.validate", "mcp.evolution.suggest_tools"],
             },
-            "tools": [meta["name"] for meta in list_tool_metadata()],
+            "tools": [meta["name"] for meta in list_tool_metadata() if capabilities.tool_enabled(meta["name"])],
+            "config": capabilities.current_config(),
         })
 
     @mcp.tool(name="mcp.health")
@@ -256,52 +318,106 @@ def register_docs_tools(mcp, project_path: str) -> None:
     @mcp.tool(name="mcp.list_tools_verbose")
     def mcp_list_tools_verbose() -> dict:
         """Return registered tool metadata."""
-        return ok({"tools": list_tool_metadata()})
+        return ok({"tools": _visible_metadata()})
 
     @mcp.tool(name="mcp.help")
     def mcp_help(tool_name: str = "") -> dict:
         """Return detailed help for one tool or all tool groups."""
         if tool_name:
             return ok({"tool": get_tool_metadata(tool_name)})
-        return ok({"tools": list_tool_metadata(), "workflows": list(WORKFLOWS), "concepts": list(CONCEPTS)})
+        return ok({"tools": _visible_metadata(), "workflows": list(WORKFLOWS), "concepts": list(CONCEPTS)})
 
-    @mcp.tool(name="mcp.batch")
-    def mcp_batch(steps: list[dict[str, Any]], continue_on_error: bool = False) -> dict:
-        """Execute a list of MCP tool calls and return an operation trace.
+    @mcp.tool(name="mcp.catalog.list")
+    def mcp_catalog_list() -> dict:
+        """Return the hierarchical MCP tool catalog."""
+        return ok({
+            "catalog": _catalog_tree(),
+            "categories": _catalog_categories(),
+            "recommend": "Use mcp.catalog.search(query) or mcp.catalog.recommend(intent) before choosing tools.",
+        })
 
-        Each step is {"tool": "...", "arguments": {...}, "label": "..."}.
-        This intentionally goes through the MCP transport so the batch path
-        observes the same envelope and main-thread behavior as external agents.
-        """
-        trace = []
-        client = _NestedMCPClient(server.endpoint_url())
-        for index, step in enumerate(steps or []):
-            tool_name = str(step.get("tool", ""))
-            arguments = step.get("arguments", {}) or {}
-            label = str(step.get("label", "")) or tool_name
-            try:
-                result = client.call(tool_name, arguments)
-                ok_flag = bool(result.get("ok", True)) if isinstance(result, dict) else True
-                trace.append({
-                    "index": index,
-                    "label": label,
-                    "tool": tool_name,
-                    "ok": ok_flag,
-                    "result": result,
+    @mcp.tool(name="mcp.catalog.get")
+    def mcp_catalog_get(category: str = "") -> dict:
+        """Return tools under a category such as camera/framing or scene/query."""
+        needle = str(category or "").strip().lower()
+        tools = []
+        for meta in _visible_metadata():
+            meta_category = str(meta.get("category", ""))
+            lower = meta_category.lower()
+            if not needle or lower == needle or lower.startswith(needle + "/"):
+                tools.append(meta)
+        return ok({"category": category, "tools": tools, "count": len(tools), "categories": _catalog_categories()})
+
+    @mcp.tool(name="mcp.catalog.search")
+    def mcp_catalog_search(query: str, category: str = "", limit: int = 20) -> dict:
+        """Search tools by name, category, summary, tags, aliases, and concepts."""
+        matches = _search_catalog(str(query or ""), category=str(category or ""), limit=int(limit or 20))
+        return ok({"query": query, "category": category, "matches": matches})
+
+    @mcp.tool(name="mcp.catalog.recommend")
+    def mcp_catalog_recommend(intent: str, limit: int = 12) -> dict:
+        """Recommend a tool chain for a natural-language intent."""
+        lowered = str(intent or "").lower()
+        recommendations = []
+        for key, item in INTENT_RECOMMENDATIONS.items():
+            score = sum(1 for token in item.get("match", []) if str(token).lower() in lowered)
+            if score:
+                recommendations.append({
+                    "intent": key,
+                    "score": score,
+                    "summary": item["summary"],
+                    "tools": [get_tool_metadata(tool) for tool in item["tools"] if capabilities.tool_enabled(tool)],
                 })
-                if not ok_flag and not continue_on_error:
-                    break
-            except Exception as exc:
-                trace.append({
-                    "index": index,
-                    "label": label,
-                    "tool": tool_name,
-                    "ok": False,
-                    "error": {"code": "error.batch_step", "message": str(exc)},
-                })
-                if not continue_on_error:
-                    break
-        return ok({"ok": all(item.get("ok") for item in trace), "trace": trace}, trace=trace)
+        recommendations.sort(key=lambda item: item["score"], reverse=True)
+        if not recommendations:
+            recommendations.append({
+                "intent": "catalog_search",
+                "score": 0,
+                "summary": "No intent template matched; use search results as candidates.",
+                "tools": _search_catalog(str(intent or ""), limit=int(limit or 12)),
+            })
+        return ok({"intent": intent, "recommendations": recommendations[: max(int(limit or 12), 1)]})
+
+    if capabilities.feature_enabled("batch_execution"):
+        @mcp.tool(name="mcp.batch")
+        def mcp_batch(steps: list[dict[str, Any]], continue_on_error: bool = False) -> dict:
+            """Execute a list of MCP tool calls and return an operation trace.
+
+            Each step is {"tool": "...", "arguments": {...}, "label": "..."}.
+            This intentionally goes through the MCP transport so the batch path
+            observes the same envelope and main-thread behavior as external agents.
+            """
+            max_steps = int(capabilities.limit("batch_max_steps", 100) or 100)
+            trace = []
+            client = _NestedMCPClient(server.endpoint_url())
+            for index, step in enumerate((steps or [])[:max_steps]):
+                tool_name = str(step.get("tool", ""))
+                arguments = step.get("arguments", {}) or {}
+                label = str(step.get("label", "")) or tool_name
+                try:
+                    result = client.call(tool_name, arguments)
+                    ok_flag = bool(result.get("ok", True)) if isinstance(result, dict) else True
+                    trace.append({
+                        "index": index,
+                        "label": label,
+                        "tool": tool_name,
+                        "ok": ok_flag,
+                        "result": result,
+                    })
+                    if not ok_flag and not continue_on_error:
+                        break
+                except Exception as exc:
+                    trace.append({
+                        "index": index,
+                        "label": label,
+                        "tool": tool_name,
+                        "ok": False,
+                        "error": {"code": "error.batch_step", "message": str(exc)},
+                    })
+                    if not continue_on_error:
+                        break
+            truncated = len(steps or []) > max_steps
+            return ok({"ok": all(item.get("ok") for item in trace), "trace": trace, "truncated": truncated}, trace=trace)
 
     @mcp.tool(name="engine.concepts")
     def engine_concepts() -> dict:
@@ -347,25 +463,174 @@ def _lookup_key(mapping: dict[str, Any], name: str) -> str:
     return ""
 
 
+def _visible_metadata() -> list[dict[str, Any]]:
+    return [meta for meta in list_tool_metadata() if capabilities.tool_enabled(meta["name"])]
+
+
+def _catalog_categories() -> list[dict[str, Any]]:
+    counts: dict[str, int] = {}
+    for meta in _visible_metadata():
+        category = str(meta.get("category", "") or "misc/other")
+        parts = category.split("/")
+        for idx in range(1, len(parts) + 1):
+            key = "/".join(parts[:idx])
+            counts[key] = counts.get(key, 0) + (1 if idx == len(parts) else 0)
+    return [{"category": key, "tool_count": counts[key]} for key in sorted(counts)]
+
+
+def _catalog_tree() -> dict[str, Any]:
+    root: dict[str, Any] = {}
+    for meta in _visible_metadata():
+        category = str(meta.get("category", "") or "misc/other")
+        node = root
+        for part in [p for p in category.split("/") if p]:
+            node = node.setdefault(part, {"tools": {}, "children": {}})["children"]
+        leaf = root
+        for part in [p for p in category.split("/") if p]:
+            leaf = leaf[part]["children"]
+        target = root
+        parts = [p for p in category.split("/") if p]
+        for part in parts[:-1]:
+            target = target[part]["children"]
+        if parts:
+            target[parts[-1]].setdefault("tools", {})[meta["name"]] = {
+                "summary": meta.get("summary", ""),
+                "level": meta.get("level", "semantic"),
+                "tags": meta.get("tags", []),
+                "signature": meta.get("signature", ""),
+                "parameters": meta.get("parameters", {}),
+                "required_parameters": meta.get("required_parameters", []),
+                "returns": meta.get("returns", {}),
+            }
+    return root
+
+
+def _search_catalog(query: str, *, category: str = "", limit: int = 20) -> list[dict[str, Any]]:
+    tokens = [token for token in str(query or "").lower().replace("/", " ").replace(".", " ").split() if token]
+    category = str(category or "").lower().strip()
+    scored = []
+    for meta in _visible_metadata():
+        meta_category = str(meta.get("category", ""))
+        if category and not meta_category.lower().startswith(category):
+            continue
+        haystack_parts = [
+            meta.get("name", ""),
+            meta_category,
+            meta.get("summary", ""),
+            meta.get("doc", ""),
+            meta.get("signature", ""),
+            " ".join(str(key) for key in (meta.get("parameters", {}) or {}).keys()),
+            " ".join(str(value.get("annotation", "")) for value in (meta.get("parameters", {}) or {}).values() if isinstance(value, dict)),
+            " ".join(str(example.get("description", "")) for example in meta.get("examples", []) if isinstance(example, dict)),
+            " ".join(str(item) for item in meta.get("tags", [])),
+            " ".join(str(item) for item in meta.get("aliases", [])),
+            " ".join(str(item) for item in (meta.get("concepts", {}) or {}).keys()),
+        ]
+        haystack = " ".join(str(part).lower() for part in haystack_parts)
+        if not tokens:
+            score = 1
+        else:
+            score = sum(3 if token in str(meta.get("name", "")).lower() else 1 for token in tokens if token in haystack)
+        if score:
+            scored.append((score, meta))
+    scored.sort(key=lambda item: (-item[0], str(item[1].get("name", ""))))
+    return [{**meta, "score": score} for score, meta in scored[: max(int(limit or 20), 1)]]
+
+
+def _self_description_category(name: str) -> str:
+    if name.startswith("mcp.catalog."):
+        return "foundation/catalog"
+    if name.startswith("api."):
+        return "foundation/api"
+    if name.startswith("shader."):
+        return "shader/guide"
+    if name.startswith("audio."):
+        return "audio/guide"
+    return "foundation/discovery"
+
+
+def _self_description_tags(name: str) -> list[str]:
+    if name.startswith("mcp.catalog."):
+        return ["catalog", "discover", "tools"]
+    if name.startswith("api."):
+        return ["api", "script", "docs", "subsystem"]
+    if name.startswith("shader."):
+        return ["shader", "glsl", "material", "docs"]
+    if name.startswith("audio."):
+        return ["audio", "sound", "script", "docs"]
+    return ["self-description", "help"]
+
+
 def _register_metadata() -> None:
     for name, summary in {
         "project.info": "Return current project, active scene, play state, and selection.",
         "editor.get_state": "Return lightweight editor state.",
+        "editor.play": "Enter Play Mode only after the active scene is saved, clean, and not loading.",
+        "editor.stop": "Exit Play Mode; idempotent when already in edit mode.",
+        "editor.step": "Step one frame only while Play Mode is paused.",
+        "scene.status": "Return active scene path, dirty flag, and suggested save path.",
         "scene.inspect": "Return compact active scene summary.",
         "scene.get_hierarchy": "Return active scene hierarchy.",
+        "scene.save": "Save the active scene through SceneFileManager; use this instead of asset tools for .scene files.",
+        "scene.open": "Open a scene file only when not playing, not dirty, and not already loading.",
+        "scene.new": "Create a new empty scene only with force=true and a reason.",
         "hierarchy.create_object": "Create a GameObject using registered HierarchyCreationService kinds.",
         "gameobject.add_component": "Attach a built-in or Python script component to a GameObject.",
         "component.describe_type": "Describe fields and metadata for a component type.",
+        "asset.ensure_folder": "Ensure a project folder exists; succeeds when the folder already exists.",
         "asset.write_text": "Write a UTF-8 project file and notify AssetDatabase.",
         "console.read": "Read recent editor console entries.",
     }.items():
         register_tool_metadata(name, summary=summary)
+    for name in ["scene.save", "scene.open", "scene.new", "editor.play", "editor.step"]:
+        register_tool_metadata(
+            name,
+            summary=get_tool_metadata(name).get("summary", ""),
+            recovery=[
+                "Call scene.status before changing scenes or entering Play Mode.",
+                "If scene.loading is true, wait and retry later.",
+                "If scene.dirty is true, call scene.save before scene.open/scene.new/editor.play.",
+                "Do not use asset.write_text/write_json/patch_text for .scene files.",
+            ],
+            next_suggested_tools=["scene.status", "runtime.wait", "mcp.health"],
+            concepts={"Active Scene": "Only the currently open scene may be edited through MCP scene mutation tools."},
+            side_effects=["May change editor scene state or Play Mode state."],
+        )
     for name in [
         "mcp.ping", "mcp.version", "mcp.discovery", "mcp.capabilities", "mcp.health", "mcp.help", "mcp.batch",
+        "mcp.catalog.list", "mcp.catalog.get", "mcp.catalog.search", "mcp.catalog.recommend",
+        "api.subsystems", "api.get", "api.search", "shader.guide", "shader.catalog", "shader.describe", "audio.guide",
         "engine.concepts", "engine.concept.get", "workflow.list", "workflow.help",
         "workflow.examples",
     ]:
-        register_tool_metadata(name, summary=f"Self-description tool: {name}.")
+        register_tool_metadata(
+            name,
+            summary=f"Self-description tool: {name}.",
+            category=_self_description_category(name),
+            tags=_self_description_tags(name),
+            aliases=["tool menu", "categories", "search tools", "script api", "shader api", "audio api"] if name.startswith(("mcp.catalog.", "api.", "shader.", "audio.")) else [],
+            level="foundation",
+        )
+    for name, summary in {
+        "scene.query.objects": "Search scene objects with semantic filters.",
+        "scene.query.summary": "Return grouped scene semantics for cameras, lights, renderers, UI, scripts, and subjects.",
+        "scene.query.subjects": "Rank likely primary scene subjects.",
+        "gameobject.describe_spatial": "Describe object transform, hierarchy path, components, and approximate bounds.",
+    }.items():
+        register_tool_metadata(
+            name,
+            summary=summary,
+            category="scene/query",
+            tags=["scene", "query", "gameobject", "subject", "bounds"],
+            aliases=["find object", "scene semantics", "主体", "查找物体", "空间信息"],
+            recovery=[
+                "If data.stop_repeating is true, do not call the same query again.",
+                "For fuzzy object lookup, prefer query.name_contains or query.path_contains.",
+                "For exact matching, use query.name_exact or query.path_exact.",
+                "If subjects is empty in a bootstrap scene, create or locate a renderable/gameplay object before camera framing.",
+            ],
+            next_suggested_tools=["camera.visibility_report", "gameobject.get", "component.get"],
+        )
 
 
 class _NestedMCPClient:

--- a/python/Infernux/mcp/tools/editor.py
+++ b/python/Infernux/mcp/tools/editor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from Infernux.mcp.tools.common import main_thread
+from Infernux.mcp.tools.common import main_thread, scene_status
 
 
 def register_editor_tools(mcp) -> None:
@@ -26,6 +26,7 @@ def register_editor_tools(mcp) -> None:
                 "selected_ids": sel.get_ids() if sel else [],
                 "scene_dirty": bool(sfm.is_dirty) if sfm else False,
                 "is_prefab_mode": bool(getattr(sfm, "is_prefab_mode", False)) if sfm else False,
+                "scene_status": scene_status(),
             }
 
         return main_thread("editor.get_state", _read)
@@ -39,7 +40,33 @@ def register_editor_tools(mcp) -> None:
             pmm = PlayModeManager.instance()
             if pmm is None:
                 raise RuntimeError("PlayModeManager is not available.")
-            return {"accepted": bool(pmm.enter_play_mode()), "state": pmm.state.name.lower()}
+            status = scene_status()
+            if status["play_state"] != "edit":
+                raise RuntimeError("Play Mode is already active.")
+            if status["loading"]:
+                raise RuntimeError("Cannot enter Play Mode while scene loading is pending.")
+            try:
+                from Infernux.engine.deferred_task import DeferredTaskRunner
+                runner = DeferredTaskRunner.instance()
+                if runner and runner.is_busy:
+                    raise RuntimeError("Cannot enter Play Mode while a deferred editor task is running.")
+            except RuntimeError:
+                raise
+            except Exception:
+                pass
+            if not status["saved_to_file"]:
+                raise RuntimeError("Cannot enter Play Mode until the active scene is saved. Call scene.save first.")
+            if status["dirty"]:
+                raise RuntimeError("Cannot enter Play Mode while the active scene is dirty. Call scene.save first.")
+            accepted = bool(pmm.enter_play_mode())
+            return {
+                "accepted": accepted,
+                "state": pmm.state.name.lower(),
+                "requested_state": "playing" if accepted else pmm.state.name.lower(),
+                "deferred": bool(accepted),
+                "preflight": status,
+                "next_suggested_tools": ["runtime.wait", "mcp.health", "runtime.read_errors"] if accepted else ["scene.status"],
+            }
 
         return main_thread("editor.play", _play)
 
@@ -52,7 +79,9 @@ def register_editor_tools(mcp) -> None:
             pmm = PlayModeManager.instance()
             if pmm is None:
                 raise RuntimeError("PlayModeManager is not available.")
-            return {"accepted": bool(pmm.exit_play_mode()), "state": pmm.state.name.lower()}
+            if pmm.state.name.lower() == "edit":
+                return {"accepted": True, "already_stopped": True, "state": "edit"}
+            return {"accepted": bool(pmm.exit_play_mode()), "already_stopped": False, "state": pmm.state.name.lower()}
 
         return main_thread("editor.stop", _stop)
 
@@ -65,6 +94,8 @@ def register_editor_tools(mcp) -> None:
             pmm = PlayModeManager.instance()
             if pmm is None:
                 raise RuntimeError("PlayModeManager is not available.")
+            if pmm.state.name.lower() != "playing":
+                raise RuntimeError("editor.pause requires Play Mode to be playing.")
             return {"accepted": bool(pmm.pause()), "state": pmm.state.name.lower()}
 
         return main_thread("editor.pause", _pause)
@@ -78,6 +109,8 @@ def register_editor_tools(mcp) -> None:
             pmm = PlayModeManager.instance()
             if pmm is None:
                 raise RuntimeError("PlayModeManager is not available.")
+            if pmm.state.name.lower() != "paused":
+                raise RuntimeError("editor.resume requires Play Mode to be paused.")
             return {"accepted": bool(pmm.resume()), "state": pmm.state.name.lower()}
 
         return main_thread("editor.resume", _resume)
@@ -91,6 +124,8 @@ def register_editor_tools(mcp) -> None:
             pmm = PlayModeManager.instance()
             if pmm is None:
                 raise RuntimeError("PlayModeManager is not available.")
+            if pmm.state.name.lower() != "paused":
+                raise RuntimeError("editor.step requires paused Play Mode. Call editor.pause after editor.play before stepping.")
             pmm.step_frame()
             return {"state": pmm.state.name.lower()}
 
@@ -112,4 +147,4 @@ def register_editor_tools(mcp) -> None:
                 sel.clear()
             return {"selected_ids": sel.get_ids()}
 
-        return main_thread("editor.select", _select)
+        return main_thread("editor.select", _select, arguments={"object_ids": object_ids or [], "primary_id": primary_id})

--- a/python/Infernux/mcp/tools/material.py
+++ b/python/Infernux/mcp/tools/material.py
@@ -4,17 +4,31 @@ from __future__ import annotations
 
 from typing import Any
 
-from Infernux.mcp.tools.common import main_thread, notify_asset_changed, register_tool_metadata, resolve_project_path, serialize_value
+from Infernux.mcp.tools.common import (
+    main_thread,
+    notify_asset_changed,
+    register_tool_metadata,
+    require_knowledge_token,
+    resolve_project_path,
+    serialize_value,
+)
 
 
 def register_material_tools(mcp, project_path: str) -> None:
     _register_metadata()
 
     @mcp.tool(name="material.create")
-    def material_create(path: str, template: str = "lit", overwrite: bool = False, properties: dict[str, Any] | None = None) -> dict:
+    def material_create(
+        path: str,
+        template: str = "lit",
+        overwrite: bool = False,
+        properties: dict[str, Any] | None = None,
+        knowledge_token: str = "",
+    ) -> dict:
         """Create a material asset and optionally set properties."""
 
         def _create():
+            require_knowledge_token("shader", knowledge_token, required_tool="shader.guide")
             import os
             from Infernux.core.material import Material
             file_path = resolve_project_path(project_path, path)
@@ -26,9 +40,9 @@ def register_material_tools(mcp, project_path: str) -> None:
             _set_properties(mat, properties or {})
             mat.save(file_path)
             notify_asset_changed(file_path, "created")
-            return {"path": os.path.relpath(file_path, project_path).replace("\\", "/"), "properties": _properties(mat)}
+            return {"path": os.path.relpath(file_path, project_path).replace("\\", "/"), **_material_info(mat)}
 
-        return main_thread("material.create", _create)
+        return main_thread("material.create", _create, arguments={"path": path, "template": template, "overwrite": overwrite, "knowledge_token": knowledge_token})
 
     @mcp.tool(name="material.get_properties")
     def material_get_properties(path: str) -> dict:
@@ -37,24 +51,25 @@ def register_material_tools(mcp, project_path: str) -> None:
         def _get():
             import os
             mat = _load_material(project_path, path)
-            return {"path": os.path.relpath(resolve_project_path(project_path, path), project_path).replace("\\", "/"), "properties": _properties(mat)}
+            return {"path": os.path.relpath(resolve_project_path(project_path, path), project_path).replace("\\", "/"), **_material_info(mat)}
 
         return main_thread("material.get_properties", _get)
 
     @mcp.tool(name="material.set_property")
-    def material_set_property(path: str, name: str, value: Any, value_type: str = "auto") -> dict:
+    def material_set_property(path: str, name: str, value: Any, value_type: str = "auto", knowledge_token: str = "") -> dict:
         """Set one material property."""
 
         def _set():
+            require_knowledge_token("shader", knowledge_token, required_tool="shader.guide")
             file_path = resolve_project_path(project_path, path)
             mat = _load_material(project_path, path)
             _set_one(mat, name, value, value_type)
             mat.flush()
             mat.save(file_path)
             notify_asset_changed(file_path, "modified")
-            return {"path": path, "name": name, "value": serialize_value(mat.get_property(name))}
+            return {"path": path, "name": name, "value": serialize_value(mat.get_property(name)), **_material_info(mat)}
 
-        return main_thread("material.set_property", _set)
+        return main_thread("material.set_property", _set, arguments={"path": path, "name": name, "value_type": value_type, "knowledge_token": knowledge_token})
 
 
 def _load_material(project_path: str, path: str):
@@ -96,10 +111,32 @@ def _properties(mat) -> dict[str, Any]:
         return {}
 
 
+def _material_info(mat) -> dict[str, Any]:
+    return {
+        "name": str(getattr(mat, "name", "")),
+        "shader": {
+            "shader_name": str(getattr(mat, "shader_name", "") or ""),
+            "vertex": str(getattr(mat, "vert_shader_name", "") or ""),
+            "fragment": str(getattr(mat, "frag_shader_name", "") or ""),
+        },
+        "render_queue": int(getattr(mat, "render_queue", 0) or 0),
+        "properties": _properties(mat),
+    }
+
+
 def _register_metadata() -> None:
     for name, summary in {
         "material.create": "Create a material asset.",
-        "material.get_properties": "Read material properties.",
+        "material.get_properties": "Read material shader selection and properties.",
         "material.set_property": "Set a material shader property.",
     }.items():
-        register_tool_metadata(name, summary=summary)
+        register_tool_metadata(
+            name,
+            summary=summary,
+            category="assets/materials",
+            tags=["material", "shader", "properties"],
+            aliases=["shader selection", "fragment shader", "vertex shader", "材质", "着色器属性"],
+            preconditions=["Requires a valid shader knowledge_token from shader.guide or api.get('shader')."],
+            recovery=["Call shader.guide, read the guide, then retry with data.knowledge_lock.token as knowledge_token."],
+            next_suggested_tools=["shader.describe", "shader.catalog", "api.get"],
+        )

--- a/python/Infernux/mcp/tools/project_tools.py
+++ b/python/Infernux/mcp/tools/project_tools.py
@@ -3,7 +3,17 @@
 from __future__ import annotations
 
 from Infernux.mcp.project_tools.registry import get_project_tool_registry
-from Infernux.mcp.project_tools.trace import current_trace, last_trace, list_traces, start_trace, stop_trace
+from Infernux.mcp.project_tools.trace import (
+    clear_session_log,
+    current_trace,
+    last_trace,
+    list_traces,
+    read_session_log,
+    session_log_info,
+    start_trace,
+    stop_trace,
+)
+from Infernux.mcp.capabilities import feature_enabled
 from Infernux.mcp.tools.common import main_thread, ok, register_tool_metadata
 
 
@@ -37,33 +47,52 @@ def register_project_tool_management(mcp, project_path: str) -> None:
         """Return recent project tool load/call audit events."""
         return ok(registry.audit(limit))
 
-    @mcp.tool(name="mcp.trace.start")
-    def mcp_trace_start(task: str = "") -> dict:
-        """Start recording MCP tool call trace metadata."""
-        return ok(start_trace(project_path, task))
+    if feature_enabled("trace_recorder"):
+        @mcp.tool(name="mcp.trace.start")
+        def mcp_trace_start(task: str = "") -> dict:
+            """Start recording MCP tool call trace metadata."""
+            return ok(start_trace(project_path, task))
 
-    @mcp.tool(name="mcp.trace.stop")
-    def mcp_trace_stop(save: bool = True) -> dict:
-        """Stop the active MCP trace and optionally save it to .infernux/mcp_traces."""
-        return ok(stop_trace(project_path, save=save))
+        @mcp.tool(name="mcp.trace.stop")
+        def mcp_trace_stop(save: bool = True) -> dict:
+            """Stop the active MCP trace and optionally save it to .infernux/mcp_traces."""
+            return ok(stop_trace(project_path, save=save))
 
-    @mcp.tool(name="mcp.trace.current")
-    def mcp_trace_current() -> dict:
-        """Return the currently active MCP trace."""
-        return ok(current_trace())
+        @mcp.tool(name="mcp.trace.current")
+        def mcp_trace_current() -> dict:
+            """Return the currently active MCP trace."""
+            return ok(current_trace())
 
-    @mcp.tool(name="mcp.trace.last")
-    def mcp_trace_last() -> dict:
-        """Return the last stopped MCP trace."""
-        return ok(last_trace())
+        @mcp.tool(name="mcp.trace.last")
+        def mcp_trace_last() -> dict:
+            """Return the last stopped MCP trace."""
+            return ok(last_trace())
 
-    @mcp.tool(name="mcp.trace.list")
-    def mcp_trace_list(limit: int = 50) -> dict:
-        """List saved MCP traces."""
-        return ok({"traces": list_traces(project_path, limit=limit)})
+        @mcp.tool(name="mcp.trace.list")
+        def mcp_trace_list(limit: int = 50) -> dict:
+            """List saved MCP trace files."""
+            return ok({"traces": list_traces(project_path, limit=limit)})
+
+    if feature_enabled("session_call_log"):
+        @mcp.tool(name="mcp.session_log.info")
+        def mcp_session_log_info() -> dict:
+            """Return the current per-editor-session MCP call log path and size."""
+            return ok(session_log_info(project_path))
+
+        @mcp.tool(name="mcp.session_log.read")
+        def mcp_session_log_read(limit: int = 200) -> dict:
+            """Read recent MCP calls from the current editor session log."""
+            return ok(read_session_log(project_path, limit=limit))
+
+        @mcp.tool(name="mcp.session_log.clear")
+        def mcp_session_log_clear() -> dict:
+            """Clear the current editor session MCP call log."""
+            return ok(clear_session_log(project_path))
 
 
 def register_project_defined_tools(mcp, project_path: str) -> dict:
+    if not feature_enabled("project_defined_tools"):
+        return {"registered": [], "disabled": True}
     registry = get_project_tool_registry(project_path)
     registry.configure(project_path)
     registry.discover()
@@ -82,6 +111,9 @@ def _register_metadata() -> None:
         "mcp.trace.current": "Return the active MCP trace.",
         "mcp.trace.last": "Return the last stopped MCP trace.",
         "mcp.trace.list": "List saved MCP trace files.",
+        "mcp.session_log.info": "Return current session MCP call log file info.",
+        "mcp.session_log.read": "Read recent current-session MCP call log entries.",
+        "mcp.session_log.clear": "Clear the current-session MCP call log.",
     }.items():
         register_tool_metadata(name, summary=summary)
 

--- a/python/Infernux/mcp/tools/renderstack.py
+++ b/python/Infernux/mcp/tools/renderstack.py
@@ -1,0 +1,363 @@
+"""RenderStack MCP tools for pipeline and post-processing control."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from Infernux.mcp.tools.common import main_thread, register_tool_metadata, serialize_value
+
+
+def register_renderstack_tools(mcp) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="renderstack.find_or_create")
+    def renderstack_find_or_create(name: str = "RenderStack", create_if_missing: bool = True) -> dict:
+        """Find the active RenderStack or create one."""
+
+        def _find_or_create():
+            stack = _find_stack()
+            created = False
+            if stack is None and create_if_missing:
+                from Infernux.engine.hierarchy_creation_service import HierarchyCreationService
+                entry = HierarchyCreationService.instance().create("rendering.render_stack", name=name, select=False)
+                obj = _find_game_object(int(entry["id"]))
+                stack = _find_stack_on_object(obj)
+                created = True
+            if stack is None:
+                raise FileNotFoundError("No RenderStack found and create_if_missing is false.")
+            return {"created": created, "stack": _stack_snapshot(stack)}
+
+        return main_thread("renderstack.find_or_create", _find_or_create, arguments={"name": name, "create_if_missing": create_if_missing})
+
+    @mcp.tool(name="renderstack.inspect")
+    def renderstack_inspect() -> dict:
+        """Inspect the active RenderStack, pipeline, injection points, and mounted passes."""
+
+        def _inspect():
+            stack = _find_stack()
+            if stack is None:
+                return {
+                    "exists": False,
+                    "reason": "no_renderstack_in_active_scene",
+                    "message": "No RenderStack exists in the active scene. Do not repeat renderstack.inspect; call renderstack.find_or_create if rendering stack control is needed.",
+                    "next_suggested_tools": [
+                        {
+                            "tool": "renderstack.find_or_create",
+                            "arguments": {"name": "RenderStack", "create_if_missing": True},
+                        },
+                        {
+                            "tool": "hierarchy.create_object",
+                            "arguments": {"kind": "rendering.render_stack", "name": "RenderStack"},
+                        },
+                    ],
+                }
+            return _stack_snapshot(stack, include_catalog=True)
+
+        return main_thread("renderstack.inspect", _inspect)
+
+    @mcp.tool(name="renderstack.list_pipelines")
+    def renderstack_list_pipelines() -> dict:
+        """List discovered RenderPipeline classes."""
+
+        def _list():
+            from Infernux.renderstack.discovery import discover_pipelines
+            return {"pipelines": [_pipeline_entry(name, cls) for name, cls in sorted(discover_pipelines().items())]}
+
+        return main_thread("renderstack.list_pipelines", _list)
+
+    @mcp.tool(name="renderstack.set_pipeline")
+    def renderstack_set_pipeline(pipeline: str = "") -> dict:
+        """Set the active RenderStack pipeline. Empty string means default forward pipeline."""
+
+        def _set():
+            stack = _require_stack()
+            stack.set_pipeline(str(pipeline or ""))
+            _mark_scene_dirty()
+            return _stack_snapshot(stack)
+
+        return main_thread("renderstack.set_pipeline", _set, arguments={"pipeline": pipeline})
+
+    @mcp.tool(name="renderstack.list_passes")
+    def renderstack_list_passes(include_mounted: bool = True, include_available: bool = True) -> dict:
+        """List mounted and/or available RenderPass effects."""
+
+        def _list():
+            stack = _find_stack()
+            result: dict[str, Any] = {}
+            if include_mounted and stack is not None:
+                result["mounted"] = _mounted_passes(stack)
+                result["injection_points"] = _injection_points(stack)
+            if include_available:
+                result["available"] = _available_passes()
+            return result
+
+        return main_thread("renderstack.list_passes", _list)
+
+    @mcp.tool(name="renderstack.add_pass")
+    def renderstack_add_pass(pass_name: str, enabled: bool = True, params: dict[str, Any] | None = None) -> dict:
+        """Add a discovered RenderPass or FullScreenEffect to the active RenderStack."""
+
+        def _add():
+            stack = _require_stack()
+            cls = _pass_class(pass_name)
+            render_pass = cls(enabled=bool(enabled))
+            if params:
+                _set_pass_params(render_pass, params)
+            added = bool(stack.add_pass(render_pass))
+            if not added:
+                raise ValueError(f"Render pass '{pass_name}' could not be added. It may already be mounted or target an invalid injection point.")
+            _mark_scene_dirty()
+            return _stack_snapshot(stack)
+
+        return main_thread("renderstack.add_pass", _add, arguments={"pass_name": pass_name, "enabled": enabled, "params": params or {}})
+
+    @mcp.tool(name="renderstack.remove_pass")
+    def renderstack_remove_pass(pass_name: str) -> dict:
+        """Remove a mounted pass from the active RenderStack."""
+
+        def _remove():
+            stack = _require_stack()
+            removed = bool(stack.remove_pass(str(pass_name)))
+            if not removed:
+                raise FileNotFoundError(f"Mounted render pass '{pass_name}' was not found.")
+            _mark_scene_dirty()
+            return _stack_snapshot(stack)
+
+        return main_thread("renderstack.remove_pass", _remove, arguments={"pass_name": pass_name})
+
+    @mcp.tool(name="renderstack.set_pass_enabled")
+    def renderstack_set_pass_enabled(pass_name: str, enabled: bool) -> dict:
+        """Enable or disable a mounted pass."""
+
+        def _set_enabled():
+            stack = _require_stack()
+            _require_mounted_pass(stack, pass_name)
+            stack.set_pass_enabled(str(pass_name), bool(enabled))
+            _mark_scene_dirty()
+            return _stack_snapshot(stack)
+
+        return main_thread("renderstack.set_pass_enabled", _set_enabled, arguments={"pass_name": pass_name, "enabled": enabled})
+
+    @mcp.tool(name="renderstack.set_pass_params")
+    def renderstack_set_pass_params(pass_name: str, params: dict[str, Any]) -> dict:
+        """Set serialized parameters on a mounted pass/effect."""
+
+        def _set_params():
+            stack = _require_stack()
+            entry = _require_mounted_pass(stack, pass_name)
+            _set_pass_params(entry.render_pass, params or {})
+            stack.invalidate_graph()
+            _mark_scene_dirty()
+            return _stack_snapshot(stack)
+
+        return main_thread("renderstack.set_pass_params", _set_params, arguments={"pass_name": pass_name, "params": params or {}})
+
+
+def _find_stack():
+    try:
+        from Infernux.renderstack import RenderStack
+        stack = RenderStack.instance()
+        if stack is not None:
+            return stack
+    except Exception:
+        pass
+    try:
+        from Infernux.lib import SceneManager
+        scene = SceneManager.instance().get_active_scene()
+        if not scene:
+            return None
+        for obj in scene.get_all_objects() or []:
+            stack = _find_stack_on_object(obj)
+            if stack is not None:
+                return stack
+    except Exception:
+        return None
+    return None
+
+
+def _require_stack():
+    stack = _find_stack()
+    if stack is None:
+        raise FileNotFoundError("No RenderStack exists in the active scene. Use renderstack.find_or_create.")
+    return stack
+
+
+def _find_stack_on_object(obj):
+    try:
+        from Infernux.renderstack import RenderStack
+        for comp in obj.get_py_components() or []:
+            if isinstance(comp, RenderStack):
+                return comp
+    except Exception:
+        return None
+    return None
+
+
+def _find_game_object(object_id: int):
+    from Infernux.mcp.tools.common import find_game_object
+    return find_game_object(object_id)
+
+
+def _stack_snapshot(stack, *, include_catalog: bool = False) -> dict[str, Any]:
+    go = stack.game_object
+    data = {
+        "object_id": int(go.id),
+        "object_name": str(go.name),
+        "pipeline": str(getattr(stack, "pipeline_class_name", "") or ""),
+        "active": bool(stack is type(stack).instance()),
+        "enabled": bool(getattr(stack, "enabled", True)),
+        "injection_points": _injection_points(stack),
+        "mounted_passes": _mounted_passes(stack),
+        "build_failed": bool(getattr(stack, "_build_failed", False)),
+    }
+    if include_catalog:
+        data["available_pipelines"] = _available_pipelines()
+        data["available_passes"] = _available_passes()
+    return data
+
+
+def _injection_points(stack) -> list[dict[str, Any]]:
+    points = []
+    try:
+        for point in stack.injection_points:
+            points.append({
+                "name": str(getattr(point, "name", "")),
+                "description": str(getattr(point, "description", "")),
+            })
+    except Exception:
+        pass
+    return points
+
+
+def _mounted_passes(stack) -> list[dict[str, Any]]:
+    items = []
+    for entry in list(getattr(stack, "pass_entries", []) or []):
+        render_pass = entry.render_pass
+        items.append({
+            "name": str(getattr(render_pass, "name", "")),
+            "class_name": type(render_pass).__name__,
+            "injection_point": str(getattr(render_pass, "injection_point", "")),
+            "enabled": bool(getattr(entry, "enabled", getattr(render_pass, "enabled", True))),
+            "order": int(getattr(entry, "order", 0) or 0),
+            "params": _pass_params(render_pass),
+        })
+    return items
+
+
+def _available_pipelines() -> list[dict[str, Any]]:
+    from Infernux.renderstack.discovery import discover_pipelines
+    return [_pipeline_entry(name, cls) for name, cls in sorted(discover_pipelines().items())]
+
+
+def _available_passes() -> list[dict[str, Any]]:
+    from Infernux.renderstack.discovery import discover_passes
+    return [_pass_entry(name, cls) for name, cls in sorted(discover_passes().items())]
+
+
+def _pipeline_entry(name: str, cls) -> dict[str, Any]:
+    return {"name": str(name), "class_name": cls.__name__, "module": cls.__module__, "fields": _field_schema(cls)}
+
+
+def _pass_entry(name: str, cls) -> dict[str, Any]:
+    return {
+        "name": str(name),
+        "class_name": cls.__name__,
+        "module": cls.__module__,
+        "injection_point": str(getattr(cls, "injection_point", "")),
+        "default_order": int(getattr(cls, "default_order", 0) or 0),
+        "menu_path": str(getattr(cls, "menu_path", "")),
+        "requires": sorted(str(item) for item in getattr(cls, "requires", set()) or set()),
+        "modifies": sorted(str(item) for item in getattr(cls, "modifies", set()) or set()),
+        "creates": sorted(str(item) for item in getattr(cls, "creates", set()) or set()),
+        "fields": _field_schema(cls),
+    }
+
+
+def _field_schema(cls) -> list[dict[str, Any]]:
+    from Infernux.components.serialized_field import get_serialized_fields
+    fields = []
+    for name, meta in get_serialized_fields(cls).items():
+        fields.append({
+            "name": str(name),
+            "type": getattr(getattr(meta, "field_type", None), "name", str(getattr(meta, "field_type", ""))),
+            "default": serialize_value(getattr(meta, "default", None)),
+            "range": serialize_value(getattr(meta, "range", None)),
+            "tooltip": str(getattr(meta, "tooltip", "")),
+            "readonly": bool(getattr(meta, "readonly", False)),
+        })
+    return fields
+
+
+def _pass_class(pass_name: str):
+    from Infernux.renderstack.discovery import discover_passes
+    passes = discover_passes()
+    if pass_name in passes:
+        return passes[pass_name]
+    lowered = str(pass_name).lower()
+    for name, cls in passes.items():
+        if name.lower() == lowered or cls.__name__.lower() == lowered:
+            return cls
+    raise FileNotFoundError(f"Render pass '{pass_name}' was not found.")
+
+
+def _require_mounted_pass(stack, pass_name: str):
+    lowered = str(pass_name).lower()
+    for entry in list(getattr(stack, "pass_entries", []) or []):
+        render_pass = entry.render_pass
+        if str(getattr(render_pass, "name", "")).lower() == lowered or type(render_pass).__name__.lower() == lowered:
+            return entry
+    raise FileNotFoundError(f"Mounted render pass '{pass_name}' was not found.")
+
+
+def _pass_params(render_pass) -> dict[str, Any]:
+    if hasattr(render_pass, "get_params_dict"):
+        try:
+            return serialize_value(render_pass.get_params_dict())
+        except Exception:
+            return {}
+    return {}
+
+
+def _set_pass_params(render_pass, params: dict[str, Any]) -> None:
+    if hasattr(render_pass, "set_params_dict"):
+        render_pass.set_params_dict(params or {})
+        return
+    for key, value in (params or {}).items():
+        setattr(render_pass, key, value)
+
+
+def _mark_scene_dirty() -> None:
+    try:
+        from Infernux.engine.scene_manager import SceneFileManager
+        sfm = SceneFileManager.instance()
+        if sfm:
+            sfm.mark_dirty()
+    except Exception:
+        pass
+
+
+def _register_metadata() -> None:
+    for name, summary in {
+        "renderstack.find_or_create": "Find or create the active scene RenderStack.",
+        "renderstack.inspect": "Inspect the active RenderStack pipeline and mounted passes.",
+        "renderstack.list_pipelines": "List discovered RenderPipeline classes.",
+        "renderstack.set_pipeline": "Switch the active RenderStack pipeline.",
+        "renderstack.list_passes": "List mounted and available RenderStack passes.",
+        "renderstack.add_pass": "Mount a post-process or render pass on the active RenderStack.",
+        "renderstack.remove_pass": "Remove a mounted RenderStack pass.",
+        "renderstack.set_pass_enabled": "Enable or disable a mounted RenderStack pass.",
+        "renderstack.set_pass_params": "Edit serialized parameters on a mounted RenderStack pass.",
+    }.items():
+        category = "renderstack/pipeline" if "pipeline" in name or name.endswith(("inspect", "find_or_create")) else "renderstack/effects"
+        register_tool_metadata(
+            name,
+            summary=summary,
+            category=category,
+            tags=["renderstack", "rendering", "pipeline", "postprocess"],
+            aliases=["render stack", "post processing", "effects"],
+            recovery=[
+                "If renderstack.inspect returns exists=false, do not repeat it.",
+                "Call renderstack.find_or_create(name='RenderStack', create_if_missing=true) before editing the stack.",
+            ],
+            next_suggested_tools=["renderstack.find_or_create", "renderstack.inspect", "runtime.read_errors"],
+        )

--- a/python/Infernux/mcp/tools/research.py
+++ b/python/Infernux/mcp/tools/research.py
@@ -1,0 +1,243 @@
+"""Research-grade MCP meta-tools: config, contracts, and evolution hints."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from Infernux.mcp import capabilities
+from Infernux.mcp.project_tools.trace import current_trace, last_trace, list_traces
+from Infernux.mcp.tools.common import get_tool_metadata, list_tool_metadata, ok, register_tool_metadata
+
+
+def register_research_tools(mcp, project_path: str) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="mcp.config.get")
+    def mcp_config_get() -> dict:
+        """Return the active configurable MCP capability profile."""
+        return ok({
+            "config": capabilities.current_config(),
+            "config_path": capabilities.config_path(project_path),
+            "restart_required_for_registration_changes": True,
+        })
+
+    @mcp.tool(name="mcp.config.write_default")
+    def mcp_config_write_default() -> dict:
+        """Materialize the default-on MCP capability config file."""
+        path = capabilities.write_default_config(project_path)
+        return ok({"path": _rel(project_path, path), "written_or_existing": bool(path)})
+
+    @mcp.tool(name="mcp.config.set_feature")
+    def mcp_config_set_feature(name: str, enabled: bool, persist: bool = True) -> dict:
+        """Enable or disable one MCP feature flag."""
+        config = capabilities.set_feature(name, enabled)
+        path = capabilities.save_config(config, project_path) if persist else ""
+        return ok({
+            "config": config,
+            "persisted_path": _rel(project_path, path) if path else "",
+            "restart_required_for_registration_changes": True,
+        })
+
+    @mcp.tool(name="mcp.config.set_tool_group")
+    def mcp_config_set_tool_group(name: str, enabled: bool, persist: bool = True) -> dict:
+        """Enable or disable one MCP tool group for the next server registration."""
+        config = capabilities.set_tool_group(name, enabled)
+        path = capabilities.save_config(config, project_path) if persist else ""
+        return ok({
+            "config": config,
+            "persisted_path": _rel(project_path, path) if path else "",
+            "restart_required_for_registration_changes": True,
+        })
+
+    @mcp.tool(name="mcp.config.set_tool")
+    def mcp_config_set_tool(name: str, enabled: bool, persist: bool = True) -> dict:
+        """Enable or disable one specific tool name in config metadata."""
+        config = capabilities.set_tool_enabled(name, enabled)
+        path = capabilities.save_config(config, project_path) if persist else ""
+        return ok({
+            "config": config,
+            "persisted_path": _rel(project_path, path) if path else "",
+            "restart_required_for_registration_changes": True,
+        })
+
+    @mcp.tool(name="mcp.contracts.list")
+    def mcp_contracts_list() -> dict:
+        """Return executable contract metadata for every known tool."""
+        return ok({"contracts": [_contract(meta) for meta in _visible_metadata()]})
+
+    @mcp.tool(name="mcp.contracts.get")
+    def mcp_contracts_get(tool_name: str) -> dict:
+        """Return the executable contract metadata for one tool."""
+        return ok({"contract": _contract(get_tool_metadata(tool_name))})
+
+    @mcp.tool(name="mcp.contracts.validate")
+    def mcp_contracts_validate() -> dict:
+        """Grade tool metadata for self-description and recovery quality."""
+        contracts = [_contract(meta) for meta in _visible_metadata()]
+        threshold = float((capabilities.current_config().get("contracts") or {}).get("grade_threshold", 0.70))
+        failing = [item for item in contracts if item["grade"] < threshold]
+        return ok({
+            "passed": not failing,
+            "threshold": threshold,
+            "tool_count": len(contracts),
+            "failing": failing,
+            "summary": {
+                "average_grade": round(sum(item["grade"] for item in contracts) / max(len(contracts), 1), 3),
+                "missing_recovery": [item["name"] for item in contracts if not item["recovery"]],
+                "missing_side_effects": [item["name"] for item in contracts if _looks_mutating(item["name"]) and not item["side_effects"]],
+            },
+        })
+
+    @mcp.tool(name="mcp.evolution.suggest_tools")
+    def mcp_evolution_suggest_tools(use_last_trace: bool = True, min_sequence_length: int = 3) -> dict:
+        """Suggest project-defined tools from failed or repetitive trace patterns."""
+        if not capabilities.feature_enabled("trace_to_tool_evolution"):
+            return ok({"enabled": False, "suggestions": []})
+        trace = (last_trace().get("trace") if use_last_trace else current_trace().get("trace")) or {}
+        suggestions = _suggest_tools_from_trace(trace, min_sequence_length=min_sequence_length)
+        return ok({
+            "enabled": True,
+            "trace_id": trace.get("trace_id", ""),
+            "suggestions": suggestions,
+            "generated_tool_root": (capabilities.current_config().get("evolution") or {}).get("generated_tool_root", "Assets/AgentTools/generated"),
+            "saved_traces": list_traces(project_path, limit=10),
+        })
+
+    @mcp.tool(name="mcp.research.profile")
+    def mcp_research_profile() -> dict:
+        """Return the research claims this MCP configuration is designed to support."""
+        return ok({
+            "profile": capabilities.current_config().get("profile", "research_full"),
+            "claims": [
+                "Self-describing tools reduce engine-specific hallucinations.",
+                "Executable contracts make long-horizon tool use easier to validate and repair.",
+                "Trace-driven project tools close capability gaps inside the target environment.",
+                "Transactions reduce partial-state damage during multi-step game generation.",
+                "Runtime observation grounds generated games in executable behavior.",
+            ],
+            "recommended_ablations": [
+                "Disable executable_contracts.",
+                "Disable trace_to_tool_evolution.",
+                "Disable transactions.",
+                "Disable runtime_observation.",
+                "Compare low-level tools only vs semantic workflows.",
+            ],
+        })
+
+
+def _contract(meta: dict[str, Any]) -> dict[str, Any]:
+    name = str(meta.get("name", ""))
+    checks = {
+        "has_summary": bool(meta.get("summary")),
+        "has_recovery": bool(meta.get("recovery")),
+        "has_next_tools": bool(meta.get("next_suggested_tools")),
+        "has_concepts": bool(meta.get("concepts")),
+        "has_side_effects_when_mutating": bool(meta.get("side_effects")) if _looks_mutating(name) else True,
+    }
+    grade = sum(1 for value in checks.values() if value) / max(len(checks), 1)
+    return {
+        "name": name,
+        "summary": meta.get("summary", ""),
+        "preconditions": meta.get("preconditions", []),
+        "postconditions": meta.get("postconditions", []),
+        "side_effects": meta.get("side_effects", []),
+        "recovery": meta.get("recovery", []),
+        "next_suggested_tools": meta.get("next_suggested_tools", []),
+        "concepts": meta.get("concepts", {}),
+        "invariants": meta.get("invariants", []),
+        "risk_level": meta.get("risk_level", "medium"),
+        "feature": meta.get("feature", ""),
+        "checks": checks,
+        "grade": round(grade, 3),
+    }
+
+
+def _suggest_tools_from_trace(trace: dict[str, Any], *, min_sequence_length: int) -> list[dict[str, Any]]:
+    steps = trace.get("steps") or []
+    suggestions = []
+    failed = [step for step in steps if not step.get("ok")]
+    if failed:
+        tool_names = sorted({str(step.get("tool", "")) for step in failed if step.get("tool")})
+        suggestions.append({
+            "kind": "failure_recovery_tool",
+            "name": "project.recover_" + "_".join(tool_names[:2]).replace(".", "_"),
+            "summary": "Project-specific recovery helper for repeated MCP failures.",
+            "source_trace": trace.get("trace_id", ""),
+            "evidence": failed[-5:],
+            "template": _tool_template("project.recover_generated_failure", "Recover from failures observed in MCP trace."),
+        })
+    repeated = _find_repeated_sequence([str(step.get("tool", "")) for step in steps], max(int(min_sequence_length), 2))
+    if repeated:
+        suggestions.append({
+            "kind": "workflow_compression_tool",
+            "name": "project.workflow_" + "_then_".join(item.split(".")[-1] for item in repeated[:3]),
+            "summary": "Compress a repeated MCP tool sequence into one project-defined semantic tool.",
+            "source_trace": trace.get("trace_id", ""),
+            "sequence": repeated,
+            "template": _tool_template("project.generated_workflow", "Run a repeated workflow discovered from an MCP trace."),
+        })
+    return suggestions
+
+
+def _find_repeated_sequence(names: list[str], min_len: int) -> list[str]:
+    clean = [name for name in names if name]
+    for width in range(min(8, len(clean) // 2), min_len - 1, -1):
+        seen: dict[tuple[str, ...], int] = {}
+        for index in range(0, len(clean) - width + 1):
+            seq = tuple(clean[index:index + width])
+            seen[seq] = seen.get(seq, 0) + 1
+            if seen[seq] >= 2:
+                return list(seq)
+    return []
+
+
+def _tool_template(name: str, summary: str) -> str:
+    return (
+        "from Infernux.mcp.project_tools import agent_tool\n\n\n"
+        f"@agent_tool(name=\"{name}\", summary=\"{summary}\", generated=True)\n"
+        "def generated_tool() -> dict:\n"
+        "    return {\"ok\": True, \"message\": \"Implement project-specific workflow here.\"}\n"
+    )
+
+
+def _looks_mutating(name: str) -> bool:
+    verbs = (".create", ".write", ".edit", ".delete", ".move", ".rename", ".copy", ".set", ".add", ".remove", ".save", ".open", ".new", ".play", ".stop", ".begin", ".rollback", ".commit")
+    return any(verb in name for verb in verbs)
+
+
+def _visible_metadata() -> list[dict[str, Any]]:
+    return [meta for meta in list_tool_metadata() if capabilities.tool_enabled(meta["name"])]
+
+
+def _rel(project_path: str, path: str) -> str:
+    if not path:
+        return ""
+    try:
+        return os.path.relpath(os.path.abspath(path), os.path.abspath(project_path)).replace("\\", "/")
+    except Exception:
+        return path
+
+
+def _register_metadata() -> None:
+    for name, summary in {
+        "mcp.config.get": "Return active MCP capability toggles.",
+        "mcp.config.write_default": "Write the default-on MCP capability config.",
+        "mcp.config.set_feature": "Toggle one MCP feature flag.",
+        "mcp.config.set_tool_group": "Toggle one MCP tool group.",
+        "mcp.config.set_tool": "Enable or disable one tool by name.",
+        "mcp.contracts.list": "List executable/self-description contracts for tools.",
+        "mcp.contracts.get": "Inspect one tool contract.",
+        "mcp.contracts.validate": "Grade MCP tool contract completeness.",
+        "mcp.evolution.suggest_tools": "Suggest project tools from trace failure/repetition patterns.",
+        "mcp.research.profile": "Return research claims and ablation plan for this MCP layer.",
+    }.items():
+        register_tool_metadata(
+            name,
+            summary=summary,
+            side_effects=["May read or update ProjectSettings/mcp_capabilities.json." if name.startswith("mcp.config.") else "No editor-scene mutation."],
+            recovery=["Use mcp.config.get to inspect current toggles.", "Restart the MCP server after changing registration-level tool groups."],
+            concepts={"MCP Capability": "A feature or tool group that can be enabled or disabled through project config."},
+            next_suggested_tools=["mcp.config.get", "mcp.capabilities"],
+            feature="executable_contracts",
+        )

--- a/python/Infernux/mcp/tools/scene.py
+++ b/python/Infernux/mcp/tools/scene.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from Infernux.mcp.tools.common import (
     coerce_vector3,
     find_game_object,
     main_thread,
+    require_knowledge_token,
     resolve_asset_path,
     serialize_component,
     serialize_value,
     serialize_vector,
+    scene_status,
 )
 
 
@@ -60,11 +63,30 @@ def register_scene_tools(mcp) -> None:
                 save_path = resolve_asset_path(get_project_root(), path)
                 ok = bool(sfm._do_save(save_path))
             else:
-                ok = bool(sfm.save_current_scene())
-                save_path = getattr(sfm, "current_scene_path", "") or ""
-            return {"saved": ok, "path": save_path, "dirty": bool(getattr(sfm, "is_dirty", False))}
+                current_path = getattr(sfm, "current_scene_path", "") or ""
+                if current_path:
+                    save_path = current_path
+                    ok = bool(sfm._do_save(save_path))
+                else:
+                    default_path = getattr(sfm, "_default_scene_save_path", lambda: None)()
+                    if not default_path:
+                        raise RuntimeError("Cannot determine a default scene save path under Assets/.")
+                    save_path = default_path
+                    ok = bool(sfm._do_save(save_path))
+            return {
+                "saved": ok,
+                "path": _project_rel(save_path) if save_path else "",
+                "absolute_path": save_path,
+                "dirty": bool(getattr(sfm, "is_dirty", False)),
+                "status": scene_status(),
+            }
 
-        return main_thread("scene.save", _save)
+        return main_thread("scene.save", _save, arguments={"path": path})
+
+    @mcp.tool(name="scene.status")
+    def scene_status_tool() -> dict:
+        """Return active scene path, dirty state, and suggested save path."""
+        return main_thread("scene.status", scene_status)
 
     @mcp.tool(name="scene.open")
     def scene_open(path: str) -> dict:
@@ -77,13 +99,25 @@ def register_scene_tools(mcp) -> None:
             sfm = SceneFileManager.instance()
             if sfm is None:
                 raise RuntimeError("SceneFileManager is not available.")
+            if getattr(sfm, "is_dirty", False):
+                raise RuntimeError("The active scene is dirty. Call scene.save before scene.open.")
+            current_path = os.path.abspath(str(getattr(sfm, "current_scene_path", "") or ""))
+            if current_path and os.path.abspath(scene_path) == current_path:
+                return {
+                    "accepted": True,
+                    "already_open": True,
+                    "path": _project_rel(scene_path),
+                    "absolute_path": scene_path,
+                    "loading": bool(getattr(sfm, "is_loading", False)),
+                    "status": scene_status(),
+                }
             accepted = bool(sfm.open_scene(scene_path))
-            return {"accepted": accepted, "path": scene_path, "loading": bool(getattr(sfm, "is_loading", False))}
+            return {"accepted": accepted, "already_open": False, "path": _project_rel(scene_path), "absolute_path": scene_path, "loading": bool(getattr(sfm, "is_loading", False))}
 
-        return main_thread("scene.open", _open)
+        return main_thread("scene.open", _open, arguments={"path": path})
 
     @mcp.tool(name="scene.new")
-    def scene_new() -> dict:
+    def scene_new(force: bool = False, reason: str = "") -> dict:
         """Create a new empty scene through SceneFileManager."""
 
         def _new():
@@ -91,10 +125,16 @@ def register_scene_tools(mcp) -> None:
             sfm = SceneFileManager.instance()
             if sfm is None:
                 raise RuntimeError("SceneFileManager is not available.")
+            if not force:
+                raise ValueError("scene.new is destructive. Pass force=true and a short reason to create a new empty scene.")
+            if not reason:
+                raise ValueError("scene.new requires a reason when force=true.")
+            if getattr(sfm, "is_dirty", False):
+                raise RuntimeError("The active scene is dirty. Call scene.save before scene.new.")
             sfm.new_scene()
-            return {"accepted": True, "loading": bool(getattr(sfm, "is_loading", False))}
+            return {"accepted": True, "loading": bool(getattr(sfm, "is_loading", False)), "status": scene_status()}
 
-        return main_thread("scene.new", _new)
+        return main_thread("scene.new", _new, arguments={"force": force, "reason": reason})
 
     @mcp.tool(name="scene.serialize")
     def scene_serialize() -> dict:
@@ -142,6 +182,7 @@ def register_scene_tools(mcp) -> None:
                         })
             return {
                 "scene": getattr(scene, "name", ""),
+                "status": scene_status(),
                 "object_count": len(objects),
                 "root_count": len(roots),
                 "component_counts": component_counts,
@@ -167,10 +208,12 @@ def register_scene_tools(mcp) -> None:
         component_type: str,
         script_path: str = "",
         fields: dict[str, Any] | None = None,
+        knowledge_token: str = "",
     ) -> dict:
         """Add a native, built-in wrapper, registered Python, or script component."""
 
         def _add():
+            _require_component_knowledge(component_type, knowledge_token)
             obj = find_game_object(object_id)
             before_ids = _component_ids(obj)
             is_py = False
@@ -202,7 +245,7 @@ def register_scene_tools(mcp) -> None:
                 "components": _all_components(obj),
             }
 
-        return main_thread("gameobject.add_component", _add)
+        return main_thread("gameobject.add_component", _add, arguments={"object_id": object_id, "component_type": component_type, "knowledge_token": knowledge_token})
 
     @mcp.tool(name="gameobject.get")
     def gameobject_get(object_id: int, depth: int = 1, include_components: bool = True) -> dict:
@@ -323,6 +366,93 @@ def register_scene_tools(mcp) -> None:
             return {"matches": matches}
 
         return main_thread("scene.find", _scene_find)
+
+    @mcp.tool(name="scene.query.objects")
+    def scene_query_objects(query: dict[str, Any] | None = None, limit: int = 50, include_components: bool = True) -> dict:
+        """Semantic GameObject search by name/path/component/tag/layer/active filters."""
+
+        def _query_objects():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            criteria = query or {}
+            matches = []
+            for obj in list(scene.get_all_objects() or []):
+                if not _matches_scene_query(obj, criteria):
+                    continue
+                data = _serialize_object(obj, depth=0, include_components=bool(include_components), include_inactive=True)
+                data["path"] = _object_path(obj)
+                data["spatial"] = _spatial_summary(obj)
+                matches.append(data)
+                if len(matches) >= max(int(limit), 1):
+                    break
+            result = {"query": criteria, "matches": matches, "count": len(matches)}
+            if not matches:
+                result.update(_empty_query_result(criteria, scene))
+            return result
+
+        return main_thread("scene.query.objects", _query_objects, arguments={"query": query or {}, "limit": limit})
+
+    @mcp.tool(name="scene.query.summary")
+    def scene_query_summary(include_subjects: bool = True, subject_limit: int = 8) -> dict:
+        """Return grouped scene semantics: cameras, lights, renderers, UI, scripts, and likely subjects."""
+
+        def _summary():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            objects = list(scene.get_all_objects() or [])
+            groups = _group_scene_objects(objects)
+            return {
+                "scene": getattr(scene, "name", ""),
+                "status": scene_status(),
+                "object_count": len(objects),
+                "groups": groups,
+                "subjects": _rank_subjects(objects, max(int(subject_limit), 1)) if include_subjects else [],
+            }
+
+        return main_thread("scene.query.summary", _summary)
+
+    @mcp.tool(name="scene.query.subjects")
+    def scene_query_subjects(query: dict[str, Any] | None = None, limit: int = 8) -> dict:
+        """Rank likely primary scene subjects for camera framing or gameplay edits."""
+
+        def _subjects():
+            from Infernux.lib import SceneManager
+            scene = SceneManager.instance().get_active_scene()
+            if not scene:
+                raise RuntimeError("No active scene.")
+            objects = [
+                obj
+                for obj in list(scene.get_all_objects() or [])
+                if _matches_scene_query(obj, query or {})
+            ]
+            subjects = _rank_subjects(objects, max(int(limit), 1))
+            result = {"subjects": subjects, "query": query or {}}
+            if not subjects:
+                result.update(_empty_subject_result(objects, query or {}))
+            return result
+
+        return main_thread("scene.query.subjects", _subjects, arguments={"query": query or {}, "limit": limit})
+
+    @mcp.tool(name="gameobject.describe_spatial")
+    def gameobject_describe_spatial(object_id: int, include_descendants: bool = True) -> dict:
+        """Return transform, hierarchy path, components, and approximate bounds."""
+
+        def _describe_spatial():
+            obj = find_game_object(object_id)
+            return {
+                "object_id": int(obj.id),
+                "name": str(obj.name),
+                "path": _object_path(obj),
+                "components": _component_names(obj),
+                "spatial": _spatial_summary(obj, include_descendants=bool(include_descendants)),
+                "children_count": len(list(obj.get_children() or [])),
+            }
+
+        return main_thread("gameobject.describe_spatial", _describe_spatial, arguments={"object_id": object_id})
 
     @mcp.tool(name="gameobject.path")
     def gameobject_path(object_id: int) -> dict:
@@ -590,10 +720,12 @@ def register_scene_tools(mcp) -> None:
         field: str,
         value: Any,
         ordinal: int = 0,
+        knowledge_token: str = "",
     ) -> dict:
         """Set a field/property on a component attached to a GameObject."""
 
         def _set():
+            _require_component_knowledge(component_type, knowledge_token)
             obj = find_game_object(object_id)
             comp = _find_component(obj, component_type, int(ordinal))
             if comp is None:
@@ -609,13 +741,14 @@ def register_scene_tools(mcp) -> None:
                 "value": serialize_value(getattr(comp, field)),
             }
 
-        return main_thread("component.set_field", _set)
+        return main_thread("component.set_field", _set, arguments={"object_id": object_id, "component_type": component_type, "field": field, "knowledge_token": knowledge_token})
 
     @mcp.tool(name="component.set_fields")
-    def component_set_fields(object_id: int, component_type: str, values: dict[str, Any], ordinal: int = 0) -> dict:
+    def component_set_fields(object_id: int, component_type: str, values: dict[str, Any], ordinal: int = 0, knowledge_token: str = "") -> dict:
         """Set multiple fields/properties on a component."""
 
         def _set_fields():
+            _require_component_knowledge(component_type, knowledge_token)
             obj = find_game_object(object_id)
             comp = _find_component(obj, component_type, int(ordinal))
             if comp is None:
@@ -629,7 +762,7 @@ def register_scene_tools(mcp) -> None:
                 changed[field] = serialize_value(getattr(comp, field))
             return {"object_id": int(obj.id), "component": serialize_component(comp), "changed": changed}
 
-        return main_thread("component.set_fields", _set_fields)
+        return main_thread("component.set_fields", _set_fields, arguments={"object_id": object_id, "component_type": component_type, "knowledge_token": knowledge_token})
 
     @mcp.tool(name="component.ensure")
     def component_ensure(
@@ -637,10 +770,12 @@ def register_scene_tools(mcp) -> None:
         component_type: str,
         script_path: str = "",
         fields: dict[str, Any] | None = None,
+        knowledge_token: str = "",
     ) -> dict:
         """Return an existing component or add it if missing."""
 
         def _ensure():
+            _require_component_knowledge(component_type, knowledge_token)
             obj = find_game_object(object_id)
             comp = _find_component(obj, component_type, 0)
             created = False
@@ -666,7 +801,7 @@ def register_scene_tools(mcp) -> None:
                 setattr(comp, key, _coerce_property_value(key, value))
             return {"object_id": int(obj.id), "created": created, "component": serialize_component(comp), "components": _all_components(obj)}
 
-        return main_thread("component.ensure", _ensure)
+        return main_thread("component.ensure", _ensure, arguments={"object_id": object_id, "component_type": component_type, "knowledge_token": knowledge_token})
 
     @mcp.tool(name="component.list_on_object")
     def component_list_on_object(object_id: int) -> dict:
@@ -1038,3 +1173,300 @@ def _component_field_schema(cls) -> list[dict[str, Any]]:
             "component_type": str(getattr(meta, "component_type", "") or ""),
         })
     return fields
+
+
+def _require_component_knowledge(component_type: str, token: str) -> None:
+    type_name = str(component_type or "")
+    audio_types = {"AudioSource", "AudioListener"}
+    ui_types = {"UICanvas", "UIText", "UIButton", "UIImage", "UISelectable", "InxUIScreenComponent", "InxUIComponent"}
+    if type_name in audio_types:
+        require_knowledge_token("audio", token, required_tool="audio.guide")
+    elif type_name in ui_types:
+        require_knowledge_token("ui", token, required_tool="api.get")
+
+
+def _matches_scene_query(obj, criteria: dict[str, Any]) -> bool:
+    criteria = criteria or {}
+    name = str(getattr(obj, "name", ""))
+    path = _object_path(obj)
+    name_l = name.lower()
+    path_l = path.lower()
+    if criteria.get("name_exact") and str(criteria["name_exact"]).lower() != name_l:
+        return False
+    if criteria.get("name") and str(criteria["name"]).lower() not in name_l:
+        return False
+    if criteria.get("name_contains") and str(criteria["name_contains"]).lower() not in name_l:
+        return False
+    if criteria.get("path_exact") and str(criteria["path_exact"]).strip("/").lower() != path.strip("/").lower():
+        return False
+    if criteria.get("path") and str(criteria["path"]).lower() not in path_l:
+        return False
+    if criteria.get("path_contains") and str(criteria["path_contains"]).lower() not in path_l:
+        return False
+    if criteria.get("tag") and str(getattr(obj, "tag", "")) != str(criteria["tag"]):
+        return False
+    if criteria.get("layer") is not None and int(getattr(obj, "layer", -1)) != int(criteria["layer"]):
+        return False
+    if criteria.get("active") is not None and bool(getattr(obj, "active", True)) != bool(criteria["active"]):
+        return False
+
+    names = set(_component_names(obj))
+    component_type = str(criteria.get("component_type", "") or "")
+    if component_type and component_type not in names:
+        return False
+    any_components = {str(item) for item in criteria.get("component_any", []) or []}
+    if any_components and not names.intersection(any_components):
+        return False
+    all_components = {str(item) for item in criteria.get("component_all", []) or []}
+    if all_components and not all_components.issubset(names):
+        return False
+    excluded = {str(item) for item in criteria.get("exclude_component_any", []) or []}
+    if excluded and names.intersection(excluded):
+        return False
+    return True
+
+
+def _empty_query_result(criteria: dict[str, Any], scene) -> dict[str, Any]:
+    return {
+        "reason": "no_objects_matched_query",
+        "stop_repeating": True,
+        "message": "No GameObjects matched this query. Do not repeat the same query; broaden filters or inspect scene.query.summary.",
+        "query_semantics": {
+            "name": "contains match, case-insensitive",
+            "name_contains": "contains match, case-insensitive",
+            "name_exact": "exact match, case-insensitive",
+            "path": "contains match, case-insensitive",
+            "path_contains": "contains match, case-insensitive",
+            "path_exact": "exact hierarchy path, case-insensitive",
+        },
+        "scene_object_count": len(list(scene.get_all_objects() or [])),
+        "recommended_next_tools": [
+            {"tool": "scene.query.summary", "arguments": {"include_subjects": True, "subject_limit": 8}},
+            {"tool": "scene.query.objects", "arguments": {"query": {}, "limit": 20}},
+        ],
+    }
+
+
+def _empty_subject_result(objects: list[Any], criteria: dict[str, Any]) -> dict[str, Any]:
+    groups = _group_scene_objects(objects)
+    service_count = len(groups.get("cameras", [])) + len(groups.get("lights", []))
+    reason = "only_service_objects_present" if objects and service_count == len(objects) else "no_subject_candidates"
+    return {
+        "reason": reason,
+        "stop_repeating": True,
+        "message": (
+            "No likely camera/gameplay subjects were found. Do not repeat scene.query.subjects with the same query. "
+            "If this is a new/bootstrap scene, create or locate a renderable/gameplay object first."
+        ),
+        "scene_contains_only": {
+            "cameras": groups.get("cameras", []),
+            "lights": groups.get("lights", []),
+            "renderers": groups.get("renderers", []),
+            "ui": groups.get("ui", []),
+            "scripts": groups.get("scripts", []),
+        },
+        "recommended_next_tools": [
+            {"tool": "scene.query.summary", "arguments": {"include_subjects": True, "subject_limit": 8}},
+            {"tool": "hierarchy.create_object", "arguments": {"kind": "primitive.cube", "name": "Subject"}},
+            {"tool": "camera.find_main", "arguments": {}},
+        ],
+    }
+
+
+def _group_scene_objects(objects: list[Any]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = {
+        "cameras": [],
+        "lights": [],
+        "renderers": [],
+        "ui": [],
+        "scripts": [],
+        "renderstacks": [],
+        "generated_roots": [],
+    }
+    for obj in objects:
+        names = set(_component_names(obj))
+        entry = _object_index_entry(obj, names)
+        if "Camera" in names:
+            groups["cameras"].append(entry)
+        if "Light" in names:
+            groups["lights"].append(entry)
+        if names.intersection({"MeshRenderer", "SpriteRenderer", "SkinnedMeshRenderer"}):
+            groups["renderers"].append(entry)
+        if names.intersection({"UICanvas", "UIText", "UIButton", "UIImage"}):
+            groups["ui"].append(entry)
+        if "RenderStack" in names:
+            groups["renderstacks"].append(entry)
+        if any(name not in {"Transform", "Camera", "Light", "MeshRenderer", "SpriteRenderer", "SkinnedMeshRenderer", "UICanvas", "UIText", "UIButton", "UIImage", "RenderStack"} for name in names):
+            groups["scripts"].append(entry)
+        if str(getattr(obj, "name", "")).lower().startswith(("mcp", "generated", "runtime")):
+            parent = None
+            try:
+                parent = obj.get_parent()
+            except Exception:
+                parent = None
+            if parent is None:
+                groups["generated_roots"].append(entry)
+    return groups
+
+
+def _rank_subjects(objects: list[Any], limit: int) -> list[dict[str, Any]]:
+    scored = []
+    for obj in objects:
+        score, reasons = _subject_score(obj)
+        if score <= 0:
+            continue
+        names = _component_names(obj)
+        scored.append((
+            score,
+            {
+                **_object_index_entry(obj, set(names)),
+                "score": score,
+                "reasons": reasons,
+                "spatial": _spatial_summary(obj),
+            },
+        ))
+    scored.sort(key=lambda item: (-item[0], str(item[1].get("path", ""))))
+    return [item for _score, item in scored[: max(int(limit), 1)]]
+
+
+def _subject_score(obj) -> tuple[int, list[str]]:
+    names = set(_component_names(obj))
+    object_name = str(getattr(obj, "name", ""))
+    lower = object_name.lower()
+    score = 0
+    reasons: list[str] = []
+    render_components = {"MeshRenderer", "SpriteRenderer", "SkinnedMeshRenderer"}
+    ignored_components = {"Camera", "Light", "UICanvas", "UIText", "UIButton", "UIImage", "RenderStack"}
+    if names.intersection(render_components):
+        score += 6
+        reasons.append("has_renderer")
+    if names and not names.issubset(ignored_components | {"Transform"}):
+        score += 2
+        reasons.append("has_gameplay_or_custom_component")
+    for token, weight in {
+        "player": 5,
+        "hero": 5,
+        "main": 4,
+        "subject": 4,
+        "target": 4,
+        "board": 3,
+        "root": 2,
+        "piece": 2,
+        "ball": 2,
+    }.items():
+        if token in lower:
+            score += weight
+            reasons.append(f"name_contains:{token}")
+    if names.intersection({"Camera", "Light"}) and not names.intersection(render_components):
+        score -= 8
+        reasons.append("non_subject_service_object")
+    return score, reasons
+
+
+def _object_index_entry(obj, component_names: set[str] | None = None) -> dict[str, Any]:
+    return {
+        "id": int(obj.id),
+        "name": str(obj.name),
+        "path": _object_path(obj),
+        "active": bool(getattr(obj, "active", True)),
+        "components": sorted(component_names if component_names is not None else _component_names(obj)),
+    }
+
+
+def _component_names(obj) -> list[str]:
+    names: list[str] = []
+    try:
+        for comp in obj.get_components() or []:
+            names.append(str(getattr(comp, "type_name", type(comp).__name__)))
+    except Exception:
+        pass
+    try:
+        for comp in obj.get_py_components() or []:
+            type_name = str(getattr(comp, "type_name", type(comp).__name__))
+            if type_name not in names:
+                names.append(type_name)
+    except Exception:
+        pass
+    return names
+
+
+def _spatial_summary(obj, *, include_descendants: bool = True) -> dict[str, Any]:
+    points = []
+    for item in _object_and_descendants(obj) if include_descendants else [obj]:
+        points.extend(_approx_object_points(item))
+    if not points:
+        points = [_transform_position(obj)]
+    min_v = [min(point[i] for point in points) for i in range(3)]
+    max_v = [max(point[i] for point in points) for i in range(3)]
+    center = [(min_v[i] + max_v[i]) * 0.5 for i in range(3)]
+    size = [max_v[i] - min_v[i] for i in range(3)]
+    return {
+        "transform": _transform_snapshot(obj),
+        "bounds": {"min": min_v, "max": max_v, "center": center, "size": size},
+    }
+
+
+def _object_and_descendants(obj) -> list[Any]:
+    result = [obj]
+    try:
+        children = list(obj.get_children() or [])
+    except Exception:
+        children = []
+    for child in children:
+        result.extend(_object_and_descendants(child))
+    return result
+
+
+def _approx_object_points(obj) -> list[list[float]]:
+    pos = _transform_position(obj)
+    scale = _transform_scale(obj)
+    half = [max(abs(scale[i]) * 0.5, 0.05) for i in range(3)]
+    names = set(_component_names(obj))
+    if not names.intersection({"MeshRenderer", "SpriteRenderer", "SkinnedMeshRenderer"}):
+        half = [0.05, 0.05, 0.05]
+    return [
+        [pos[0] - half[0], pos[1] - half[1], pos[2] - half[2]],
+        [pos[0] + half[0], pos[1] + half[1], pos[2] + half[2]],
+    ]
+
+
+def _transform_snapshot(obj) -> dict[str, Any]:
+    trans = getattr(obj, "transform", None)
+    if trans is None:
+        return {}
+    return {
+        "position": _vector_list(getattr(trans, "position", None)),
+        "local_position": _vector_list(getattr(trans, "local_position", None)),
+        "euler_angles": _vector_list(getattr(trans, "euler_angles", None)),
+        "local_euler_angles": _vector_list(getattr(trans, "local_euler_angles", None)),
+        "local_scale": _vector_list(getattr(trans, "local_scale", None)),
+    }
+
+
+def _transform_position(obj) -> list[float]:
+    trans = getattr(obj, "transform", None)
+    return _vector_list(getattr(trans, "position", None)) if trans is not None else [0.0, 0.0, 0.0]
+
+
+def _transform_scale(obj) -> list[float]:
+    trans = getattr(obj, "transform", None)
+    return _vector_list(getattr(trans, "local_scale", None), default=[1.0, 1.0, 1.0]) if trans is not None else [1.0, 1.0, 1.0]
+
+
+def _vector_list(value, default: list[float] | None = None) -> list[float]:
+    if value is None:
+        return list(default or [0.0, 0.0, 0.0])
+    return [float(getattr(value, axis, 0.0)) for axis in ("x", "y", "z")]
+
+
+def _project_rel(path: str | None) -> str:
+    if not path:
+        return ""
+    try:
+        from Infernux.engine.project_context import get_project_root
+        root = get_project_root()
+        if root:
+            return os.path.relpath(os.path.abspath(path), os.path.abspath(root)).replace("\\", "/")
+    except Exception:
+        pass
+    return str(path)

--- a/python/Infernux/mcp/tools/transactions.py
+++ b/python/Infernux/mcp/tools/transactions.py
@@ -1,0 +1,48 @@
+"""Transactional MCP tools for long-horizon agent edits."""
+
+from __future__ import annotations
+
+from Infernux.mcp.project_tools import transactions
+from Infernux.mcp.tools.common import ok, register_tool_metadata
+
+
+def register_transaction_tools(mcp, project_path: str) -> None:
+    _register_metadata()
+
+    @mcp.tool(name="transaction.begin")
+    def transaction_begin(label: str = "") -> dict:
+        """Start a best-effort MCP transaction for generated file/asset edits."""
+        return ok(transactions.begin(project_path, label=label))
+
+    @mcp.tool(name="transaction.status")
+    def transaction_status() -> dict:
+        """Return the active or last MCP transaction status."""
+        return ok(transactions.status())
+
+    @mcp.tool(name="transaction.commit")
+    def transaction_commit() -> dict:
+        """Commit the active MCP transaction."""
+        return ok(transactions.commit())
+
+    @mcp.tool(name="transaction.rollback")
+    def transaction_rollback() -> dict:
+        """Rollback tracked file/asset mutations from the active transaction."""
+        return ok(transactions.rollback())
+
+
+def _register_metadata() -> None:
+    metadata = {
+        "transaction.begin": "Start a best-effort transaction for long-horizon MCP mutations.",
+        "transaction.status": "Inspect active/last MCP transaction state.",
+        "transaction.commit": "Accept tracked MCP mutations.",
+        "transaction.rollback": "Restore tracked paths from the active MCP transaction.",
+    }
+    for name, summary in metadata.items():
+        register_tool_metadata(
+            name,
+            summary=summary,
+            side_effects=["Reads or mutates MCP transaction bookkeeping under .infernux/mcp_transactions."],
+            recovery=["Use transaction.status before rollback; use asset.list to inspect generated paths after rollback."],
+            concepts={"MCP Transaction": "A best-effort recovery boundary for multi-step agent edits."},
+            next_suggested_tools=["transaction.status", "mcp.trace.current"],
+        )

--- a/python/Infernux/renderstack/render_stack.pyi
+++ b/python/Infernux/renderstack/render_stack.pyi
@@ -22,7 +22,11 @@ class PassEntry:
 
 
 class RenderStack(InxComponent):
-    """Component that manages a stack of render passes driven by a pipeline."""
+    """Scene singleton component that manages render pipelines and injected passes.
+
+    Runtime class also mixes in render-pass management and pipeline reload
+    behavior; those public methods are mirrored in this stub.
+    """
 
     pipeline_class_name: str
     mounted_passes_json: str
@@ -38,6 +42,9 @@ class RenderStack(InxComponent):
         ...
     def on_destroy(self) -> None:
         """Clean up the render stack when the component is destroyed."""
+        ...
+    def on_inspector_gui(self, ctx: object) -> None:
+        """Render the custom editor inspector for this RenderStack."""
         ...
 
     @staticmethod

--- a/python/Infernux/renderstack/render_stack_pipeline.pyi
+++ b/python/Infernux/renderstack/render_stack_pipeline.pyi
@@ -22,6 +22,7 @@ class RenderStackPipeline(RenderPipeline):
     """
 
     name: ClassVar[str]
+    """Display/internal pipeline name: ``"_RenderStackBridge"``."""
 
     def __init__(self) -> None: ...
     def render(self, context: Any, cameras: Any) -> None: ...

--- a/python/Infernux/ui/__init__.pyi
+++ b/python/Infernux/ui/__init__.pyi
@@ -10,6 +10,8 @@ from .enums import (
     TextAlignV as TextAlignV,
     TextOverflow as TextOverflow,
     TextResizeMode as TextResizeMode,
+    UIScaleMode as UIScaleMode,
+    ScreenMatchMode as ScreenMatchMode,
     UITransitionType as UITransitionType,
 )
 from .inx_ui_component import InxUIComponent as InxUIComponent
@@ -33,6 +35,8 @@ __all__ = [
     "TextAlignV",
     "TextOverflow",
     "TextResizeMode",
+    "UIScaleMode",
+    "ScreenMatchMode",
     "UITransitionType",
     "InxUIComponent",
     "InxUIScreenComponent",

--- a/python/Infernux/ui/enums.pyi
+++ b/python/Infernux/ui/enums.pyi
@@ -61,6 +61,26 @@ class TextResizeMode(IntEnum):
     """Both width and height are fixed."""
 
 
+class UIScaleMode(IntEnum):
+    """How a UICanvas scales UI elements, aligned with Unity CanvasScaler."""
+    ConstantPixelSize = 0
+    """UI elements keep their design pixel size."""
+    ScaleWithScreenSize = 1
+    """Scale elements from reference resolution to current screen size."""
+    ConstantPhysicalSize = 2
+    """Future DPI-aware physical sizing; currently behaves like constant pixels."""
+
+
+class ScreenMatchMode(IntEnum):
+    """How ScaleWithScreenSize chooses width/height scale."""
+    MatchWidthOrHeight = 0
+    """Blend between width and height using match_width_or_height."""
+    Expand = 1
+    """Scale so the canvas expands and nothing is cropped."""
+    Shrink = 2
+    """Scale so the canvas shrinks and everything fits."""
+
+
 class UITransitionType(IntEnum):
     """Visual transition type for interactive elements (UISelectable)."""
     ColorTint = 0

--- a/python/Infernux/ui/inx_ui_screen_component.pyi
+++ b/python/Infernux/ui/inx_ui_screen_component.pyi
@@ -200,9 +200,11 @@ class InxUIScreenComponent(InxUIComponent):
         self,
         px: float, py: float,
         canvas_width: float, canvas_height: float,
+        tolerance: float = ...,
     ) -> bool:
         """Test whether canvas-space point ``(px, py)`` lies inside this element.
 
         Uses the oriented (rotated) bounding box for accurate hit-testing.
+        ``tolerance`` expands the hit area in canvas pixels.
         """
         ...

--- a/python/Infernux/ui/ui_button.pyi
+++ b/python/Infernux/ui/ui_button.pyi
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import List
+
 from Infernux.ui.enums import TextAlignH, TextAlignV
 from Infernux.ui.ui_selectable import UISelectable
 from Infernux.ui.ui_event import UIEvent
+from Infernux.ui.ui_event_entry import UIEventEntry
 from Infernux.ui.ui_event_data import PointerEventData
 
 
@@ -51,7 +54,7 @@ class UIButton(UISelectable):
     letter_spacing: float
     texture_path: str
     background_color: list
-    on_click_entries: list
+    on_click_entries: List[UIEventEntry]
 
     def awake(self) -> None: ...
 

--- a/python/Infernux/ui/ui_canvas.pyi
+++ b/python/Infernux/ui/ui_canvas.pyi
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Iterator, List, Optional
+from typing import Iterator, List, Optional, Tuple
 
 from Infernux.ui.inx_ui_component import InxUIComponent
 from Infernux.ui.inx_ui_screen_component import InxUIScreenComponent
-from Infernux.ui.enums import RenderMode
+from Infernux.ui.enums import RenderMode, ScreenMatchMode, UIScaleMode
 
 
 class UICanvas(InxUIComponent):
@@ -22,6 +22,11 @@ class UICanvas(InxUIComponent):
         target_camera_id: Camera GameObject ID (CameraOverlay mode only).
         reference_width: Design reference width in pixels (default 1920).
         reference_height: Design reference height in pixels (default 1080).
+        ui_scale_mode: Canvas scaler mode.
+        screen_match_mode: Width/height match behavior for ScaleWithScreenSize.
+        match_width_or_height: 0 = match width, 1 = match height.
+        pixel_perfect: Round scale to integer pixels when possible.
+        reference_pixels_per_unit: Sprite pixel density hint.
     """
 
     render_mode: RenderMode
@@ -29,6 +34,19 @@ class UICanvas(InxUIComponent):
     target_camera_id: int
     reference_width: int
     reference_height: int
+    ui_scale_mode: UIScaleMode
+    screen_match_mode: ScreenMatchMode
+    match_width_or_height: float
+    pixel_perfect: bool
+    reference_pixels_per_unit: float
+
+    def compute_scale(self, screen_w: float, screen_h: float) -> Tuple[float, float, float]:
+        """Compute ``(scale_x, scale_y, text_scale)`` for a viewport size.
+
+        Mirrors the supported Unity CanvasScaler modes. Agents should use this
+        when converting design-space UI coordinates to Game View pixels.
+        """
+        ...
 
     def invalidate_element_cache(self) -> None:
         """Mark the cached element list as stale.
@@ -42,7 +60,7 @@ class UICanvas(InxUIComponent):
         """Yield all screen-space UI components on child GameObjects (depth-first)."""
         ...
 
-    def raycast(self, canvas_x: float, canvas_y: float) -> Optional[InxUIScreenComponent]:
+    def raycast(self, canvas_x: float, canvas_y: float, tolerance: float = ...) -> Optional[InxUIScreenComponent]:
         """Return the front-most element hit at ``(canvas_x, canvas_y)``, or ``None``.
 
         Iterates children in reverse depth-first order (last drawn = top).
@@ -54,7 +72,7 @@ class UICanvas(InxUIComponent):
         """
         ...
 
-    def raycast_all(self, canvas_x: float, canvas_y: float) -> List[InxUIScreenComponent]:
+    def raycast_all(self, canvas_x: float, canvas_y: float, tolerance: float = ...) -> List[InxUIScreenComponent]:
         """Return all elements hit at the given point, front-to-back order.
 
         Args:

--- a/python/Infernux/ui/ui_event_entry.pyi
+++ b/python/Infernux/ui/ui_event_entry.pyi
@@ -63,6 +63,14 @@ class UIEventMethodParameter:
     component_type: str
     default_value: Any
 
+    def __init__(
+        self,
+        name: str,
+        kind: str,
+        component_type: str = ...,
+        default_value: Any = ...,
+    ) -> None: ...
+
     @property
     def display_name(self) -> str:
         """Human-readable label for editor display."""


### PR DESCRIPTION
## Summary

This branch introduces an MCP **basement** for Infernux: a FastMCP-backed server and a layered tool surface so agents can inspect and operate the editor/runtime through structured tools (scene graph, assets, camera, UI, materials, docs/capabilities, console, etc.). It adds **self-evolving project-defined tools**: Python modules under `Assets/AgentTools/` decorated with `@agent_tool`, registered at startup with validation and optional reload hooks, plus a minimal **trace** facility for recorded MCP-call diagnostics.

Alongside MCP work, the branch includes targeted engine/editor fixes needed for dogfooding (hierarchy creation refactor, texture/asset pipeline tweaks, renderer/outline/material/Vulkan adjustments, benchmark-driven fixes such as Flappy Bird). Dependencies and packaging (`pyproject.toml`, `runtime_requirements.py`, bundled `requirements.txt`) are extended where MCP stack imports require them.

## What changed

### MCP server and tools

- New MCP package: `python/Infernux/mcp/` — server bootstrap (`server.py`), threading helpers (`threading.py`), tool registration (`tools/__init__.py`), and modular tools under `tools/` including `common.py`, `assets.py`, `scene.py`, `camera.py`, `ui.py`, `material.py`, `editor.py`, `hierarchy.py`, `project.py`, `runtime.py`, `console.py`, `docs.py`, and **project tool management** (`project_tools.py`).
- **Project-defined agent tools**: `python/Infernux/mcp/project_tools/` — `decorators.py`, `registry.py`, `loadability.py`, `trace.py`, package `__init__.py`; integrates with editor bootstrap so project scripts can extend MCP without rebuilding core.

### Engine / editor integration

- Engine bootstrap and hierarchy: refactors toward `hierarchy_creation_service.py`; updates across `bootstrap.py`, `engine/__init__.py`, `engine.py`, and related UI/inspector paths (`project_utils.py`, inspector components, asset preview).
- Minor fixes in builtin components (e.g. `sprite_renderer.py`), `asset_types.py`, `ui_texture_cache.py`.

### Renderer / resources / C++

- CMake and renderer pipeline updates (`CMakeLists.txt`, `OutlineRenderer`, `VkCoreMaterial`, modular Vulkan core, material pipeline manager, outline rendering).
- New `VertexInputFilter.h`; texture loading expanded (`InxTextureLoader.cpp`, `TextureLoader.cpp`); asset database/importer touchpoints.
- `ProjectPanel.cpp` and related editor/renderer glue.

### Packaging

- `pyproject.toml` and `python/Infernux/resources/supports/requirements.txt` aligned with MCP/runtime deps.

## Verification

- [x] Built the affected targets (CMake / native + Python packaging as applicable)
- [x] Ran the relevant tests or static validation (`compileall` / smoke tests on MCP imports and editor startup)
- [ ] Updated docs if behavior or public APIs changed (capabilities/tools surfaced via MCP; restart behavior noted below)

## Notes for reviewers

- **Restart** the Infernux Editor (or the MCP server process) after deploying so new tools and project-tool discovery (`project_tools.*`, trace hooks, capability lists) load in the running session.
- **Risk surface**: large addition under `python/Infernux/mcp/` — prefer reviewing `server.py`, `tools/common.py`, `tools/__init__.py`, and `project_tools/` registry/loadability for threading and import-order concerns (circular imports were avoided via lazy registration paths).
- **Dogfood context**: renderer/asset changes support MCP-driven benchmarks (e.g. Flappy Bird sample); validate outline/material paths on Windows Vulkan if touching those areas.
- Hierarchy refactor consolidates creation logic; UI/inspector call sites were updated — sanity-check create/reparent flows in the editor.
