### PR TITLE
fix: remove the weird progres text

### DIFF
--- a/packaging/view/installs_view.py
+++ b/packaging/view/installs_view.py
@@ -252,6 +252,7 @@ class InstallEditorDialog(QDialog):
         # Progress bar (hidden until download starts)
         self._progress_bar = QProgressBar()
         self._progress_bar.setFixedHeight(6)
+        self._progress_bar.setTextVisible(False)
         self._progress_bar.hide()
         layout.addWidget(self._progress_bar)
 


### PR DESCRIPTION
## Summary
## What changed
移除了下载编辑器界面进度条默认自带的进度数值文本，防止出现文字与进度条重叠的奇怪外观
<img width="1124" height="623" alt="image" src="https://github.com/user-attachments/assets/24edf506-1fd0-46ca-813d-51cf64c48c44" />

（上面是之前的样子）

## Verification

- [x] Built the affected targets
- [x] Ran the relevant tests or static validation
- ~~Updated docs if behavior or public APIs changed~~ - no need

## Notes for reviewers

无。
