### PR TITLE
fix: double shortcut paste in Hierarchy panel and can't shortcut paste in Project panel

### DIFF
--- a/cpp/infernux/function/editor/HierarchyPanel.cpp
+++ b/cpp/infernux/function/editor/HierarchyPanel.cpp
@@ -1575,6 +1575,16 @@ void HierarchyPanel::OnRenderContent(InxGUIContext *ctx)
         return std::chrono::duration<double, std::milli>(Clock::now() - start).count();
     };
 
+    // ── Focus transition detection ──────────────────────────────
+    {
+        bool focused = ctx->IsWindowFocused(0);
+        if (focused != m_wasFocused) {
+            m_wasFocused = focused;
+            if (onHierarchyPanelFocused)
+                onHierarchyPanelFocused(focused);
+        }
+    }
+
     HandleClipboardShortcuts(ctx);
 
     // ── Header: scene name / prefab mode / ui mode ──────────────

--- a/cpp/infernux/function/editor/HierarchyPanel.h
+++ b/cpp/infernux/function/editor/HierarchyPanel.h
@@ -123,6 +123,10 @@ class HierarchyPanel : public EditorPanel
     std::function<void(uint64_t)> prefabRevertOverrides;
     std::function<void(uint64_t)> prefabUnpack;
 
+    // ── Focus callback ──────────────────────────────────────────────
+
+    std::function<void(bool)> onHierarchyPanelFocused;
+
     // ── Clipboard callbacks ──────────────────────────────────────────
 
     std::function<bool(bool)> copySelected; // (cut) → success
@@ -230,6 +234,9 @@ class HierarchyPanel : public EditorPanel
 
     // ── Right-click tracking ─────────────────────────────────────────
     uint64_t m_rightClickedObjId = 0;
+
+    // ── Focus tracking ───────────────────────────────────────────────
+    bool m_wasFocused = false;
 
     // ── Split sub-timings (accumulated ms, consumed by profile) ────
     double m_subPreHidden = 0.0;

--- a/cpp/infernux/function/editor/ProjectPanel.cpp
+++ b/cpp/infernux/function/editor/ProjectPanel.cpp
@@ -1790,6 +1790,16 @@ void ProjectPanel::PreRender(InxGUIContext *ctx)
 
 void ProjectPanel::OnRenderContent(InxGUIContext *ctx)
 {
+    // ── Focus transition detection ──────────────────────────────
+    {
+        bool focused = ctx->IsWindowFocused(0);
+        if (focused != m_wasFocused) {
+            m_wasFocused = focused;
+            if (onProjectPanelFocused)
+                onProjectPanelFocused(focused);
+        }
+    }
+
     // Process any deferred cache invalidation from the previous frame
     // (CommitRename, Delete, Paste, Move set this flag to avoid invalidating
     // the items pointer mid-iteration in RenderFileGrid).

--- a/cpp/infernux/function/editor/ProjectPanel.h
+++ b/cpp/infernux/function/editor/ProjectPanel.h
@@ -59,6 +59,10 @@ class ProjectPanel : public EditorPanel
     }
     void SetCurrentPath(const std::string &path);
 
+    // ── Focus callback ──────────────────────────────────────────────
+
+    std::function<void(bool)> onProjectPanelFocused;
+
     // ── Notification callbacks ───────────────────────────────────────
 
     /// Called when file selection changes (receives single path or empty).
@@ -310,6 +314,9 @@ class ProjectPanel : public EditorPanel
     std::vector<std::string> m_clipboardPaths;
     bool m_clipboardIsCut = false;
 
+    // ── Focus tracking ───────────────────────────────────────────────
+    bool m_wasFocused = false;
+    
     // Model expansion
     std::unordered_set<std::string> m_expandedModels;
 

--- a/cpp/infernux/tools/pybinding/BindingGUI.cpp
+++ b/cpp/infernux/tools/pybinding/BindingGUI.cpp
@@ -924,6 +924,8 @@ void RegisterGUIBindings(py::module_ &m)
         .def_readwrite("prefab_apply_overrides", &HierarchyPanel::prefabApplyOverrides)
         .def_readwrite("prefab_revert_overrides", &HierarchyPanel::prefabRevertOverrides)
         .def_readwrite("prefab_unpack", &HierarchyPanel::prefabUnpack)
+        // Hierarchy panel focus callback
+        .def_readwrite("on_hierarchy_panel_focused", &HierarchyPanel::onHierarchyPanelFocused)
         // Clipboard callbacks
         .def_readwrite("copy_selected", &HierarchyPanel::copySelected)
         .def_readwrite("paste_clipboard", &HierarchyPanel::pasteClipboard)
@@ -960,6 +962,8 @@ void RegisterGUIBindings(py::module_ &m)
         .def("receive_dropped_files", &ProjectPanel::ReceiveDroppedFiles, py::arg("paths"))
         .def("get_current_path", &ProjectPanel::GetCurrentPath)
         .def("set_current_path", &ProjectPanel::SetCurrentPath, py::arg("path"))
+        // Project panel focus callback
+        .def_readwrite("on_project_panel_focused", &ProjectPanel::onProjectPanelFocused)
         // Notification callbacks
         .def_readwrite("on_file_selected", &ProjectPanel::onFileSelected)
         .def_readwrite("on_empty_area_clicked", &ProjectPanel::onEmptyAreaClicked)

--- a/python/Infernux/engine/bootstrap_hierarchy/_wire.py
+++ b/python/Infernux/engine/bootstrap_hierarchy/_wire.py
@@ -319,6 +319,16 @@ def wire_hierarchy_callbacks(bs: EditorBootstrap) -> None:
     hp.is_selection_empty = lambda: sel.is_empty()
     hp.set_ordered_ids = lambda ids: sel.set_ordered_ids(ids)
 
+    # -- Panel focus sync --
+    def _on_hierarchy_focus_changed(focused: bool):
+        from Infernux.engine.ui.closable_panel import ClosablePanel
+        if focused:
+            ClosablePanel._active_panel_id = "hierarchy"
+        elif ClosablePanel._active_panel_id == "hierarchy":
+            ClosablePanel._active_panel_id = None
+
+    hp.on_hierarchy_panel_focused = _on_hierarchy_focus_changed
+
     # -- Translation & warning --
     hp.translate = _t
     hp.show_warning = lambda msg: Debug.log_warning(msg)

--- a/python/Infernux/engine/bootstrap_project.py
+++ b/python/Infernux/engine/bootstrap_project.py
@@ -315,3 +315,13 @@ def wire_project_callbacks(bs: EditorBootstrap) -> None:
 
     bs._external_drop_forwarder = _ExternalDropForwarder()
     bs.engine.register_gui("project_drop_forwarder", bs._external_drop_forwarder)
+
+    # -- Panel focus sync --
+    def _on_project_focus_changed(focused: bool):
+        from Infernux.engine.ui.closable_panel import ClosablePanel
+        if focused:
+            ClosablePanel._active_panel_id = "project"
+        elif ClosablePanel._active_panel_id == "project":
+            ClosablePanel._active_panel_id = None
+
+    pp.on_project_panel_focused = _on_project_focus_changed

--- a/python/Infernux/engine/ui/closable_panel.py
+++ b/python/Infernux/engine/ui/closable_panel.py
@@ -266,6 +266,10 @@ class ClosablePanel(InxGUIRenderable):
             focused = ctx.is_window_focused(0)
             if focused and not self._panel_was_focused:
                 self._activate_panel(ctx)
+            # Focus lost
+            elif not focused and self._panel_was_focused:
+                if ClosablePanel._active_panel_id == self._window_id:
+                    ClosablePanel._active_panel_id = None
             self._panel_was_focused = focused
         
         return visible and self._is_open


### PR DESCRIPTION
## Summary

In v0.1.6 I found that using shortcut copy in scene-view panel and shortcut paste in hierarchy panel causes a double paste operation and disables shortcut copy/paste in project panel. This is because the native C++ panels Hierarchy and Project lack focus change callbacks, causing Python to always use outdated panel id - scene_view.

## What changed

-Add focus transition detection in HierarchyPanel.cpp/.h and ProjectPanel.cpp/h
-Expose them to py in BindingGUI.cpp
-Sync Hierarchy panel focus in _wire.py and Project panel focus in bootstrap_project.py
-Add focus loss detection in closable_panel.py to avoid weird shortcut key routing

## Verification

- [✅] Built the affected targets
- [✅] Ran the relevant tests or static validation

## Notes for reviewers

List any risky areas, migration notes, or tradeoffs that need reviewer attention.
